### PR TITLE
Fix leaderboard save after authenticated finish

### DIFF
--- a/scores.js
+++ b/scores.js
@@ -22,7 +22,6 @@ import {
   doc,
   setDoc,
   getDoc,
-  updateDoc,
   collection,
   orderBy,
   query,
@@ -63,6 +62,29 @@ function setCurrentUser(user) {
   currentUser = user;
 }
 
+function getActiveUser() {
+  if (currentUser) {
+    return currentUser;
+  }
+
+  const authModule = window.AuthModule;
+  if (!authModule) {
+    return null;
+  }
+
+  try {
+    const authStateUser = authModule.getAuthState?.()?.user || authModule.getCurrentUser?.();
+    if (authStateUser) {
+      currentUser = authStateUser;
+      return authStateUser;
+    }
+  } catch (error) {
+    console.warn("Unable to refresh current user from AuthModule:", error);
+  }
+
+  return null;
+}
+
 /**
  * Update user's best time in Firestore
  * @param {string} userId - Firebase user ID
@@ -91,7 +113,7 @@ function updateUserBestTime(userId, time) {
         if (docSnap.exists()) {
           const userData = docSnap.data();
           // Update only if new time is better or no time exists yet
-          if (!userData.bestTime || time < userData.bestTime) {
+          if (typeof userData.bestTime !== 'number' || time <= userData.bestTime) {
             shouldUpdate = true;
           }
         } else {
@@ -103,11 +125,10 @@ function updateUserBestTime(userId, time) {
 
         if (shouldUpdate) {
           console.log(`Updating best time for user ${userId} to ${time}`);
-          // Using updateDoc is slightly safer if we only want to add/modify bestTime fields
-          updateDoc(userDocRef, {
+          setDoc(userDocRef, {
             bestTime: time,
             updatedAt: serverTimestamp() // Track when the best time was updated
-          })
+          }, { merge: true })
           .then(() => {
             console.log("Best time updated successfully in user document.");
             updateLeaderboard(userId, time); // Update leaderboard only after successful user doc update
@@ -356,15 +377,16 @@ function displayLeaderboard() {
         // This ensures the leaderboard is displayed even with permissions problems
 
         const { scores, users } = result;
+        const activeUser = getActiveUser();
         let html = '<h3>Top 10 Times</h3><table>';
         html += '<tr><th>Rank</th><th>Player</th><th>Time</th></tr>';
 
         scores.forEach((score, index) => {
           const user = users[index];
           // Show current user differently (match by userId)
-          const isCurrentUser = currentUser && score.userId === currentUser.uid;
+          const isCurrentUser = activeUser && score.userId === activeUser.uid;
           const displayName = isCurrentUser ? 
-            (currentUser.displayName || 'You') : 
+            (activeUser.displayName || 'You') : 
             `${user.displayName} ${index + 1}`;
             
           html += `<tr class="${isCurrentUser ? 'current-user-score' : ''}">
@@ -447,9 +469,11 @@ function recordScore(time) {
   try {
     const localBestTimeStr = localStorage.getItem('snowgliderBestTime');
     const localBestTime = localBestTimeStr ? parseFloat(localBestTimeStr) : null;
-    const isNewPersonalBest = localBestTime === null || time < localBestTime;
+    const hasValidLocalBest = typeof localBestTime === 'number' && !isNaN(localBestTime);
+    const isNewLocalBest = !hasValidLocalBest || time < localBestTime;
+    const shouldSyncBestTime = !hasValidLocalBest || time <= localBestTime;
 
-    if (isNewPersonalBest) {
+    if (isNewLocalBest) {
       localStorage.setItem('snowgliderBestTime', time.toString());
       console.log("New local best time recorded:", time);
     } else {
@@ -461,8 +485,8 @@ function recordScore(time) {
       logEvent(analytics, 'complete_run', { time: time });
     }
 
-    // Create a local copy of the user reference to prevent race conditions
-    const userAtTimeOfRecord = currentUser ? {...currentUser} : null;
+    // Read the signed-in user at record time so auth UI and scoring stay in sync.
+    const userAtTimeOfRecord = getActiveUser();
     
     // If Firestore isn't available but should be, try to reinitialize it
     if (userAtTimeOfRecord && !firestore && window.navigator.onLine && 
@@ -471,8 +495,8 @@ function recordScore(time) {
       window.AuthModule.reinitializeFirestore();
     }
     
-    // Update Firestore only if user is signed in, Firestore is available, AND it's a new personal best
-    if (userAtTimeOfRecord && firestore && isNewPersonalBest) {
+    // Update Firestore only if user is signed in, Firestore is available, AND this run matches or beats the local best.
+    if (userAtTimeOfRecord && firestore && shouldSyncBestTime) {
       console.log("Attempting to update Firestore with new best time:", time);
       // Use the snapshot of user data captured at function start time
       updateUserBestTime(userAtTimeOfRecord.uid, time); // This function handles leaderboard update too
@@ -493,7 +517,7 @@ function recordScore(time) {
           console.log("Device appears to be offline. Check internet connection.");
         }
       }
-      if (!isNewPersonalBest) console.log("Skipping Firestore update: Not a new personal best.");
+      if (!shouldSyncBestTime) console.log("Skipping Firestore update: Not a new personal best.");
     }
 
   } catch (error) {

--- a/snowglider.js
+++ b/snowglider.js
@@ -515,6 +515,27 @@ window.addEventListener('resize', () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
+function getSignedInUser() {
+  const authModule = window.AuthModule;
+  if (!authModule) {
+    return null;
+  }
+
+  try {
+    return authModule.getCurrentUser?.() || authModule.getAuthState?.()?.user || null;
+  } catch (error) {
+    console.warn("Unable to read auth state:", error);
+    return null;
+  }
+}
+
+function removeLoginPrompt() {
+  const loginPrompt = document.getElementById('loginPrompt');
+  if (loginPrompt) {
+    loginPrompt.remove();
+  }
+}
+
 // Add these functions for game over handling
 // Expose showGameOver on window for test mocking
 function showGameOver(reason) {
@@ -529,6 +550,7 @@ function showGameOver(reason) {
   document.body.classList.remove('game-active');
   
   gameOverDetail.textContent = reason;
+  removeLoginPrompt();
   
   // TODO: AUDIO DISABLED - Pause audio on game over (will be no-op if disabled)
   if (window.AudioModule) {
@@ -552,11 +574,18 @@ function showGameOver(reason) {
   // Only update times if player reached the end successfully
   if (reason === "You reached the end of the slope!") {
     const currentTime = (performance.now() - startTime) / 1000;
+    const isNewBestTime = currentTime < bestTime;
+    const canRecordScore = window.AuthModule && typeof window.AuthModule.recordScore === 'function';
+
+    if (canRecordScore) {
+      window.AuthModule.recordScore(currentTime);
+    } else if (isNewBestTime) {
+      localStorage.setItem('snowgliderBestTime', currentTime);
+    }
     
     // Show appropriate message based on time
-    if (currentTime < bestTime) {
+    if (isNewBestTime) {
       bestTime = currentTime;
-      localStorage.setItem('snowgliderBestTime', bestTime);
       bestTimeDisplay.textContent = `New Best Time: ${bestTime.toFixed(2)}s`;
       bestTimeDisplay.style.color = '#ffff00'; // Highlight new record
       
@@ -566,23 +595,13 @@ function showGameOver(reason) {
         bestTimeElement.textContent = `${bestTime.toFixed(2)}s`;
         bestTimeElement.style.color = '#ffff00'; // Highlight new record
       }
-      
-      // Record to Firebase if user is logged in
-      if (window.AuthModule && window.AuthModule.getCurrentUser()) {
-        window.AuthModule.recordScore(currentTime);
-      }
     } else {
       bestTimeDisplay.textContent = `Your Time: ${currentTime.toFixed(2)}s (Best: ${bestTime.toFixed(2)}s)`;
       bestTimeDisplay.style.color = 'white';
-      
-      // Still record to Firebase even if not a personal best
-      if (window.AuthModule && window.AuthModule.getCurrentUser()) {
-        window.AuthModule.recordScore(currentTime);
-      }
     }
     
     // Show login prompt if not logged in
-    if (window.AuthModule && !window.AuthModule.getCurrentUser()) {
+    if (!getSignedInUser()) {
       const loginPrompt = document.createElement('p');
       loginPrompt.textContent = 'Log in to save your score and see the leaderboard!';
       loginPrompt.style.color = '#4285F4';
@@ -628,7 +647,7 @@ function showGameOver(reason) {
   }
   
   // Get leaderboard if user is logged in
-  if (window.AuthModule && window.AuthModule.getCurrentUser()) {
+  if (getSignedInUser()) {
     // Get the leaderboard element
     const leaderboardElement = document.getElementById('leaderboard');
     

--- a/tests/regression-tests.js
+++ b/tests/regression-tests.js
@@ -293,6 +293,54 @@ runTest('Best Time Recording Logic', () => {
     "Best time should not be updated on tree collision");
 });
 
+runTest('Leaderboard Sync When Local Best Was Prewritten', () => {
+  const mockLocalStorage = {
+    storage: {},
+    getItem: function(key) {
+      return this.storage[key] !== undefined ? this.storage[key] : null;
+    },
+    setItem: function(key, value) {
+      this.storage[key] = String(value);
+    }
+  };
+
+  const signedInUser = { uid: 'test-user' };
+  const firestoreAvailable = true;
+  let firestoreUpdateCalls = 0;
+
+  function recordScore(time) {
+    const localBestTimeStr = mockLocalStorage.getItem('snowgliderBestTime');
+    const localBestTime = localBestTimeStr ? parseFloat(localBestTimeStr) : null;
+    const hasValidLocalBest = typeof localBestTime === 'number' && !isNaN(localBestTime);
+    const isNewLocalBest = !hasValidLocalBest || time < localBestTime;
+    const shouldSyncBestTime = !hasValidLocalBest || time <= localBestTime;
+
+    if (isNewLocalBest) {
+      mockLocalStorage.setItem('snowgliderBestTime', time.toString());
+    }
+
+    if (signedInUser && firestoreAvailable && shouldSyncBestTime) {
+      firestoreUpdateCalls++;
+    }
+  }
+
+  // Reproduces the bug: snowglider.js had already written the new best before recordScore ran.
+  mockLocalStorage.setItem('snowgliderBestTime', '19.43');
+  recordScore(19.43);
+  assertEquals(firestoreUpdateCalls, 1,
+    "Equal local best should still be eligible for Firestore leaderboard sync");
+
+  recordScore(22.0);
+  assertEquals(firestoreUpdateCalls, 1,
+    "Worse times should not be synced as best times");
+
+  recordScore(18.0);
+  assertEquals(firestoreUpdateCalls, 2,
+    "Better times should be synced as best times");
+  assertEquals(mockLocalStorage.getItem('snowgliderBestTime'), '18',
+    "Better times should update local best storage");
+});
+
 // Test 4: Snow Splash Effect Interference
 // Verifies that snow splash effects don't interfere with snowman position
 runTest('Snow Splash Effect Interference', () => {


### PR DESCRIPTION
## Summary
- Fix authenticated leaderboard saves when the new best time has already been written to localStorage
- Keep score recording in sync with AuthModule user state and remove stale login prompts
- Use Firestore setDoc with merge for best-time updates so missing user docs do not block leaderboard writes

## Testing
- npm run lint
- npm run test:coverage
- npm run test:browser with Node 23 and system Chrome