### PR TITLE
Integrate skill & structure layer: course, ski technique, avalanche UI, ghost racing

### DIFF
--- a/IMPLEMENTATION_REPORT.md
+++ b/IMPLEMENTATION_REPORT.md
@@ -1,0 +1,207 @@
+# SnowGlider — Implementation Report
+### Skill & Structure layer: gates/checkpoints, carving/snowplow, avalanche warning UI, and ghost racing
+
+**Scope of this work:** the single *Top Recommendation* from the feature-gap analysis —
+
+> gates/checkpoints + carving/snowplow mechanics + avalanche warning UI, plus split-time ghost racing.
+
+This is the layer the report argues should ship *before* more content, because it converts a pleasant
+Three.js snowman demo into a game with skill, tension, and a reason to replay. Everything below was
+implemented against the repository at `github.com/den-run-ai/snowglider` and verified headlessly in this
+session.
+
+---
+
+## 1. Summary of changes
+
+| File | Status | What changed |
+|------|--------|--------------|
+| `course.js` | **new** (~560 lines) | Checkpoint gates + finish arch, live split timing, progress HUD, ghost racing, result screen |
+| `effects.js` | **new** (~190 lines) | Avalanche warning banner + danger meter + vignette + camera shake; speed‑based FOV |
+| `snowman.js` | modified | Carving / snowplow / tuck ski‑technique model; technique + landing surfaced for HUD/juice |
+| `snowglider.js` | modified | Wires the two modules into reset, the animation loop, and game‑over; HUD technique readout |
+| `index.html` | modified | Loads `effects.js` and `course.js` in the existing script chain, before `snowglider.js` |
+
+Net: **2 new files, 3 modified files, +195 / −13 lines on tracked files.** No dependencies added, no
+build step, no changes to the Firebase/auth/audio/scores subsystems.
+
+---
+
+## 2. How each recommendation was addressed
+
+### 2.1 A clearer course and objective feedback (report §1) — `course.js`
+
+The slope previously read as a sandbox: the only objective was the implicit "reach `z < -195`". The course
+is now legible end‑to‑end:
+
+- **Gates** are placed down the fall line at `z = -60, -105, -150`, plus a larger gold **finish arch** at
+  `z = -195`. Each gate is two coloured poles + a banner with a canvas‑texture label
+  (`CHECKPOINT 1…3`, `FINISH`). Gates are **purely decorative — they never collide**, so they cannot fight
+  the existing tree‑collision system.
+- A **progress bar + "m to finish"** read‑out sits at the top of the screen (1 world unit = 1 m, ~180 m
+  course).
+- Crossing a checkpoint flashes the **split time** and, once you have a personal best, the **±delta vs your
+  best split** in green/red.
+- A **result screen** at the finish shows total time, a medal, an improvement line, and a per‑checkpoint
+  split table with Δ‑vs‑best.
+
+### 2.2 Skiing skill, not just steering (report §2, issues #48/#54) — `snowman.js`
+
+The original handling was "slide with steering": left/right added lateral velocity with constant friction,
+and the brake only nudged downhill velocity. The new model rewards technique:
+
+- **Snowplow / "pizza" brake (Down):** decelerates along the *actual* direction of travel (sheds real
+  speed, not just downhill velocity) and *raises* steering authority + grip, so you can scrub speed under
+  control. The skis visibly form a wedge.
+- **Carving vs skidding (Left/Right):** smooth turns hold speed; hard turns at speed wash the edges out and
+  scrub speed. The penalty scales with speed and (inversely) with grip, so panic‑steering at speed costs
+  you while anticipatory turns do not.
+- **Tuck / straight‑line (Up, no steer):** least friction, most speed, least room to react — the
+  risk/reward line.
+- **Terrain‑dependent grip:** a touch more bite on moderate pitches, looser when flat (folded into the
+  carve/skid term, not the base coast friction — see §4).
+
+The live technique (`Carving / Snowplow / Tuck / Skidding / Ground`) is shown in the Game Stats HUD.
+
+### 2.3 Telegraphing and drama around the avalanche (report §3, issues #44/#49) — `effects.js`
+
+The avalanche existed but was poorly communicated, especially from behind. Now, while it is bearing down:
+
+- A red **warning banner** ("⚠ AVALANCHE — GO!", escalating to "RIGHT BEHIND YOU!" when very close).
+- A **danger meter** showing metres behind you, filling amber→red as it closes.
+- A **red vignette** and **camera shake** whose intensity rise with proximity.
+
+These are driven by the avalanche system's existing `getClosestDistance(playerPos)` and `active` flag, so no
+changes to `avalanche.js` were needed.
+
+### 2.4 Progression and replay hooks (report §6) — `course.js`
+
+- **Ghost racing:** your best run's trajectory is recorded (~20 Hz) and replayed as a translucent blue
+  snowman you race in real time. A HUD read‑out shows **AHEAD / BEHIND** by seconds, computed at your
+  current depth on the hill.
+- **Medals:** awarded relative to your own pace, which is robust without a hand‑tuned global par —
+  *first descent* (first finish), *new record* (beat your best), *silver* (within +10 %), *bronze*
+  (within +25 %), else *finished*.
+- **Persistence:** best splits (`snowgliderBestSplits`) and the best‑run ghost (`snowgliderGhost`) are
+  saved to `localStorage` and committed **only when a run beats the stored best**, keeping the ghost
+  honest. This complements — and does not change — the existing `snowgliderBestTime` flow.
+
+### 2.5 Game feel / "juice" (report §7) — `effects.js`
+
+- **Speed‑based FOV** widens from 75° toward 88° at speed for a sense of acceleration.
+- **Camera shake** on hard landings (scaled by airtime) and on avalanche proximity.
+- All motion respects `prefers-reduced-motion`.
+
+---
+
+## 3. Controls (additions)
+
+| Input | Before | After |
+|-------|--------|-------|
+| ↓ / S | weak downhill nudge | **Snowplow brake** — sheds real speed, tighter turns, ski wedge |
+| ← → / A D | add lateral velocity | **Carve** (smooth) holds speed; **skid** (hard, fast) scrubs speed |
+| ↑ / W | accelerate | **Tuck / straight‑line** — max speed, least control |
+
+No keys were added or remapped, so the existing keyboard/touch handling and `controls-tests` are untouched.
+
+---
+
+## 4. Key design decision: a test‑safe physics seam
+
+The repository ships a comprehensive test suite, and several browser tests drive the **real**
+`Snowman.updateSnowman`. The ski‑technique model is therefore layered so that **when the player gives no
+steering or brake input, the grounded physics is byte‑for‑byte identical to the original**:
+
+- The skid‑scrub term is `0` unless the player is steering, so the friction applied while coasting is
+  unchanged.
+- The snowplow deceleration branch only runs on `controls.down`.
+- `turnForce` is recomputed but is only *applied* under left/right input, and the sign is preserved
+  (left → −x, right → +x), so the sign‑based physics assertions still hold.
+- The terrain‑dependent term modifies carve/skid grip only — never the base coast friction.
+
+This was not assumed; it was **measured** (see §5).
+
+---
+
+## 5. Verification
+
+All suites were run at integration time (see `verification/results.txt`), **including the browser/Puppeteer
+suite** — which the original packaging sandbox could not run. Against the fully integrated game (which now
+loads `effects.js` + `course.js`), `npm run test:browser` is **51/51 passing, 0 failed**, identical to a
+clean baseline checkout; an in‑browser probe additionally confirms `CourseModule`/`EffectsModule` initialize,
+the course HUD and avalanche banner build, and the checkpoint labels are unified, with no page errors. Re‑run
+before deploy as a matter of course.
+
+**5.1 Node regression suite — 31/31 passing**, before and after the changes
+(terrain 7, physics 6, regression 5, tree‑collision 3, avalanche 10). `three` was installed in an isolated
+directory so the two `three`‑dependent suites could run.
+
+**5.2 Physics invariant + technique harness** (`verification/physics_invariant_harness.js`) loads the
+baseline `updateSnowman` (the frozen pre‑feature snapshot `verification/snowman_baseline.js`) and the current
+one with a shared deterministic terrain and a seeded RNG, then compares trajectories. **All five checks are
+reported here** (one is a deliberate diagnostic, not a pass):
+
+1. **Coasting, no input: max abs difference `0.000e+0` → IDENTICAL ✅.** The load‑bearing property that keeps
+   the existing suite green; the harness's exit code gates on this.
+2. **Snowplow (Down):** final speed `0.13` vs `3.27` coasting — brakes to a near‑stop ✅.
+3. **Hold Right vs coast straight:** turn ends faster than coasting → **"turning costs speed" is `❌`.** This
+   is a **diagnostic, not a regression**: the technique model is intentionally thin (the lateral turn force
+   still nets positive at normal speeds; skid scrub only dominates at high speed), so it does **not** fail the
+   build. Deepening it is a tracked design decision — see §8 and issues #48/#54.
+4. **Same Right input, baseline vs current:** current is slower, edge scrub active ✅.
+5. **High‑speed hard turn (entry 20 u/s):** current ~9 % slower than baseline ✅.
+
+**5.3 DOM smoke test** (`verification/dom_smoke_test.js`, jsdom + a mocked THREE) — **16/16 passing**:
+both modules build their DOM/gates without throwing; the full per‑frame loop runs; every checkpoint and the
+finish are reached; the ghost trajectory and best splits persist; the result panel is produced; and a faster
+second run is correctly reported as a new record.
+
+**5.4 Static checks:** `node --check` passes on all four JS files and on the extracted inline loader block
+in `index.html`; no test references `fov` and none invoke `animate()`, so the loop‑only FOV/shake cannot
+affect the camera suite.
+
+---
+
+## 6. Integration points (for review)
+
+- **`snowglider.js` init** (after the snowman is created): `CourseModule.init({ scene, getTerrainHeight,
+  createSnowman })` and `EffectsModule.init()`.
+- **`resetSnowman()`**: `CourseModule.reset()` + `EffectsModule.reset()` start a fresh timed run.
+- **`animate()`**: `CourseModule.update(pos, elapsed, snowman)` each frame; the avalanche block feeds
+  `EffectsModule.updateAvalanche(active, distance)`; camera shake/FOV are applied for the render and the
+  positional offset is reverted afterward so the camera manager's own smoothing is never fed its own shake.
+- **`showGameOver(reason)`**: captures `previousBest` *before* the existing finish branch mutates it, and on
+  `"You reached the end of the slope!"` inserts `CourseModule.onFinish(elapsed, previousBest)` above the
+  restart button. The load‑bearing finish string and the existing best‑time/leaderboard logic are unchanged.
+- **`index.html`**: `effects.js` → `course.js` → `snowglider.js` in the existing sequential loader.
+
+---
+
+## 7. What to run
+
+The five files are integrated directly into the repository (no patch/`src/` apply step). The headless
+harnesses moved into `verification/` and are wired into `npm test` via `npm run test:verify`; `jsdom` was
+added as a test‑only devDependency for the DOM smoke test.
+
+```bash
+npm ci                  # or: npm install
+npm test                # Node suite + verify harness (test:verify) — physics invariant + DOM smoke
+npm run test:browser    # Puppeteer suite — run before deploy
+npm start               # play locally at http://localhost:8080
+```
+
+`verification/physics_invariant_harness.js` compares `verification/snowman_baseline.js` (the frozen
+pre‑feature snapshot) against the live `snowman.js`; regenerate the baseline only on a deliberate physics
+change (`git show <ref>:snowman.js > verification/snowman_baseline.js`, re‑adding the header).
+
+**Recommended manual smoke before deploy:** one full run to the finish (confirm gates, splits, ghost, result
+screen), a snowplow stop, a hard carve, an avalanche encounter from behind, and a **second run after a
+personal best** to confirm split deltas stay live (the Gap‑2 fix).
+
+---
+
+## 8. Deliberately out of scope
+
+Left for follow‑ups so this change stays focused on the top recommendation: snow trails carved from the skis,
+a day→sunset→night skybox and weather, the "Yeti"-style chaser, arcade power‑ups, and the AI‑coach / NL course
+prompt ideas from the report's AI section.

--- a/course.js
+++ b/course.js
@@ -1,0 +1,588 @@
+// course.js - Course structure, split timing, ghost racing and result screen for SnowGlider
+//
+// This module turns the open slope into a timed course:
+//   - Visible checkpoint gates and a finish arch placed down the fall line
+//   - Live split times at each checkpoint, compared against your personal best
+//   - A progress bar / distance-to-finish HUD so the objective is always legible
+//   - A translucent "ghost" of your best run that you race in real time
+//   - A result screen with per-checkpoint splits and a medal
+//
+// Design notes:
+//   - The course runs from START_Z (top) to FINISH_Z (bottom); the snowman moves
+//     in the -Z direction, matching the finish trigger in snowman.js (pos.z < -195).
+//   - Gates are decorative (non-colliding) so they never fight the tree-collision
+//     system; they exist to mark the line and the split points.
+//   - Best splits and the best-run trajectory are persisted in localStorage and only
+//     committed when a run sets a new personal best, so the ghost is always your best.
+
+const CourseModule = (function () {
+  'use strict';
+
+  // --- Course geometry (world units; 1 unit == 1 metre for the HUD) ---
+  const START_Z = -15;
+  const FINISH_Z = -195;
+  const CHECKPOINT_Z = [-60, -105, -150]; // intermediate gates; finish handled separately
+  const GATE_HALF_WIDTH = 9;              // poles sit at x = +/- this, framing the lane
+  const FINISH_HALF_WIDTH = 14;
+  const COURSE_LENGTH = Math.abs(FINISH_Z - START_Z);
+
+  // Ghost sampling cadence
+  const SAMPLE_INTERVAL = 0.05; // seconds between recorded trajectory samples (~20 Hz)
+
+  // localStorage keys
+  const LS_SPLITS = 'snowgliderBestSplits';
+  const LS_GHOST = 'snowgliderGhost';
+
+  // --- Module state ---
+  let scene = null;
+  let getTerrainHeight = null;
+  let createSnowman = null;
+
+  let gateGroup = null;        // container for all gate meshes
+  let ghost = null;            // ghost snowman group (or null)
+  let ghostSamples = null;     // loaded best-run trajectory for playback
+  let ghostTotalTime = 0;
+
+  let bestSplits = null;       // array of best split times (per checkpoint + finish), or null
+
+  // Per-run state
+  let nextIndex = 0;           // index into the combined checkpoint+finish list
+  let runSplits = [];          // split times recorded this run
+  let recordSamples = [];      // trajectory recorded this run
+  let sampleAccum = 0;
+  let runActive = false;
+
+  // Combined list of split gates (checkpoints then finish)
+  const splitPoints = CHECKPOINT_Z.map((z, i) => ({ z, label: `CHECKPOINT ${i + 1}` }))
+    .concat([{ z: FINISH_Z, label: 'Finish' }]);
+
+  const reduceMotion = typeof window !== 'undefined' &&
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // ---------------------------------------------------------------------------
+  // HUD construction
+  // ---------------------------------------------------------------------------
+  let hud = {};
+
+  function buildHud() {
+    if (hud.root) return;
+
+    const root = document.createElement('div');
+    root.id = 'courseHud';
+    Object.assign(root.style, {
+      position: 'fixed', top: '14px', left: '50%', transform: 'translateX(-50%)',
+      zIndex: '900', display: 'none', flexDirection: 'column', alignItems: 'center',
+      gap: '6px', pointerEvents: 'none', fontFamily: 'Arial, sans-serif',
+      textShadow: '0 1px 3px rgba(0,0,0,0.8)', width: 'min(420px, 86vw)'
+    });
+
+    // Progress bar
+    const track = document.createElement('div');
+    Object.assign(track.style, {
+      width: '100%', height: '8px', borderRadius: '5px',
+      background: 'rgba(0,0,0,0.35)', overflow: 'hidden',
+      border: '1px solid rgba(255,255,255,0.25)'
+    });
+    const fill = document.createElement('div');
+    Object.assign(fill.style, {
+      width: '0%', height: '100%', borderRadius: '5px',
+      background: 'linear-gradient(90deg,#4a69bd,#74b9ff)', transition: 'width 0.12s linear'
+    });
+    track.appendChild(fill);
+
+    // Distance + ghost delta row
+    const row = document.createElement('div');
+    Object.assign(row.style, {
+      display: 'flex', justifyContent: 'space-between', width: '100%',
+      fontSize: '13px', color: '#fff', fontWeight: '600'
+    });
+    const distance = document.createElement('span');
+    distance.textContent = `${COURSE_LENGTH} m to finish`;
+    const ghostDelta = document.createElement('span');
+    ghostDelta.textContent = '';
+    row.appendChild(distance);
+    row.appendChild(ghostDelta);
+
+    root.appendChild(track);
+    root.appendChild(row);
+    document.body.appendChild(root);
+
+    // Split flash (briefly shows the time + delta when crossing a checkpoint)
+    const flash = document.createElement('div');
+    Object.assign(flash.style, {
+      position: 'fixed', top: '64px', left: '50%', transform: 'translateX(-50%)',
+      zIndex: '901', padding: '8px 18px', borderRadius: '10px',
+      background: 'rgba(0,0,0,0.6)', color: '#fff', fontFamily: 'Arial, sans-serif',
+      fontSize: '18px', fontWeight: '700', textAlign: 'center', opacity: '0',
+      transition: reduceMotion ? 'none' : 'opacity 0.25s ease', pointerEvents: 'none',
+      textShadow: '0 1px 3px rgba(0,0,0,0.8)'
+    });
+    document.body.appendChild(flash);
+
+    hud = { root, fill, distance, ghostDelta, flash };
+  }
+
+  let flashTimer = null;
+  function showFlash(html, color) {
+    if (!hud.flash) return;
+    hud.flash.innerHTML = html;
+    hud.flash.style.color = color || '#fff';
+    hud.flash.style.opacity = '1';
+    if (flashTimer) clearTimeout(flashTimer);
+    flashTimer = setTimeout(() => { hud.flash.style.opacity = '0'; }, 1600);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gate / finish meshes
+  // ---------------------------------------------------------------------------
+  function makeGate(zPos, colorHex, label, isFinish) {
+    const group = new THREE.Group();
+    const halfW = isFinish ? FINISH_HALF_WIDTH : GATE_HALF_WIDTH;
+    const poleMat = new THREE.MeshStandardMaterial({ color: colorHex, roughness: 0.6 });
+    const poleHeight = isFinish ? 9 : 6;
+    const poleRadius = isFinish ? 0.35 : 0.25;
+
+    [-halfW, halfW].forEach((xOff) => {
+      const groundY = getTerrainHeight(xOff, zPos);
+      const pole = new THREE.Mesh(
+        new THREE.CylinderGeometry(poleRadius, poleRadius, poleHeight, 10),
+        poleMat
+      );
+      pole.position.set(xOff, groundY + poleHeight / 2, zPos);
+      pole.castShadow = true;
+      group.add(pole);
+
+      // Small flag near the top of each pole
+      const flag = new THREE.Mesh(
+        new THREE.PlaneGeometry(1.8, 1.1),
+        new THREE.MeshStandardMaterial({
+          color: colorHex, side: THREE.DoubleSide, roughness: 0.8
+        })
+      );
+      flag.position.set(xOff + (xOff < 0 ? 1.0 : -1.0), groundY + poleHeight - 0.9, zPos);
+      group.add(flag);
+    });
+
+    // Banner across the top spanning the gate
+    const midY = (getTerrainHeight(-halfW, zPos) + getTerrainHeight(halfW, zPos)) / 2;
+    const banner = new THREE.Mesh(
+      new THREE.BoxGeometry(halfW * 2, isFinish ? 1.6 : 1.0, 0.2),
+      new THREE.MeshStandardMaterial({ color: colorHex, roughness: 0.7 })
+    );
+    banner.position.set(0, midY + poleHeight - 0.4, zPos);
+    banner.castShadow = true;
+    group.add(banner);
+
+    // Text label on the banner (canvas texture)
+    if (label) {
+      const canvas = document.createElement('canvas');
+      canvas.width = 512; canvas.height = 96;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'rgba(0,0,0,0)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.font = 'bold 70px Arial';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText(label, canvas.width / 2, canvas.height / 2);
+      const tex = new THREE.CanvasTexture(canvas);
+      const textMat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+      const textPlane = new THREE.Mesh(
+        new THREE.PlaneGeometry(halfW * 2 * 0.9, (isFinish ? 1.6 : 1.0) * 0.9),
+        textMat
+      );
+      textPlane.position.set(0, midY + poleHeight - 0.4, zPos + 0.12);
+      group.add(textPlane);
+    }
+
+    return group;
+  }
+
+  function buildGates() {
+    if (gateGroup) return;
+    gateGroup = new THREE.Group();
+
+    const palette = [0x00b894, 0x0984e3, 0xfdcb6e]; // green, blue, amber for CPs
+    CHECKPOINT_Z.forEach((z, i) => {
+      // Single source of truth for the label so the 3D banner and the HUD/result
+      // table never drift apart (was "CHECKPOINT n" here vs "CP n" in the HUD).
+      gateGroup.add(makeGate(z, palette[i % palette.length], splitPoints[i].label, false));
+    });
+    gateGroup.add(makeGate(FINISH_Z, 0xffd700, 'FINISH', true));
+
+    scene.add(gateGroup);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ghost
+  // ---------------------------------------------------------------------------
+  function loadGhost() {
+    ghostSamples = null;
+    ghostTotalTime = 0;
+    try {
+      const raw = localStorage.getItem(LS_GHOST);
+      if (raw) {
+        const data = JSON.parse(raw);
+        if (Array.isArray(data) && data.length > 1) {
+          ghostSamples = data;
+          ghostTotalTime = data[data.length - 1].t;
+        }
+      }
+    } catch (e) {
+      ghostSamples = null;
+    }
+  }
+
+  // Load the persisted best splits into module state. Used by both init() and
+  // reset() so the in-memory baseline never goes stale after a personal best
+  // within a session (the split flash + result table compare against this).
+  function loadBests() {
+    try {
+      const raw = localStorage.getItem(LS_SPLITS);
+      bestSplits = raw ? JSON.parse(raw) : null;
+    } catch (e) {
+      bestSplits = null;
+    }
+  }
+
+  function buildGhost() {
+    if (!ghostSamples || ghost || !createSnowman) return;
+    ghost = createSnowman(scene);
+    // Make it a translucent blue apparition that never collides or shadows.
+    ghost.traverse((obj) => {
+      if (obj.isMesh && obj.material) {
+        const m = obj.material.clone();
+        m.transparent = true;
+        m.opacity = 0.32;
+        if (m.color) m.color.lerp(new THREE.Color(0x66ccff), 0.6);
+        if ('emissive' in m && m.emissive) m.emissive = new THREE.Color(0x113355);
+        obj.material = m;
+        obj.castShadow = false;
+        obj.receiveShadow = false;
+      }
+    });
+    ghost.visible = false;
+  }
+
+  // Interpolate the ghost's recorded position at time t (seconds since run start).
+  function ghostPositionAt(t) {
+    if (!ghostSamples) return null;
+    const s = ghostSamples;
+    if (t <= s[0].t) return s[0];
+    if (t >= s[s.length - 1].t) return s[s.length - 1];
+    // Linear scan is fine for a few hundred samples.
+    for (let i = 1; i < s.length; i++) {
+      if (s[i].t >= t) {
+        const a = s[i - 1], b = s[i];
+        const f = (t - a.t) / Math.max(1e-4, b.t - a.t);
+        return {
+          x: a.x + (b.x - a.x) * f,
+          y: a.y + (b.y - a.y) * f,
+          z: a.z + (b.z - a.z) * f,
+          rot: a.rot + (b.rot - a.rot) * f
+        };
+      }
+    }
+    return s[s.length - 1];
+  }
+
+  // The time at which the ghost reached a given downhill depth (z).
+  function ghostTimeAtZ(z) {
+    if (!ghostSamples) return null;
+    const s = ghostSamples;
+    if (z >= s[0].z) return 0;
+    for (let i = 1; i < s.length; i++) {
+      if (s[i].z <= z) {
+        const a = s[i - 1], b = s[i];
+        const f = (a.z - z) / Math.max(1e-4, a.z - b.z);
+        return a.t + (b.t - a.t) * f;
+      }
+    }
+    return ghostTotalTime;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  function init(opts) {
+    scene = opts.scene;
+    getTerrainHeight = opts.getTerrainHeight;
+    createSnowman = opts.createSnowman;
+
+    // Load persisted bests
+    loadBests();
+
+    buildHud();
+    buildGates();
+    loadGhost();
+    buildGhost();
+  }
+
+  // Called from resetSnowman(): start a fresh timed run.
+  function reset() {
+    nextIndex = 0;
+    runSplits = [];
+    recordSamples = [];
+    sampleAccum = 0;
+    runActive = true;
+
+    // Refresh ghost + best splits in case a previous run set a new best.
+    loadBests();
+    loadGhost();
+    buildGhost();
+    if (ghost) ghost.visible = false;
+
+    if (hud.root) {
+      hud.root.style.display = 'flex';
+      hud.fill.style.width = '0%';
+      hud.distance.textContent = `${COURSE_LENGTH} m to finish`;
+      hud.ghostDelta.textContent = ghostSamples ? 'Racing your ghost' : 'No ghost yet';
+      hud.ghostDelta.style.color = '#74b9ff';
+      hud.flash.style.opacity = '0';
+    }
+  }
+
+  function formatTime(t) {
+    return `${t.toFixed(2)}s`;
+  }
+
+  function formatDelta(d) {
+    const sign = d <= 0 ? '−' : '+';
+    return `${sign}${Math.abs(d).toFixed(2)}s`;
+  }
+
+  // Called every frame from the animation loop.
+  // pos: snowman position, elapsed: seconds since run start, snowman: the player group.
+  function update(pos, elapsed, snowman) {
+    if (!runActive) return;
+
+    // --- Progress HUD ---
+    const progressed = Math.min(COURSE_LENGTH, Math.max(0, START_Z - pos.z));
+    const frac = progressed / COURSE_LENGTH;
+    if (hud.fill) hud.fill.style.width = `${(frac * 100).toFixed(1)}%`;
+    if (hud.distance) {
+      const remaining = Math.max(0, COURSE_LENGTH - progressed);
+      hud.distance.textContent = `${remaining.toFixed(0)} m to finish`;
+    }
+
+    // --- Split detection ---
+    if (nextIndex < splitPoints.length && pos.z <= splitPoints[nextIndex].z) {
+      const idx = nextIndex;
+      const sp = splitPoints[idx];
+      runSplits[idx] = elapsed;
+      nextIndex++;
+
+      let deltaHtml = '';
+      let color = '#74b9ff';
+      if (bestSplits && typeof bestSplits[idx] === 'number') {
+        const d = elapsed - bestSplits[idx];
+        color = d <= 0 ? '#55efc4' : '#ff7675';
+        deltaHtml = `<div style="font-size:14px;margin-top:2px;color:${color}">${formatDelta(d)} vs best</div>`;
+      }
+      if (idx < splitPoints.length - 1) {
+        showFlash(`${sp.label} &middot; ${formatTime(elapsed)}${deltaHtml}`, color);
+      }
+    }
+
+    // --- Ghost playback ---
+    if (ghost && ghostSamples) {
+      ghost.visible = true;
+      const gp = ghostPositionAt(elapsed);
+      if (gp) {
+        ghost.position.set(gp.x, gp.y, gp.z);
+        if (typeof gp.rot === 'number') ghost.rotation.y = gp.rot;
+      }
+      // Ahead/behind readout, expressed in time at the player's current depth.
+      const gt = ghostTimeAtZ(pos.z);
+      if (gt !== null && hud.ghostDelta) {
+        const delta = elapsed - gt; // +ve: ghost was here earlier => you're behind
+        if (pos.z > START_Z - 2) {
+          hud.ghostDelta.textContent = 'Racing your ghost';
+          hud.ghostDelta.style.color = '#74b9ff';
+        } else if (delta <= 0) {
+          hud.ghostDelta.textContent = `AHEAD ${formatDelta(delta).replace('−', '')}`;
+          hud.ghostDelta.style.color = '#55efc4';
+        } else {
+          hud.ghostDelta.textContent = `BEHIND ${formatDelta(delta).replace('+', '')}`;
+          hud.ghostDelta.style.color = '#ff7675';
+        }
+      }
+    }
+
+    // --- Record this run's trajectory for a future ghost ---
+    sampleAccum += 1; // accumulate frames; we throttle by wall-clock via elapsed below
+    if (recordSamples.length === 0 ||
+        elapsed - recordSamples[recordSamples.length - 1].t >= SAMPLE_INTERVAL) {
+      recordSamples.push({
+        t: elapsed,
+        x: +pos.x.toFixed(2),
+        y: +pos.y.toFixed(2),
+        z: +pos.z.toFixed(2),
+        rot: snowman ? +snowman.rotation.y.toFixed(3) : 0
+      });
+    }
+  }
+
+  function hideHud() {
+    runActive = false;
+    if (hud.root) hud.root.style.display = 'none';
+    if (hud.flash) hud.flash.style.opacity = '0';
+    if (ghost) ghost.visible = false;
+  }
+
+  // Decide a medal based on the player's own pace (robust without a global par).
+  function medalFor(total, previousBest, isFirst) {
+    if (isFirst) return { key: 'gold', icon: '🥇', label: 'First descent!' };
+    if (total < previousBest) return { key: 'gold', icon: '🥇', label: 'New record!' };
+    if (total <= previousBest * 1.10) return { key: 'silver', icon: '🥈', label: 'Silver run' };
+    if (total <= previousBest * 1.25) return { key: 'bronze', icon: '🥉', label: 'Bronze run' };
+    return { key: 'finish', icon: '🏁', label: 'Finished' };
+  }
+
+  // Called from showGameOver() on a successful finish.
+  // Returns a DOM node (the result panel) to insert into the game-over overlay.
+  function onFinish(totalTime, previousBest) {
+    hideHud();
+
+    const isFirst = !(previousBest < Infinity);
+    const isBest = isFirst || totalTime < previousBest;
+
+    // Record the finish split.
+    runSplits[splitPoints.length - 1] = totalTime;
+
+    // Commit best splits + ghost if this is the best run so far.
+    if (isBest) {
+      try {
+        localStorage.setItem(LS_SPLITS, JSON.stringify(runSplits));
+        // Ensure the final sample lands exactly on the finish time, but keep the
+        // player's real x/y/rotation so the ghost doesn't snap to center or dip
+        // at the line (terrain-y at the finish is not 0).
+        const lastReal = recordSamples[recordSamples.length - 1];
+        recordSamples.push({
+          t: totalTime,
+          x: lastReal ? lastReal.x : 0,
+          y: lastReal ? lastReal.y : (getTerrainHeight ? getTerrainHeight(0, FINISH_Z) : 0),
+          z: FINISH_Z,
+          rot: lastReal ? lastReal.rot : Math.PI
+        });
+        localStorage.setItem(LS_GHOST, JSON.stringify(recordSamples));
+      } catch (e) { /* storage may be unavailable; ignore */ }
+    }
+
+    const medal = medalFor(totalTime, previousBest, isFirst);
+    return buildResultPanel(totalTime, previousBest, isBest, isFirst, medal);
+  }
+
+  function buildResultPanel(totalTime, previousBest, isBest, isFirst, medal) {
+    const panel = document.createElement('div');
+    panel.id = 'courseResult';
+    Object.assign(panel.style, {
+      background: 'rgba(20,24,38,0.78)', borderRadius: '14px', padding: '18px 22px',
+      margin: '6px 0 18px', color: '#fff', fontFamily: 'Arial, sans-serif',
+      width: 'min(380px, 88vw)', boxShadow: '0 8px 30px rgba(0,0,0,0.45)',
+      border: '1px solid rgba(255,255,255,0.12)'
+    });
+
+    const header = document.createElement('div');
+    Object.assign(header.style, {
+      display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '10px'
+    });
+    const icon = document.createElement('div');
+    icon.textContent = medal.icon;
+    icon.style.fontSize = '40px';
+    const titleWrap = document.createElement('div');
+    const title = document.createElement('div');
+    title.textContent = medal.label;
+    Object.assign(title.style, { fontSize: '20px', fontWeight: '800' });
+    const time = document.createElement('div');
+    time.textContent = formatTime(totalTime);
+    Object.assign(time.style, {
+      fontSize: '30px', fontWeight: '800',
+      color: isBest ? '#ffd700' : '#fff', lineHeight: '1.1'
+    });
+    titleWrap.appendChild(title);
+    titleWrap.appendChild(time);
+    header.appendChild(icon);
+    header.appendChild(titleWrap);
+    panel.appendChild(header);
+
+    // Improvement line
+    const improve = document.createElement('div');
+    Object.assign(improve.style, { fontSize: '14px', marginBottom: '12px' });
+    if (isFirst) {
+      improve.textContent = 'Set the time to beat — your ghost will race you next run.';
+      improve.style.color = '#74b9ff';
+    } else if (isBest) {
+      const d = totalTime - previousBest;
+      improve.textContent = `${formatDelta(d)} — new personal best!`;
+      improve.style.color = '#55efc4';
+    } else {
+      const d = totalTime - previousBest;
+      improve.textContent = `${formatDelta(d)} vs best (${formatTime(previousBest)})`;
+      improve.style.color = '#dfe6e9';
+    }
+    panel.appendChild(improve);
+
+    // Split table
+    const table = document.createElement('div');
+    Object.assign(table.style, {
+      display: 'grid', gridTemplateColumns: '1fr auto auto', gap: '4px 14px',
+      fontSize: '13px', alignItems: 'center'
+    });
+    const head = (txt, align) => {
+      const c = document.createElement('div');
+      c.textContent = txt;
+      Object.assign(c.style, {
+        color: '#9aa6b2', fontWeight: '700', textAlign: align || 'left',
+        borderBottom: '1px solid rgba(255,255,255,0.12)', paddingBottom: '4px'
+      });
+      return c;
+    };
+    table.appendChild(head('Split'));
+    table.appendChild(head('Time', 'right'));
+    table.appendChild(head('Δ Best', 'right'));
+
+    splitPoints.forEach((sp, i) => {
+      const name = document.createElement('div');
+      name.textContent = i < splitPoints.length - 1 ? sp.label : 'Finish';
+      name.style.color = '#fff';
+
+      const t = document.createElement('div');
+      t.textContent = typeof runSplits[i] === 'number' ? formatTime(runSplits[i]) : '—';
+      t.style.textAlign = 'right';
+      t.style.color = '#fff';
+
+      const d = document.createElement('div');
+      d.style.textAlign = 'right';
+      if (bestSplits && typeof bestSplits[i] === 'number' && typeof runSplits[i] === 'number') {
+        const diff = runSplits[i] - bestSplits[i];
+        d.textContent = formatDelta(diff);
+        d.style.color = diff <= 0 ? '#55efc4' : '#ff7675';
+      } else {
+        d.textContent = '—';
+        d.style.color = '#9aa6b2';
+      }
+      table.appendChild(name);
+      table.appendChild(t);
+      table.appendChild(d);
+    });
+    panel.appendChild(table);
+
+    return panel;
+  }
+
+  return {
+    init,
+    reset,
+    update,
+    hideHud,
+    onFinish,
+    // exposed for potential tests
+    _config: { START_Z, FINISH_Z, CHECKPOINT_Z, COURSE_LENGTH, splitPoints }
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.CourseModule = CourseModule;
+}

--- a/effects.js
+++ b/effects.js
@@ -1,0 +1,184 @@
+// effects.js - Drama and "juice" effects for SnowGlider
+//
+// Two responsibilities:
+//   1. Avalanche telegraphing: a warning banner, a "distance behind you" danger meter,
+//      and a red vignette that intensifies as the slide closes in — plus camera shake
+//      tied to proximity, so a threat from behind is felt and not just discovered.
+//   2. General game feel: speed-based field-of-view (widens at speed) and a shared
+//      camera-shake channel that other systems (e.g. hard landings) can poke.
+//
+// The camera is never modified directly inside camera.js. Instead the animation loop
+// asks this module for a per-frame shake offset, applies it for the render, and reverts
+// it, so the camera manager's own smoothing is never fed its own shake.
+
+const EffectsModule = (function () {
+  'use strict';
+
+  const BASE_FOV = 75;
+  const MAX_FOV = 88;            // at high speed
+  const FOV_SPEED_REF = 28;      // speed (units/s) that maps to MAX_FOV
+  const WARN_NEAR = 9;           // distance (units) considered "very close"
+  const WARN_FAR = 70;           // distance at/above which the meter reads empty
+
+  const reduceMotion = typeof window !== 'undefined' &&
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  let ui = {};
+  let shake = 0;        // current shake intensity (decays over time)
+  let proximityShake = 0; // sustained shake from avalanche proximity
+  let currentFov = BASE_FOV;
+
+  function buildUI() {
+    if (ui.banner) return;
+
+    // Red vignette (full-screen radial gradient overlay)
+    const vignette = document.createElement('div');
+    Object.assign(vignette.style, {
+      position: 'fixed', inset: '0', zIndex: '850', pointerEvents: 'none',
+      opacity: '0', transition: reduceMotion ? 'none' : 'opacity 0.15s linear',
+      background: 'radial-gradient(ellipse at center, rgba(0,0,0,0) 45%, rgba(200,30,30,0.55) 100%)'
+    });
+    document.body.appendChild(vignette);
+
+    // Warning banner
+    const banner = document.createElement('div');
+    Object.assign(banner.style, {
+      position: 'fixed', top: '110px', left: '50%', transform: 'translateX(-50%)',
+      zIndex: '902', padding: '10px 22px', borderRadius: '10px',
+      background: 'rgba(200,30,30,0.85)', color: '#fff', fontFamily: 'Arial, sans-serif',
+      fontSize: '20px', fontWeight: '800', letterSpacing: '0.5px', textAlign: 'center',
+      display: 'none', pointerEvents: 'none', boxShadow: '0 4px 18px rgba(0,0,0,0.5)',
+      textShadow: '0 1px 3px rgba(0,0,0,0.7)'
+    });
+    banner.textContent = '⚠ AVALANCHE — GO!';
+    document.body.appendChild(banner);
+
+    // Danger meter (label + bar) showing how close the slide is behind you
+    const meterWrap = document.createElement('div');
+    Object.assign(meterWrap.style, {
+      position: 'fixed', top: '152px', left: '50%', transform: 'translateX(-50%)',
+      zIndex: '902', width: 'min(300px, 80vw)', display: 'none',
+      fontFamily: 'Arial, sans-serif', textShadow: '0 1px 3px rgba(0,0,0,0.8)'
+    });
+    const meterLabel = document.createElement('div');
+    Object.assign(meterLabel.style, {
+      fontSize: '12px', color: '#fff', fontWeight: '700', marginBottom: '3px',
+      display: 'flex', justifyContent: 'space-between'
+    });
+    const meterLabelL = document.createElement('span');
+    meterLabelL.textContent = 'Avalanche';
+    const meterLabelR = document.createElement('span');
+    meterLabelR.textContent = '';
+    meterLabel.appendChild(meterLabelL);
+    meterLabel.appendChild(meterLabelR);
+
+    const meterTrack = document.createElement('div');
+    Object.assign(meterTrack.style, {
+      width: '100%', height: '10px', borderRadius: '6px',
+      background: 'rgba(0,0,0,0.4)', overflow: 'hidden',
+      border: '1px solid rgba(255,255,255,0.25)'
+    });
+    const meterFill = document.createElement('div');
+    Object.assign(meterFill.style, {
+      width: '0%', height: '100%', borderRadius: '6px',
+      background: 'linear-gradient(90deg,#fdcb6e,#e17055,#d63031)',
+      transition: reduceMotion ? 'none' : 'width 0.12s linear'
+    });
+    meterTrack.appendChild(meterFill);
+    meterWrap.appendChild(meterLabel);
+    meterWrap.appendChild(meterTrack);
+    document.body.appendChild(meterWrap);
+
+    ui = { vignette, banner, meterWrap, meterFill, meterLabelR };
+  }
+
+  function init() {
+    buildUI();
+    reset();
+  }
+
+  // Called each frame with the live avalanche state.
+  //   active:   whether the avalanche is currently bearing down
+  //   distance: closest boulder distance to the player (units); Infinity if none
+  function updateAvalanche(active, distance) {
+    if (!ui.banner) return;
+
+    if (!active || !isFinite(distance)) {
+      ui.banner.style.display = 'none';
+      ui.meterWrap.style.display = 'none';
+      ui.vignette.style.opacity = '0';
+      proximityShake = 0;
+      return;
+    }
+
+    ui.banner.style.display = 'block';
+    ui.meterWrap.style.display = 'block';
+
+    // Map distance -> danger in [0,1] (closer == higher).
+    const danger = Math.max(0, Math.min(1, (WARN_FAR - distance) / (WARN_FAR - WARN_NEAR)));
+    ui.meterFill.style.width = `${(danger * 100).toFixed(0)}%`;
+    ui.meterLabelR.textContent = `${Math.max(0, distance).toFixed(0)} m behind`;
+
+    // Vignette and shake scale with danger; only really bite when close.
+    ui.vignette.style.opacity = (danger * 0.9).toFixed(2);
+    proximityShake = reduceMotion ? 0 : danger * danger * 0.6;
+
+    // Pulse the banner copy when it's almost on top of you.
+    ui.banner.textContent = distance < WARN_NEAR + 6
+      ? '⚠ AVALANCHE RIGHT BEHIND YOU!'
+      : '⚠ AVALANCHE — GO!';
+  }
+
+  // Other systems can request a one-off shake impulse (e.g. a hard landing).
+  function addShake(amount) {
+    if (reduceMotion) return;
+    shake = Math.min(2.5, shake + amount);
+  }
+
+  // Per-frame camera treatment. Returns the shake offset that was applied so the
+  // caller can revert it after rendering.
+  function tickCamera(camera, dt, speed) {
+    // Speed-based FOV (smoothed). A zooming FOV is itself camera motion, so honor
+    // prefers-reduced-motion by pinning to the base FOV and skipping the zoom.
+    if (reduceMotion) {
+      currentFov = BASE_FOV;
+    } else {
+      const targetFov = BASE_FOV + (MAX_FOV - BASE_FOV) * Math.min(1, Math.max(0, speed / FOV_SPEED_REF));
+      currentFov += (targetFov - currentFov) * Math.min(1, dt * 3);
+    }
+    if (Math.abs(camera.fov - currentFov) > 0.05) {
+      camera.fov = currentFov;
+      camera.updateProjectionMatrix();
+    }
+
+    // Decay transient shake
+    shake = Math.max(0, shake - dt * 4);
+    const intensity = Math.max(shake, proximityShake);
+    if (intensity <= 0.0001) return { x: 0, y: 0, z: 0 };
+
+    const offset = {
+      x: (Math.random() - 0.5) * intensity,
+      y: (Math.random() - 0.5) * intensity,
+      z: (Math.random() - 0.5) * intensity * 0.5
+    };
+    camera.position.x += offset.x;
+    camera.position.y += offset.y;
+    camera.position.z += offset.z;
+    return offset;
+  }
+
+  function reset() {
+    shake = 0;
+    proximityShake = 0;
+    currentFov = BASE_FOV;
+    if (ui.banner) ui.banner.style.display = 'none';
+    if (ui.meterWrap) ui.meterWrap.style.display = 'none';
+    if (ui.vignette) ui.vignette.style.opacity = '0';
+  }
+
+  return { init, updateAvalanche, addShake, tickCamera, reset };
+})();
+
+if (typeof window !== 'undefined') {
+  window.EffectsModule = EffectsModule;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ module.exports = [
         Avalanche: "readonly",
         Camera: "readonly",
         Controls: "readonly",
+        CourseModule: "readonly",
+        EffectsModule: "readonly",
         Howl: "readonly",
         Howler: "readonly",
         Mountains: "readonly",

--- a/index.html
+++ b/index.html
@@ -1288,6 +1288,14 @@
                                         avalancheScript.src = 'avalanche.js';
                                         
                                         avalancheScript.onload = function() {
+                                          // Load effects (avalanche UI, camera juice) then course
+                                          // (gates, splits, ghost racing) before the main game script.
+                                          const effectsScript = document.createElement('script');
+                                          effectsScript.src = 'effects.js';
+                                          effectsScript.onload = function() {
+                                          const courseScript = document.createElement('script');
+                                          courseScript.src = 'course.js';
+                                          courseScript.onload = function() {
                                           const mainScript = document.createElement('script');
                                           mainScript.src = 'snowglider.js';
                                         
@@ -1361,6 +1369,10 @@
                                             }, 500);
                                         };
                                         document.body.appendChild(mainScript);
+                                        };
+                                        document.body.appendChild(courseScript);
+                                        };
+                                        document.body.appendChild(effectsScript);
                                         };
                                         document.body.appendChild(avalancheScript);
                                     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,64 @@
         "eslint": "^9.39.4",
         "globals": "^15.15.0",
         "http-server": "^14.1.1",
+        "jsdom": "^27.0.1",
         "puppeteer": "^23.11.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -54,6 +110,146 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1524,6 +1720,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1773,6 +1979,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -1781,6 +2027,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -1800,6 +2070,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1866,6 +2143,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -2794,6 +3084,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2874,6 +3171,73 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -3005,6 +3369,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -3242,6 +3613,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3472,6 +3856,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3488,6 +3882,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -3515,6 +3916,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
@@ -3700,6 +4114,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -3794,6 +4218,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -3858,6 +4289,52 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -3946,11 +4423,34 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -3986,6 +4486,30 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -4078,6 +4602,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "A cheerful snowman shredding mountain snow powder in a playful Three.js animation.",
   "main": "snowglider.js",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:controls",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:controls && npm run test:verify",
     "test:terrain": "node tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js",
     "test:regression": "node tests/regression-tests.js",
     "test:tree-collision": "node tests/tree-collision-tests.js",
     "test:avalanche": "node tests/avalanche-tests.js",
     "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
+    "test:verify": "node verification/physics_invariant_harness.js && node verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:all": "npm test && npm run test:browser",
     "test:coverage": "c8 --reporter=lcov --reporter=text npm run test",
@@ -28,6 +29,7 @@
     "eslint": "^9.39.4",
     "globals": "^15.15.0",
     "http-server": "^14.1.1",
+    "jsdom": "^27.0.1",
     "puppeteer": "^23.11.1"
   }
 }

--- a/snowglider.js
+++ b/snowglider.js
@@ -177,6 +177,29 @@ Snow.createSnowflakes(scene);
 // like the snowflakes for better visibility
 const snowSplash = Snow.createSnowSplash();
 
+// --- Initialize course (gates, splits, ghost racing) and effects (avalanche UI, juice) ---
+let lastTechnique = 'glide';
+if (typeof window.CourseModule !== 'undefined') {
+  try {
+    CourseModule.init({
+      scene: scene,
+      getTerrainHeight: Snow.getTerrainHeight,
+      createSnowman: Snowman.createSnowman
+    });
+    console.log("Course module initialized (gates, splits, ghost)");
+  } catch (e) {
+    console.warn("Course module init failed:", e.message);
+  }
+}
+if (typeof window.EffectsModule !== 'undefined') {
+  try {
+    EffectsModule.init();
+    console.log("Effects module initialized (avalanche warning, camera juice)");
+  } catch (e) {
+    console.warn("Effects module init failed:", e.message);
+  }
+}
+
 // --- Snowman Position & Reset ---
 let pos = { x: 0, z: -40, y: Snow.getTerrainHeight(0, -40) };
 let velocity = { x: 0, z: 0 }; 
@@ -316,6 +339,11 @@ function resetSnowman() {
   startTime = performance.now(); // Reset the timer when starting a new run
   updateTimerDisplay();
   
+  // Reset course (gates/splits/ghost) and effects (avalanche UI, FOV, shake) for the new run
+  lastTechnique = 'glide';
+  if (window.CourseModule) CourseModule.reset();
+  if (window.EffectsModule) EffectsModule.reset();
+  
   // Track game reset in Analytics if available
   try {
     // Only try to use analytics when properly initialized with modular SDK
@@ -416,9 +444,24 @@ function updateSnowman(delta) {
       groundElement.innerHTML = '🚀 JUMP!';
       groundElement.style.color = '#00FFFF';
     } else {
-      groundElement.innerHTML = '⛷️ Ground';
-      groundElement.style.color = '#AAFFAA';
+      // Reflect the active ski technique so skill is legible in the HUD.
+      const techMap = {
+        carve:    { txt: '🎿 Carving',  color: '#55efc4' },
+        skid:     { txt: '💨 Skidding', color: '#ffeaa7' },
+        snowplow: { txt: '🍕 Snowplow', color: '#74b9ff' },
+        tuck:     { txt: '🏎️ Tuck',     color: '#ff7675' },
+        glide:    { txt: '⛷️ Ground',   color: '#AAFFAA' }
+      };
+      const t = techMap[result.technique] || techMap.glide;
+      groundElement.innerHTML = t.txt;
+      groundElement.style.color = t.color;
     }
+  }
+  lastTechnique = result.technique;
+
+  // Camera shake on a meaningful landing (scales with time spent aloft).
+  if (result.justLanded && result.landingForce > 0.25 && window.EffectsModule) {
+    EffectsModule.addShake(Math.min(1.2, result.landingForce * 0.6));
   }
   
   // Update timer in the updateTimerDisplay function which is called separately
@@ -459,6 +502,12 @@ function animate(time) {
     updateSnowman(delta);
     Snow.updateSnowflakes(delta, pos, scene);
     
+    // --- Course progress: split timing, progress HUD, ghost racing ---
+    if (window.CourseModule) {
+      const elapsed = (performance.now() - startTime) / 1000;
+      CourseModule.update(pos, elapsed, snowman);
+    }
+    
     // --- Avalanche Logic ---
     if (avalanche) {
       // Trigger avalanche based on distance traveled (simple geometric trigger)
@@ -486,6 +535,13 @@ function animate(time) {
         avalancheTriggered = false;
         lastAvalancheZ = pos.z; // Reset trigger point for potential next avalanche
       }
+      
+      // Telegraph the threat: banner, "distance behind you" meter, vignette, shake.
+      if (window.EffectsModule) {
+        const avActive = avalancheTriggered && avalanche.active;
+        const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
+        EffectsModule.updateAvalanche(avActive, avDist);
+      }
     }
     
     // Save player position before snow splash effect updates
@@ -503,7 +559,20 @@ function animate(time) {
     
     updateCamera();
     updateTimerDisplay(); // Update the timer display
+    
+    // Camera juice: speed-based FOV + shake. Apply for the render only, then revert
+    // the positional offset so the camera manager's own smoothing stays clean.
+    let _shake = null;
+    if (window.EffectsModule) {
+      const spd = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
+      _shake = EffectsModule.tickCamera(camera, delta, spd);
+    }
     renderer.render(scene, camera);
+    if (_shake) {
+      camera.position.x -= _shake.x;
+      camera.position.y -= _shake.y;
+      camera.position.z -= _shake.z;
+    }
   } else if (animationRunning) {
     animationRunning = false;
   }
@@ -546,12 +615,23 @@ function showGameOver(reason) {
   }
   gameActive = false;
   
+  // Capture the best time BEFORE the finish branch updates it, so the result
+  // screen can report the delta and whether this run set a new record.
+  const previousBest = bestTime;
+
+  // Measure the finish elapsed ONCE and reuse it for both the best-time/score path
+  // and CourseModule.onFinish(). Otherwise a second performance.now() taken after the
+  // DOM/localStorage/score work could read later: a sub-millisecond personal best
+  // would be saved as a new record while the course screen sees elapsed >= previousBest,
+  // skips persisting the new ghost/splits, and shows a time that disagrees with the score.
+  const finishTime = (performance.now() - startTime) / 1000;
+
   // Remove game-active class from body for styling
   document.body.classList.remove('game-active');
   
   gameOverDetail.textContent = reason;
   removeLoginPrompt();
-  
+
   // TODO: AUDIO DISABLED - Pause audio on game over (will be no-op if disabled)
   if (window.AudioModule) {
     AudioModule.enableSound(false);
@@ -573,22 +653,24 @@ function showGameOver(reason) {
   
   // Only update times if player reached the end successfully
   if (reason === "You reached the end of the slope!") {
-    const currentTime = (performance.now() - startTime) / 1000;
+    const currentTime = finishTime;
     const isNewBestTime = currentTime < bestTime;
     const canRecordScore = window.AuthModule && typeof window.AuthModule.recordScore === 'function';
 
+    // Record the score whenever the leaderboard API is available (it handles its own
+    // auth + persistence); otherwise fall back to persisting a new local best.
     if (canRecordScore) {
       window.AuthModule.recordScore(currentTime);
     } else if (isNewBestTime) {
       localStorage.setItem('snowgliderBestTime', currentTime);
     }
-    
+
     // Show appropriate message based on time
     if (isNewBestTime) {
       bestTime = currentTime;
       bestTimeDisplay.textContent = `New Best Time: ${bestTime.toFixed(2)}s`;
       bestTimeDisplay.style.color = '#ffff00'; // Highlight new record
-      
+
       // Update the best time in the game stats window too
       const bestTimeElement = document.getElementById('bestTimeValue');
       if (bestTimeElement) {
@@ -661,12 +743,35 @@ function showGameOver(reason) {
     window.AuthModule.displayLeaderboard();
   }
   
+  // Build the result screen (splits + medal) on a finish; otherwise just clear
+  // the live HUD/effects. The panel is inserted above the restart button.
+  if (window.CourseModule) {
+    const staleResult = document.getElementById('courseResult');
+    if (staleResult && staleResult.parentNode) staleResult.parentNode.removeChild(staleResult);
+    
+    if (reason === "You reached the end of the slope!") {
+      try {
+        const panel = CourseModule.onFinish(finishTime, previousBest);
+        if (panel) gameOverOverlay.insertBefore(panel, restartButton);
+      } catch (e) {
+        console.warn("Result screen failed:", e.message);
+      }
+    } else {
+      CourseModule.hideHud();
+    }
+  }
+  if (window.EffectsModule) EffectsModule.reset();
+  
   gameOverOverlay.style.display = 'flex';
 }
 
 function restartGame() {
   gameOverOverlay.style.display = 'none';
   gameActive = true;
+  
+  // Clear the finish result panel from the previous run, if present.
+  const oldResult = document.getElementById('courseResult');
+  if (oldResult && oldResult.parentNode) oldResult.parentNode.removeChild(oldResult);
   
   // Add game-active class to body for styling
   document.body.classList.add('game-active');

--- a/snowman.js
+++ b/snowman.js
@@ -364,11 +364,20 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
 
     // Snowplow braking: decelerate along the actual direction of travel so it
     // bleeds genuine speed (not just downhill velocity), with a little extra dig.
+    // Clamp the impulse to the current speed so braking can bring the snowman to a
+    // stop but never reverse the velocity vector — otherwise at low speed the
+    // subtraction overshoots zero and the control bias below drives it back uphill,
+    // letting players climb/stall the timed course by braking.
     if (snowplow && currentSpeed > 0.001) {
       const brakeDecel = 14.0;
-      velocity.x -= (velocity.x / currentSpeed) * brakeDecel * delta;
-      velocity.z -= (velocity.z / currentSpeed) * brakeDecel * delta;
-      velocity.z += accelerationForce * delta * 0.3; // slight uphill bias for control
+      const brakeImpulse = Math.min(brakeDecel * delta, currentSpeed);
+      velocity.x -= (velocity.x / currentSpeed) * brakeImpulse;
+      velocity.z -= (velocity.z / currentSpeed) * brakeImpulse;
+      // Only nudge the slight uphill control bias while still moving; never after the
+      // brake has stopped the snowman (that would push it uphill from a standstill).
+      if (brakeImpulse < currentSpeed) {
+        velocity.z += accelerationForce * delta * 0.3;
+      }
     }
 
     // Edge skid / carve quality: only meaningful while steering. A clean carve

--- a/verification/dom_smoke_test.js
+++ b/verification/dom_smoke_test.js
@@ -1,0 +1,158 @@
+// dom_smoke_test.js
+// Load course.js + effects.js under jsdom with a mocked THREE, then exercise
+// init/reset/update/onFinish/avalanche/camera and assert sane behavior — headless
+// coverage for the two new modules without a browser. Requires jsdom (devDependency).
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO = path.join(__dirname, '..');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+global.localStorage = (function () {
+  let store = {};
+  return {
+    getItem: k => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: k => { delete store[k]; },
+    clear: () => { store = {}; }
+  };
+})();
+window.localStorage = global.localStorage;
+window.matchMedia = window.matchMedia || (() => ({ matches: false }));
+
+// Stub <canvas> 2d context (jsdom has none without the native canvas pkg).
+const origCreate = window.document.createElement.bind(window.document);
+window.document.createElement = function (tag) {
+  const el = origCreate(tag);
+  if (tag === 'canvas') {
+    el.getContext = () => ({
+      fillStyle: '', font: '', textAlign: '', textBaseline: '',
+      fillRect() {}, fillText() {}
+    });
+  }
+  return el;
+};
+
+// --- Minimal THREE mock (only what course.js touches) ---
+class Obj3D {
+  constructor() { this.position = vec3(); this.rotation = { x: 0, y: 0, z: 0 }; this.children = []; this.visible = true; this.userData = {}; }
+  add(o) { this.children.push(o); }
+  traverse(fn) { fn(this); this.children.forEach(c => c.traverse ? c.traverse(fn) : fn(c)); }
+}
+function vec3() { return { x: 0, y: 0, z: 0, set(x, y, z) { this.x = x; this.y = y; this.z = z; return this; }, copy() { return this; }, lerp() { return this; }, add() { return this; } }; }
+const THREE = {
+  Group: class extends Obj3D {},
+  Mesh: class extends Obj3D { constructor() { super(); this.material = { color: new ColorMock() }; } },
+  CylinderGeometry: class {}, PlaneGeometry: class {}, BoxGeometry: class {},
+  IcosahedronGeometry: class {}, SphereGeometry: class {},
+  MeshStandardMaterial: class { constructor(o) { Object.assign(this, o); this.color = new ColorMock(); this.emissive = new ColorMock(); } clone() { return new THREE.MeshStandardMaterial(); } },
+  MeshBasicMaterial: class { constructor(o) { Object.assign(this, o); } },
+  CanvasTexture: class {}, DoubleSide: 2,
+};
+class ColorMock { constructor() {} lerp() { return this; } }
+THREE.Color = ColorMock;
+global.THREE = THREE; window.THREE = THREE;
+
+// Load the modules into the jsdom global scope.
+function loadInWindow(file) {
+  const code = fs.readFileSync(path.join(REPO, file), 'utf8');
+  // Evaluate with access to our globals (THREE, document, window, localStorage).
+  const fn = new Function('THREE', 'document', 'window', 'localStorage', 'console', code + '\n;return (typeof CourseModule!=="undefined"?CourseModule:(typeof EffectsModule!=="undefined"?EffectsModule:null));');
+  return fn(THREE, window.document, window, global.localStorage, console);
+}
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+
+// ---- EffectsModule ----
+console.log('--- EffectsModule ---');
+const Effects = loadInWindow('effects.js');
+check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
+Effects.init();
+const banner = window.document.body.querySelector('div');
+check('init builds DOM overlays without throwing', !!banner);
+// Inactive avalanche hides things, active shows + sets danger
+Effects.updateAvalanche(false, Infinity);
+Effects.updateAvalanche(true, 40);
+Effects.updateAvalanche(true, 8); // very close
+check('updateAvalanche(active, near) runs', true);
+// Camera FOV widens with speed and shake offset returned
+const cam = { fov: 75, position: { x: 0, y: 0, z: 0 }, updateProjectionMatrix() { this._u = (this._u || 0) + 1; } };
+Effects.addShake(1.0);
+let off = Effects.tickCamera(cam, 1 / 60, 30);
+check('tickCamera returns an offset object', off && typeof off.x === 'number');
+check('high speed widens FOV above base 75', cam.fov > 75.0);
+Effects.reset();
+check('reset() runs without throwing', true);
+
+// ---- CourseModule ----
+console.log('\n--- CourseModule ---');
+const fakeCreateSnowman = () => { const g = new THREE.Group(); g.add(new THREE.Mesh()); return g; };
+const Course = loadInWindow('course.js');
+check('module exports init/update/onFinish', !!Course && typeof Course.update === 'function' && typeof Course.onFinish === 'function');
+
+const terrain = (x, z) => 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40) + (z < -30 ? (z + 30) * 0.12 : 0);
+Course.init({ scene: new THREE.Group(), getTerrainHeight: terrain, createSnowman: fakeCreateSnowman });
+check('init builds gates + HUD', true);
+
+// Simulate a clean run reaching every split.
+global.localStorage.clear();
+Course.reset();
+const cfg = Course._config;
+const splitZ = cfg.splitPoints.map(s => s.z);
+let crossed = 0;
+const snowmanMock = { rotation: { y: Math.PI } };
+let t = 0;
+for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+  t += 0.12; // ~ seconds; arbitrary monotonic clock
+  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t, snowmanMock);
+  // count how many split thresholds we've now passed
+  crossed = splitZ.filter(sz => z <= sz).length;
+}
+check('all checkpoints + finish are reachable', crossed === splitZ.length);
+
+// First finish: should be a "first descent" (no previous best) and persist a ghost.
+const panel1 = Course.onFinish(t, Infinity);
+check('onFinish returns a result panel node', !!panel1 && panel1.id === 'courseResult');
+check('ghost trajectory persisted to localStorage', !!global.localStorage.getItem('snowgliderGhost'));
+check('best splits persisted to localStorage', !!global.localStorage.getItem('snowgliderBestSplits'));
+const panelText1 = panel1.textContent || '';
+check('first finish shows a medal/result text', /descent|record|Finish/i.test(panelText1));
+
+// Gap 3 regression: the persisted ghost's final sample keeps the player's real x
+// (not a hardcoded 0) so it doesn't snap to center at the line.
+const ghostSaved = JSON.parse(global.localStorage.getItem('snowgliderGhost'));
+const ghostLast = ghostSaved[ghostSaved.length - 1];
+check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
+
+// Second run, faster: should read as a new record and a ghost should now exist + interpolate.
+Course.reset(); // loads the stored ghost AND best splits (Gap 2 fix)
+let t2 = 0;
+for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+  t2 += 0.09; // faster pace than run 1 (0.12)
+  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t2, snowmanMock);
+}
+const previousBest = t; // run 1 total
+const panel2 = Course.onFinish(t2, previousBest);
+const panelText2 = panel2.textContent || '';
+check('faster second run reports a new record', /record/i.test(panelText2));
+check('result panel contains a split table (Δ Best)', /Δ Best/.test(panelText2));
+
+// Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
+// second run's result table shows real per-split deltas instead of the "—" placeholder.
+// (Scope the check to the split table — the "X — new personal best!" line legitimately
+// uses an em dash as a separator, so checking the whole panel would false-positive.)
+const EM_DASH = String.fromCharCode(0x2014);
+const deltaTable = panel2.lastElementChild; // split table is appended last in the panel
+check('best-split deltas not stale after PB (Gap 2)',
+  !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
+
+Course.hideHud();
+check('hideHud() runs without throwing', true);
+
+console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/verification/physics_invariant_harness.js
+++ b/verification/physics_invariant_harness.js
@@ -1,0 +1,165 @@
+// physics_invariant_harness.js
+// Headless comparison of the pre-feature ("baseline") updateSnowman against the
+// current snowman.js, to guard the load-bearing safety property of the ski-technique
+// layer: with NO steering/brake input, grounded physics must stay byte-for-byte
+// identical to the original (so the existing physics/regression/browser tests, which
+// drive the real updateSnowman, keep passing).
+//
+//   baseline: verification/snowman_baseline.js  (frozen pre-feature snapshot)
+//   current : ../snowman.js
+//
+// The process exit code is gated ONLY on that invariant (check 1) plus the
+// clearly-correct technique checks (brake slows you; modified scrubs >= original;
+// edge scrub at speed). Check 3 ("a turn should cost speed vs coasting") is a
+// diagnostic for the deliberately-thin technique model and is reported but does NOT
+// fail the build — deepening it is a tracked design decision, not a regression.
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// --- Shared deterministic terrain (mirrors mountains.js downhill shape, no noise) ---
+function getTerrainHeight(x, z) {
+  let y = 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40);
+  if (z < -30) y += (z + 30) * 0.12;
+  return y;
+}
+function getTerrainGradient(x, z) {
+  const eps = 0.1, h = getTerrainHeight(x, z);
+  return { x: (getTerrainHeight(x + eps, z) - h) / eps, z: (getTerrainHeight(x, z + eps) - h) / eps };
+}
+function getDownhillDirection(x, z) {
+  const g = getTerrainGradient(x, z);
+  const d = { x: -g.x, z: -g.z };
+  const len = Math.sqrt(d.x * d.x + d.z * d.z);
+  return len ? { x: d.x / len, z: d.z / len } : { x: 0, z: 1 };
+}
+
+// Seeded PRNG so the auto-turn (Math.random) path is identical across runs.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+function loadUpdate(file) {
+  const code = fs.readFileSync(file, 'utf8');
+  const sandbox = { window: { location: { search: '' } }, console: { log() {}, warn() {} }, Math: Object.create(Math), THREE: {} };
+  sandbox.global = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+  return sandbox.window.Snowman.updateSnowman;
+}
+
+function fakeSnowman() {
+  const ski = () => ({ position: { x: 0 }, rotation: { x: 0, y: 0, z: 0 } });
+  const ls = ski(), rs = ski();
+  return {
+    position: { set() {} },
+    rotation: { x: 0, y: Math.PI, z: 0 },
+    userData: { targetRotationY: Math.PI, currentRotX: 0, currentRotZ: 0,
+                leftSki: ls, rightSki: rs, leftSkiBaseX: -1, rightSkiBaseX: 1 }
+  };
+}
+
+// Run a descent; returns trajectory + final speed/distance.
+function simulate(updateFn, controls, seed, steps = 220, dt = 1 / 60) {
+  const rng = makeRng(seed);
+  Math.random = rng; // both runs use identical sequence given same seed
+  const snowman = fakeSnowman();
+  const pos = { x: 0, z: -15, y: getTerrainHeight(0, -15) };
+  const velocity = { x: 0, z: -3 };
+  let st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, -15),
+             airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+  const traj = [];
+  for (let i = 0; i < steps; i++) {
+    const r = updateFn(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity,
+      st.lastTerrainHeight, st.airTime, st.jumpCooldown, controls,
+      st.turnPhase, st.currentTurnDirection, st.turnChangeCooldown, 3.0,
+      getTerrainHeight, getTerrainGradient, getDownhillDirection, [], false, function () {});
+    st = r;
+    traj.push({ x: pos.x, z: pos.z, vx: velocity.x, vz: velocity.z });
+    if (pos.z < -195) break;
+  }
+  const last = traj[traj.length - 1];
+  return { traj, finalSpeed: Math.sqrt(last.vx * last.vx + last.vz * last.vz),
+           distance: -15 - pos.z, steps: traj.length, technique: st.technique };
+}
+
+const orig = loadUpdate(path.join(__dirname, 'snowman_baseline.js'));
+const mod = loadUpdate(path.join(__dirname, '..', 'snowman.js'));
+
+const NONE = { left: false, right: false, up: false, down: false, jump: false };
+const DOWN = { left: false, right: false, up: false, down: true, jump: false };
+const RIGHT = { left: false, right: true, up: false, down: false, jump: false };
+
+let hardFail = false; // gates the exit code on safety-critical checks only
+
+// 1) Coasting must be identical (no input) — THE load-bearing invariant.
+const a = simulate(orig, NONE, 12345);
+const b = simulate(mod, NONE, 12345);
+let maxDiff = 0;
+const n = Math.min(a.traj.length, b.traj.length);
+for (let i = 0; i < n; i++) {
+  maxDiff = Math.max(maxDiff,
+    Math.abs(a.traj[i].x - b.traj[i].x), Math.abs(a.traj[i].z - b.traj[i].z),
+    Math.abs(a.traj[i].vx - b.traj[i].vx), Math.abs(a.traj[i].vz - b.traj[i].vz));
+}
+const invariantOk = maxDiff < 1e-9 && a.traj.length === b.traj.length;
+console.log('--- Invariant: coasting (no input) baseline vs current [GATING] ---');
+console.log('  steps:', a.traj.length, b.traj.length, '| max abs diff:', maxDiff.toExponential(3));
+console.log('  PASS:', invariantOk ? 'IDENTICAL ✅' : 'DIFFERENT ❌');
+if (!invariantOk) hardFail = true;
+
+// 2) Snowplow (Down) should shed speed vs coasting on the current build [GATING]
+const coast = simulate(mod, NONE, 777);
+const plow = simulate(mod, DOWN, 777);
+const brakeOk = plow.finalSpeed < coast.finalSpeed;
+console.log('\n--- Snowplow brake (current): Down vs coast [GATING] ---');
+console.log('  coast finalSpeed:', coast.finalSpeed.toFixed(2), 'distance:', coast.distance.toFixed(1));
+console.log('  plow  finalSpeed:', plow.finalSpeed.toFixed(2), 'distance:', plow.distance.toFixed(1), '| technique:', plow.technique);
+console.log('  PASS:', brakeOk ? 'brake slows you ✅' : 'no slowdown ❌');
+if (!brakeOk) hardFail = true;
+
+// 3) Hard turning at speed should scrub speed vs coasting straight [DIAGNOSTIC ONLY]
+const turn = simulate(mod, RIGHT, 777);
+const turnCostsSpeed = turn.finalSpeed < coast.finalSpeed;
+console.log('\n--- Carving/skid (current): hold Right vs coast straight [DIAGNOSTIC] ---');
+console.log('  coast finalSpeed:', coast.finalSpeed.toFixed(2));
+console.log('  turn  finalSpeed:', turn.finalSpeed.toFixed(2), '| technique:', turn.technique);
+console.log('  PASS:', turnCostsSpeed ? 'turning costs speed ✅'
+  : 'turning free ❌ (known: technique model is intentionally thin — see Gap 4 / issues #48,#54)');
+
+// 4) Same Right input: current should be <= baseline (added scrub) [GATING]
+const turnOrig = simulate(orig, RIGHT, 777);
+const scrubsAtLeastOrig = turn.finalSpeed <= turnOrig.finalSpeed + 1e-6;
+console.log('\n--- Same Right input: baseline vs current final speed [GATING] ---');
+console.log('  baseline:', turnOrig.finalSpeed.toFixed(2), '| current:', turn.finalSpeed.toFixed(2));
+console.log('  PASS:', scrubsAtLeastOrig ? 'current scrubs >= baseline ✅' : 'unexpected ❌');
+if (!scrubsAtLeastOrig) hardFail = true;
+
+// 5) Clean high-speed demonstration of edge scrub: same hard-Right input, faster entry [GATING]
+function simulateFast(updateFn, controls, seed, vz0) {
+  const rng = makeRng(seed); Math.random = rng;
+  const snowman = fakeSnowman();
+  const pos = { x: 0, z: -40, y: getTerrainHeight(0, -40) };
+  const velocity = { x: 0, z: vz0 };
+  let st = { isInAir:false, verticalVelocity:0, lastTerrainHeight:getTerrainHeight(0,-40),
+             airTime:0, jumpCooldown:0, turnPhase:0, currentTurnDirection:0, turnChangeCooldown:3 };
+  for (let i=0;i<90;i++){
+    st = updateFn(snowman, 1/60, pos, velocity, st.isInAir, st.verticalVelocity, st.lastTerrainHeight,
+      st.airTime, st.jumpCooldown, controls, st.turnPhase, st.currentTurnDirection, st.turnChangeCooldown,
+      3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection, [], false, function(){});
+    if (pos.z < -195) break;
+  }
+  return Math.sqrt(velocity.x*velocity.x+velocity.z*velocity.z);
+}
+const fo = simulateFast(orig, RIGHT, 42, -20);
+const fm = simulateFast(mod,  RIGHT, 42, -20);
+const scrubAtSpeed = fm < fo;
+console.log('\n--- High-speed hard turn (entry 20 u/s), same Right input [GATING] ---');
+console.log('  baseline finalSpeed:', fo.toFixed(2), '| current finalSpeed:', fm.toFixed(2),
+            '| scrub:', (fo-fm).toFixed(2), `(${((1-fm/fo)*100).toFixed(0)}% slower)`);
+console.log('  PASS:', scrubAtSpeed ? 'edge scrub active at speed ✅' : 'no scrub ❌');
+if (!scrubAtSpeed) hardFail = true;
+
+console.log(`\nINVARIANT HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (safety invariant + technique gating checks hold)'}`);
+process.exit(hardFail ? 1 : 0);

--- a/verification/physics_invariant_harness.js
+++ b/verification/physics_invariant_harness.js
@@ -113,11 +113,15 @@ if (!invariantOk) hardFail = true;
 const coast = simulate(mod, NONE, 777);
 const plow = simulate(mod, DOWN, 777);
 const brakeOk = plow.finalSpeed < coast.finalSpeed;
+// Braking must bring the snowman to a stop but never reverse it uphill past the start
+// (distance = -15 - pos.z; negative => climbed uphill). Guards the clamp on brakeImpulse.
+const noReverse = plow.distance >= -0.01;
 console.log('\n--- Snowplow brake (current): Down vs coast [GATING] ---');
 console.log('  coast finalSpeed:', coast.finalSpeed.toFixed(2), 'distance:', coast.distance.toFixed(1));
 console.log('  plow  finalSpeed:', plow.finalSpeed.toFixed(2), 'distance:', plow.distance.toFixed(1), '| technique:', plow.technique);
 console.log('  PASS:', brakeOk ? 'brake slows you ✅' : 'no slowdown ❌');
-if (!brakeOk) hardFail = true;
+console.log('  PASS:', noReverse ? 'brake does not reverse uphill ✅' : `reverses uphill (distance ${plow.distance.toFixed(2)}) ❌`);
+if (!brakeOk || !noReverse) hardFail = true;
 
 // 3) Hard turning at speed should scrub speed vs coasting straight [DIAGNOSTIC ONLY]
 const turn = simulate(mod, RIGHT, 777);

--- a/verification/results.txt
+++ b/verification/results.txt
@@ -1,0 +1,30 @@
+SnowGlider — integration verification results
+Captured: 2026-06-15 04:35 UTC
+Node: v23.10.0  |  Chrome: Google Chrome 149.0.7827.114 
+
+============================================================
+1) Node suite + verify harness  (npm test)
+============================================================
+Tests completed: 7 passed, 0 failed
+Tests completed: 6 passed, 0 failed
+Tests completed: 5 passed, 0 failed
+Summary: 3 passed, 0 failed
+Tests completed: 10 passed, 0 failed
+  PASS: IDENTICAL ✅
+  PASS: turning free ❌ (known: technique model is intentionally thin — see Gap 4 / issues #48,#54)
+INVARIANT HARNESS: OK ✅ (safety invariant + technique gating checks hold)
+SMOKE TEST TOTAL: 18 passed, 0 failed
+EXIT: 0
+
+   (full per-check harness output: npm run test:verify)
+
+============================================================
+2) Browser / Puppeteer suite  (npm run test:browser)
+   integrated game, system Chrome via PUPPETEER_EXECUTABLE_PATH
+============================================================
+Passed: 51
+Failed: 0
+Completed suites: controls, camera, audio, gameplay, tree, avalanche
+
+   Baseline (clean HEAD, no course/effects) for comparison: Passed: 51, Failed: 0 (identical)
+   In-browser feature probe: CourseModule+EffectsModule live, labels unified, 0 page errors — PASS

--- a/verification/snowman_baseline.js
+++ b/verification/snowman_baseline.js
@@ -1,3 +1,8 @@
+// snowman_baseline.js — FROZEN pre-feature snapshot of snowman.js (git bc25048).
+// Used by physics_invariant_harness.js to prove the ski-technique layer leaves
+// coasting/no-input physics byte-for-byte identical. Regenerate ONLY on a deliberate
+// physics change:  git show <ref>:snowman.js > verification/snowman_baseline.js
+// (re-adding this header).
 // snowman.js - Snowman model and functions for SnowGlider game
 
 // Create Snowman (Three Spheres)
@@ -180,13 +185,6 @@ function createSnowman(scene) {
   rightSki.add(rightSkiTip);
   group.add(rightSki);
   
-  // Keep references + neutral pose so ski technique (e.g. snowplow wedge) can be shown.
-  group.userData = group.userData || {};
-  group.userData.leftSki = leftSki;
-  group.userData.rightSki = rightSki;
-  group.userData.leftSkiBaseX = leftSki.position.x;
-  group.userData.rightSkiBaseX = rightSki.position.x;
-  
   scene.add(group);
   return group;
 }
@@ -236,11 +234,6 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
     jumpCooldown -= delta;
   }
   
-  // Outer-scope outputs surfaced in the return value (HUD + camera juice).
-  let technique = isInAir ? 'air' : 'glide';
-  let justLanded = false;
-  let landingForce = 0;
-  
   // Get current terrain height at position
   const terrainHeightAtPosition = getTerrainHeight(pos.x, pos.z);
   
@@ -248,11 +241,9 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
   if (isInAir && pos.y <= terrainHeightAtPosition) {
     isInAir = false;
     pos.y = terrainHeightAtPosition;
-    justLanded = true;
     
     // Landing impact based on air time and height
     const landingImpact = Math.min(0.5, airTime * 0.15);
-    landingForce = airTime; // seconds aloft; used for camera shake on touchdown
     const currentSpeed = Math.sqrt(velocity.x*velocity.x + velocity.z*velocity.z);
     
     // Reduce speed on landing
@@ -326,68 +317,24 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
     velocity.x += dir.x * steepness * gravity * delta;
     velocity.z += dir.z * steepness * gravity * delta;
     
-    // --- Ski technique model -------------------------------------------------
-    // Layered on top of the original arcade handling. Crucially, when the player
-    // gives NO steering or brake input the behaviour below is identical to the
-    // original (turnForce/accel unchanged, skidScrub == 0), so coasting physics
-    // and the existing test expectations are preserved. Skill only emerges once
-    // the player actually works the edges:
-    //   - Snowplow (brake / Down): sheds real speed but grants tight, planted
-    //     turns ("pizza" stop) — slow and controllable.
-    //   - Carving (Left/Right): smooth, anticipatory turns hold speed; sharp
-    //     direction changes at speed wash the edges out and scrub speed (skid).
-    //   - Tuck / straight-line (Up, no steer): least friction, most speed, least
-    //     room to react — the risk/reward line.
-    const steering = (controls.left ? -1 : 0) + (controls.right ? 1 : 0);
-    const snowplow = !!controls.down && !isInAir;
-
-    // Terrain-dependent grip: a touch more bite on moderate pitches, looser when flat.
-    const terrainGrip = 0.6 + Math.min(0.4, steepness * 0.5);
-
-    // Steering authority: snowplow tightens the turn, speed loosens it slightly.
-    let turnForce = 16.0;
-    if (snowplow) turnForce = 24.0;            // planted wedge = sharper steering
-    else if (currentSpeed > 18) turnForce = 14.0; // hard to wrench the skis at speed
-
+    // Handle user input for steering
+    const turnForce = 16.0;
+    
     if (controls.left) {
       velocity.x -= turnForce * delta;
     }
     if (controls.right) {
       velocity.x += turnForce * delta;
     }
-
-    // Forward input / straight-line tuck.
+    
+    // Handle forward/backward input
     const accelerationForce = 10.0;
     if (controls.up) {
       velocity.z -= accelerationForce * delta;
     }
-
-    // Snowplow braking: decelerate along the actual direction of travel so it
-    // bleeds genuine speed (not just downhill velocity), with a little extra dig.
-    if (snowplow && currentSpeed > 0.001) {
-      const brakeDecel = 14.0;
-      velocity.x -= (velocity.x / currentSpeed) * brakeDecel * delta;
-      velocity.z -= (velocity.z / currentSpeed) * brakeDecel * delta;
-      velocity.z += accelerationForce * delta * 0.3; // slight uphill bias for control
+    if (controls.down) {
+      velocity.z += accelerationForce * delta * 0.5; // Braking is less powerful
     }
-
-    // Edge skid / carve quality: only meaningful while steering. A clean carve
-    // keeps speed; yanking the skis sideways at speed scrubs it. Snowplow adds
-    // grip, so braking through a turn stays controlled instead of washing out.
-    let skidScrub = 0;
-    if (steering !== 0 && currentSpeed > 4) {
-      const speedFactor2 = Math.min(1, currentSpeed / 22);
-      const grip = snowplow ? 1.0 : terrainGrip;
-      // Sharper turn relative to grip => more scrub. Range roughly 0..0.06.
-      skidScrub = 0.06 * speedFactor2 * (1 - grip * 0.85);
-    }
-
-    // Expose technique for HUD + ski pose.
-    technique = 'glide';
-    if (isInAir) technique = 'air';
-    else if (snowplow) technique = 'snowplow';
-    else if (steering !== 0) technique = skidScrub > 0.025 ? 'skid' : 'carve';
-    else if (controls.up) technique = 'tuck';
     
     // Only use automatic turning if no user input
     if (!controls.left && !controls.right) {
@@ -424,21 +371,9 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
       velocity.x += Math.sin(turnPhase * 0.3) * (turnAmplitude * 0.7) * delta * turnIntensity * currentTurnDirection;
     }
     
-    // Apply friction to slow down. Base friction is unchanged when not steering
-    // (skidScrub == 0), so straight-line/coasting behaviour is identical to before;
-    // hard turns at speed add edge-skid drag on top.
-    const totalFriction = friction + skidScrub;
-    velocity.x *= (1 - totalFriction);
-    velocity.z *= (1 - totalFriction);
-    
-    // Show the current technique on the snowman (snowplow forms a ski wedge).
-    if (snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
-      const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
-      const wedge = snowplow ? 0.35 : 0.0; // radians; tips angled inward
-      ls.rotation.y += ((-wedge) - ls.rotation.y) * Math.min(1, delta * 10);
-      rs.rotation.y += ((wedge) - rs.rotation.y) * Math.min(1, delta * 10);
-      snowman.userData.technique = technique;
-    }
+    // Apply simple friction to slow down
+    velocity.x *= (1 - friction);
+    velocity.z *= (1 - friction);
     
     // Update y position to terrain height when not in air
     pos.y = terrainHeightAtPosition;
@@ -666,10 +601,7 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
     turnPhase,
     currentTurnDirection,
     turnChangeCooldown,
-    currentSpeed,
-    technique,
-    justLanded,
-    landingForce
+    currentSpeed
   };
 }
 


### PR DESCRIPTION
## Summary

Integrates the **skill & structure layer** from `new/snowglider-complete.zip` — the top recommendation of the feature-gap analysis — and applies the pre-merge fixes from the independent verification report. Turns the open-slope demo into a timed course with technique, drama, and a replay loop.

The bundle's base was **byte-identical to `main`**, so the feature files match the verified diff exactly, except for the enumerated fixes below.

### New gameplay
- **`course.js`** — checkpoint gates + gold finish arch, live split timing, progress / "m to finish" HUD, translucent **ghost racing** of your best run (AHEAD/BEHIND), result screen with medal + per-split deltas. Gates are decorative (never collide).
- **`effects.js`** — avalanche **warning banner** + "distance behind" danger meter + red vignette + proximity camera shake; speed-based FOV. Driven by the existing `avalanche.getClosestDistance()/active` API — **`avalanche.js` is unchanged**.
- **`snowman.js`** — snowplow / carve / skid / tuck **ski-technique** model, layered so that **with no steering/brake input the grounded physics is byte-for-byte identical to before** (keeps the physics/regression/browser suites green). Technique surfaced for the HUD.
- **`snowglider.js` / `index.html`** — wire both modules into init, the `animate()` loop, and game-over; HUD technique readout; loader chain `effects.js → course.js → snowglider.js`.

### Pre-merge fixes (from the verification report)
| Gap | Severity | Fix |
|----|----|----|
| **2** | functional bug | Reload `bestSplits` in `reset()` via a shared `loadBests()` helper so split deltas don't go stale within a session after a personal best. |
| **3** | cosmetic | Persist the player's real final x/y/rotation in the ghost's last sample instead of a hardcoded `{0,0,FINISH_Z}` (no snap-to-center / height dip at the line). |
| **6** | minor | Pin FOV to base under `prefers-reduced-motion` (a zooming FOV is itself camera motion). |
| **7** | cosmetic | Single source of truth for checkpoint labels (gate banner reads from `splitPoints`) — unifies the 3D `CHECKPOINT n` with the HUD/result table. |
| **1 / 5** | docs | `IMPLEMENTATION_REPORT.md` now reflects direct integration (no broken patch/`src/` apply path) and discloses **all five** physics-harness checks. |

### Verification tooling (new, portable; wired into `npm test` via `test:verify`)
- `verification/physics_invariant_harness.js` + `snowman_baseline.js` (frozen pre-feature snapshot) — proves the **coasting-identical invariant**; the harness exit code gates on it (plus the brake/scrub checks).
- `verification/dom_smoke_test.js` (adds `jsdom` devDependency) — headless `course`/`effects` coverage including **Gap 2 and Gap 3 regression checks** (negative-control–validated).

## Verification (all run in this environment)
- ✅ `npm test` green: terrain 7, physics 6, regression 5, tree-collision 3, avalanche 10, **invariant harness OK**, **DOM smoke 18/18**.
- ✅ `npm run test:browser` **51/51, 0 failed** against the integrated game — **identical to a clean baseline checkout** (run with system Chrome). This clears the browser gate (**Gap 8**) the original reviewers couldn't run.
- ✅ In-browser probe: `CourseModule` + `EffectsModule` initialize, course HUD + avalanche banner build, labels unified, **0 page errors**.

## Open design decision (deferred — not blocking)
The ski-technique model is **intentionally thin**: turning still nets positive speed at normal velocity (the harness reports this as a transparent *diagnostic*, not a failure). It's directionally correct (a hard turn is ~9% slower than the original at speed) and ship-safe. Deepening it into a true speed-management trade-off is a follow-up — issues **#48 / #54**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
