### PR TITLE
chore(ts): TypeScript migration Phase 1 — type-check the whole codebase in place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
 
       - name: Run lint
         run: npm run lint
-      
+
+      - name: Type-check (tsc --noEmit)
+        run: npm run typecheck
+
       - name: Run Node.js tests with coverage
         run: npm run test:coverage
       

--- a/TYPESCRIPT_MIGRATION.md
+++ b/TYPESCRIPT_MIGRATION.md
@@ -1,0 +1,258 @@
+# SnowGlider — TypeScript Migration Roadmap
+
+> Gradual, test-gated transition from the current classic-script JavaScript codebase to type-checked, then fully TypeScript, source — **without breaking the GitHub Pages deploy to snowglider.ai at any point.**
+
+## Status
+
+- **Current:** ES2022 JavaScript. Classic `<script>` modules (global namespaces), three.js **r134** loaded as a CDN global, no bundler, no build step. `auth.js` / `scores.js` are the only ES modules (Firebase).
+- **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
+- **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
+
+## TL;DR
+
+The blocker is **not** TypeScript — it's the *classic-script + global-namespace + CDN-`THREE`* architecture. TS wants modules. So we do this in order, each step independently shippable:
+
+1. **Phase 1 — Type-check in place (no architecture change, no build step).** `tsconfig` with `checkJs` + a `globals.d.ts` that mirrors the globals list already in `eslint.config.js`. Lean on the JSDoc you already write. CI gains `tsc --noEmit`. **Reversible, low risk, real value.**
+2. **Phase 2 — Introduce a bundler + convert globals → ES modules**, module-by-module, behind the test suite. `THREE` moves from CDN global to `import * as THREE from 'three'`.
+3. **Phase 3 — Rename `.js` → `.ts`** and ratchet strict flags up, `strictNullChecks` first.
+4. **Parallel track — upgrade three.js off r134** (separate from all type work; sequence *after* Phase 2).
+
+Highest ROI is **typed game-state + the pure-logic modules you already test** (physics, terrain, course, avalanche, scoring) — not annotating every rendering object.
+
+---
+
+## Phase 0 — Baseline & safety net (½ day)
+
+Goal: lock in a known-good state so every later phase is measurable.
+
+- [ ] Confirm `npm test` and `npm run lint` are green on a clean checkout. Record current `c8` coverage as the baseline.
+- [ ] Tag the pre-migration commit (e.g. `pre-ts-baseline`) so any phase can be bisected against it.
+- [ ] Skim `ARCHITECTURE.md` §3 (global namespace) and §4 (injection seams) — the seams (`setTerrainFunction`, etc.) are your future typed boundaries.
+
+**No code changes. Nothing to revert.**
+
+---
+
+## Phase 1 — Type-checking in place (2–4 days)
+
+Goal: catch type bugs across the existing JS with **zero changes to how the game loads or deploys**. This is pure static analysis layered on top of your existing ESLint setup.
+
+### 1.1 Add the type-checker
+
+```bash
+npm i -D typescript
+npm i -D @types/three@~0.134   # MUST match the r134 you load from CDN
+```
+
+> ⚠️ Version-match `@types/three` to your three version. Mismatches are a known source of phantom type errors. You're on r134, so pin `~0.134`.
+
+`tsconfig.json` (checks JS, emits nothing — no build artifact, deploy unchanged):
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.js", "types/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "coverage", "tests"]
+}
+```
+
+(`tests/` is excluded initially to keep noise down; fold it in once `src/` is clean.)
+
+### 1.2 Teach TS about the globals — mirror `eslint.config.js`
+
+Your `eslint.config.js` already enumerates every global namespace (`Avalanche`, `Camera`, `Controls`, `CourseModule`, `Mountains`, `Snow`, `Snowman`, `Trees`, `Utils`, `THREE`, plus mutable state like `scene`, `velocity`, `gameActive`…). Create the **type-level twin** of that list at `types/globals.d.ts`:
+
+```ts
+import type * as THREE_NS from 'three';
+
+declare global {
+  // three.js r134, loaded as a global from cdnjs (not a module yet)
+  const THREE: typeof THREE_NS;
+
+  // Game module namespaces — attached to window by classic scripts.
+  // Start loose, tighten as each module gets typed.
+  const Avalanche: { AvalancheSystem: typeof import('../src/avalanche.js') extends never ? unknown : any };
+  const Camera: any;
+  const Controls: any;
+  const CourseModule: any;
+  const Mountains: any;
+  const Snow: any;
+  const Snowman: any;
+  const Trees: any;
+  const Utils: any;
+
+  // Shared mutable game state (see ARCHITECTURE.md §3)
+  let scene: THREE_NS.Scene;
+  let snowman: THREE_NS.Object3D;
+  let velocity: THREE_NS.Vector3;
+  let gameActive: boolean;
+  // …keep this in lockstep with the globals block in eslint.config.js
+}
+
+export {};
+```
+
+Treat `globals.d.ts` and the eslint globals list as **one logical thing kept in sync** — when you tighten a type here, you've documented the contract for that seam.
+
+### 1.3 Turn on checking file-by-file, lean on existing JSDoc
+
+You already standardize on "JSDoc-style comments for public functions" (`CLAUDE.md`). Now make those JSDoc comments *typed*, and flip files on one at a time:
+
+- [ ] Add `// @ts-check` to the top of a file, run `npx tsc --noEmit`, fix what it flags, commit.
+- [ ] Recommended order (pure logic first — highest value, already test-protected): **`avalanche.js` → `course.js` → `camera.js` → `trees.js` → `controls.js` → `effects.js` → `snow.js` → `mountains.js` → `snowman.js` → `snowglider.js`**. (`auth.js` / `scores.js` can go in parallel — they're already modules and Firebase ships its own types.)
+- [ ] Define **domain typedefs** early (in JSDoc or `types/`), since they pay off immediately:
+
+```ts
+/** @typedef {'start'|'racing'|'finished'|'crashed'} GamePhase */
+/** @typedef {(x:number, z:number) => number} TerrainHeightFn */ // the setTerrainFunction seam
+
+/**
+ * @typedef {Object} PlayerState
+ * @property {THREE.Vector3} position
+ * @property {THREE.Vector3} velocity
+ * @property {number} verticalVelocity
+ * @property {number} heading
+ * @property {boolean} isInAir
+ * @property {boolean} grounded
+ */
+
+/**
+ * @typedef {Object} Gate
+ * @property {string} id
+ * @property {THREE.Vector3} center
+ * @property {number} width
+ * @property {boolean} passed
+ */
+```
+
+These map straight onto state you already track (`velocity`, `verticalVelocity`, `isInAir`, `gameActive`, gates/checkpoints in `course.js`).
+
+### 1.4 Wire it into CI
+
+```jsonc
+// package.json scripts
+"typecheck": "tsc --noEmit"
+```
+
+- [ ] Add a `typecheck` step to your existing `.github/` workflow (run it alongside `lint` and `test`).
+- [ ] Optionally gate it as `"warn"`-equivalent first (don't fail the build) until `src/` is clean, then make it blocking.
+
+**Exit criteria for Phase 1:** every `src/*.js` has `// @ts-check`, `tsc --noEmit` is green and blocking in CI, `npm test` still green, deploy untouched. **At this point you can keep shipping features in JS indefinitely with a real safety net.** Phases 2–3 are optional and only worth it if you're committing to long-term growth.
+
+---
+
+## Phase 2 — Bundler + ES modules (1–2 weeks, incremental)
+
+Goal: replace the CDN-global + script-injection model with an ES-module graph and a thin build, so the type system can actually flow across files (and so you *can* upgrade three.js — the global/UMD build is gone in modern three).
+
+> This is the phase that changes your deploy model: from "GitHub Pages serves source directly" to "build to `dist/`, deploy `dist/`." `dist/` is already gitignored, so you're half-anticipating this.
+
+### 2.1 Add Vite (recommended) or esbuild
+
+```bash
+npm i -D vite
+npm i three@0.134   # pull three from npm instead of the CDN (keep r134 for now — upgrade separately)
+```
+
+`vite.config.js` — custom domain (snowglider.ai via CNAME) means `base: '/'`:
+
+```js
+import { defineConfig } from 'vite';
+export default defineConfig({
+  base: '/',
+  build: { outDir: 'dist', sourcemap: true },
+});
+```
+
+- [ ] Replace the CDN `<script src=".../r134/three.min.js">` and the nested `src/*.js` injection in `index.html` with a single module entry: `<script type="module" src="/src/snowglider.js"></script>`. Vite resolves the import graph and ordering for you.
+- [ ] Update the GitHub Pages workflow to `npm run build` and deploy `dist/` (e.g. via `actions/deploy-pages`), keeping the `CNAME` file in the published output.
+
+> ⚠️ **Vite does not type-check** — it strips types and bundles. Keep `tsc --noEmit` in CI as the *real* type gate. Optionally add `vite-plugin-checker` for in-editor/dev feedback.
+
+### 2.2 Convert globals → modules, one module at a time
+
+For each module, in the dependency order from Phase 1:
+
+1. Replace `class X {}` + `window.X = X` with `export`.
+2. Replace global `THREE` reads with `import * as THREE from 'three'` at the top.
+3. Replace consumers' global reads (`new Avalanche.AvalancheSystem(...)`) with `import { AvalancheSystem } from './avalanche.js'`.
+4. **Update that module's test** — it currently injects a `mockTHREE` and relies on globals; once the module imports real three, switch the test to import the module and either mock `three` or run against real three under node. Keep the test green before moving on.
+5. Remove the now-dead entry from `globals.d.ts` and from the eslint globals list.
+
+Convert lowest-coupling pure-logic modules first; convert `snowglider.js` (the orchestrator holding most global state) **last**.
+
+**Exit criteria for Phase 2:** `index.html` loads one module entry, no `window.*` namespace assignments remain, `three` comes from npm, `npm test` + `tsc --noEmit` + build + Pages deploy all green.
+
+---
+
+## Phase 3 — Rename to `.ts` and tighten (3–5 days, incremental)
+
+Now that modules exist and are JSDoc-typed, renaming is mostly mechanical.
+
+- [ ] Rename `.js` → `.ts` module-by-module; move JSDoc typedefs to real `interface`/`type` declarations.
+- [ ] **Enable `strictNullChecks` first** — it's the single highest-value flag for this game (empty raycaster hits, optional mesh refs, `getTerrainHeight` before injection). Fix, commit.
+- [ ] Then ratchet the rest: `noImplicitAny` → `strictFunctionTypes` → full `"strict": true`. One flag per PR; never big-bang `strict`.
+- [ ] Replace the shared mutable globals (`scene`, `velocity`, `gameActive`, `avalancheTriggered`, `lastAvalancheZ`, `bestTime`…) with a typed `GameState` object passed through the loop, or typed module state. This is where `PlayerState` / `Gate` / `GamePhase` / `AvalancheState` become real types and refactors get safe.
+
+**Exit criteria:** all `src` is `.ts`, `"strict": true`, no `any` in domain/logic modules (rendering may keep a few, documented).
+
+---
+
+## Parallel track — upgrade three.js off r134
+
+Independent of the type work, but **sequence it after Phase 2** (you need npm-imported, module-style three first; the global/UMD build is dropped in modern versions). Do it as its own step, not mixed with type changes:
+
+- [ ] Bump `three` + `@types/three` together, in lockstep.
+- [ ] Expect breaking changes — most notably **color management** (defaults changed in r152; outputs/lighting can shift), renderer output-encoding renames, and any `examples/jsm` addon path/API changes you use.
+- [ ] Your **regression and physics-invariant tests + puppeteer visual smoke** are exactly the guardrail for this; lean on them and bump a few minor versions at a time rather than r134 → latest in one jump.
+
+---
+
+## Per-module migration order
+
+Ordered by ROI: pure, already-tested logic first; the big stateful orchestrator last.
+
+| Order | Module | Lines | Existing tests | Notes |
+|------|--------|------:|----------------|-------|
+| 1 | `avalanche.js` | 218 | `avalanche-tests`, browser | Clean class, already `dispose()`s. Easy first win. |
+| 2 | `course.js` | 588 | (regression) | Gates/checkpoints → richest domain types (`Gate`, `Checkpoint`, `CourseSegment`). |
+| 3 | `camera.js` | 232 | `camera-tests` | One class, no global state assigned — low friction. |
+| 4 | `trees.js` | 393 | `tree-collision-tests` | Collision logic worth typing precisely. |
+| 5 | `controls.js` | 494 | `controls-tests` (browser) | Typed input state. |
+| 6 | `effects.js` / `snow.js` | 184 / 405 | (regression) | Rendering-heavy; type the public surface, allow internal looseness. |
+| 7 | `mountains.js` | 427 | `terrain-tests` | Terrain height = the `TerrainHeightFn` seam. Pure parts are high-value. |
+| 8 | `snowman.js` | 853 | (regression) | Large, visual + state. |
+| 9 | `snowglider.js` | 1193 | `physics-tests`, invariant harness, dom smoke | **Last.** Main loop + most global state. Consider extracting a typed `physics.ts` here (you have `PHYSICS.md` + invariant tests to keep it correct). |
+| ∥ | `auth.js` / `scores.js` | 521 / 562 | `audio`/regression | Already ES modules; Firebase ships its own types. Can be typed in parallel anytime. |
+
+---
+
+## What TypeScript will *not* catch (so don't expect it to)
+
+You're already ahead on the usual three.js footguns — `avalanche.js` shows correct `.dispose()` and `instanceMatrix.needsUpdate` usage. The bugs that survive any migration are **semantic**, and for this codebase specifically:
+
+- **Radians vs degrees** in `heading` / rotation math — types see `number` either way.
+- **Coordinate-system / up-axis assumptions** in terrain and camera follow logic.
+- **Aliasing of shared mutable globals** (`scene`, `velocity`, `snowman`): TS types the reference but won't catch spooky action-at-a-distance from mutation across modules. Phase 3's `GameState` refactor is the real fix, not types alone.
+- **Disposal you don't already do** — keep watching new geometry/material/texture creation in `snow.js` / `effects.js` / `mountains.js`.
+
+These belong to your existing test suite and `PHYSICS.md` discipline, not the compiler.
+
+---
+
+## Decision summary
+
+- **Stop after Phase 1** if SnowGlider is feature-stable: you get a genuine safety net, zero deploy change, and you keep shipping in JS. This is a perfectly good place to rest.
+- **Go through Phase 3** if you're committing to sustained growth (more hazards, progression, the snowglider.ai "AI" features in your `ROADMAP.md`): full type flow + a typed `GameState` makes that feature work dramatically safer to refactor.
+- **Always** keep `npm test`, `tsc --noEmit`, and the Pages deploy green at every step. Nothing here requires a big-bang rewrite, and every phase is independently revertable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "snowglider",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "firebase": "^11.5.0",
         "howler": "^2.2.4",
@@ -14,12 +15,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@types/three": "^0.134.0",
         "c8": "^10.1.2",
         "eslint": "^9.39.4",
         "globals": "^15.15.0",
         "http-server": "^14.1.1",
         "jsdom": "^27.0.1",
-        "puppeteer": "^23.11.1"
+        "puppeteer": "^23.11.1",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1430,6 +1433,13 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/three": {
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.134.0.tgz",
+      "integrity": "sha512-4YB+99Rgqq27EjiYTItEoZtdjLnTh8W9LxowgpC9eWsjaQJIL4Kn/ZcUKAnW3gB/jS4hqGN8iqmid+RcUZDzpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -4363,6 +4373,20 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:all": "npm test && npm run test:browser",
     "test:coverage": "c8 --reporter=lcov --reporter=text npm run test",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "start": "http-server -p 8080 -c-1"
   },
   "dependencies": {
@@ -26,11 +27,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/three": "^0.134.0",
     "c8": "^10.1.2",
     "eslint": "^9.39.4",
     "globals": "^15.15.0",
     "http-server": "^14.1.1",
     "jsdom": "^27.0.1",
-    "puppeteer": "^23.11.1"
+    "puppeteer": "^23.11.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,3 +1,4 @@
+// @ts-check
 // audio.js - Radically simplified audio using native HTML5 Audio
 // ~100 lines max, single track, minimal state management
 //
@@ -12,6 +13,23 @@
 // To disable: Set AUDIO_ENABLED = false
 
 const AUDIO_ENABLED = true;
+
+/**
+ * Status object returned by getStatus(). The native HTML5 implementation only
+ * populates the first fields; bufferLoaded/contextReady/contextState are legacy
+ * (Howler/AudioContext-era) fields that callers (snowglider.js checkAudioStatus)
+ * still probe — kept optional so those compat checks type-check and read as
+ * undefined at runtime.
+ * @typedef {Object} AudioStatus
+ * @property {boolean} initialized
+ * @property {boolean} disabled
+ * @property {boolean} muted
+ * @property {boolean} playing
+ * @property {string} [currentTrack]
+ * @property {boolean} [bufferLoaded]
+ * @property {boolean} [contextReady]
+ * @property {string} [contextState]
+ */
 
 const AudioModule = (function() {
   let audio = null;
@@ -30,7 +48,7 @@ const AudioModule = (function() {
   
   // Save mute preference
   function savePreferences() {
-    localStorage.setItem('snowgliderMuted', muted);
+    localStorage.setItem('snowgliderMuted', String(muted));
   }
   
   // Create the audio element
@@ -42,7 +60,8 @@ const AudioModule = (function() {
     audio.volume = 0.5;
     
     audio.addEventListener('error', (e) => {
-      console.warn('[Audio] Load error:', e.target.error?.message || 'unknown');
+      const mediaEl = /** @type {HTMLMediaElement} */ (e.target);
+      console.warn('[Audio] Load error:', mediaEl?.error?.message || 'unknown');
     });
     
     return audio;
@@ -78,7 +97,9 @@ const AudioModule = (function() {
   
   // Public API
   return {
-    init: function() {
+    // _scene accepted (and ignored) for backward-compat with the old Three.js
+    // Audio API surface; the native HTML5 implementation needs no scene.
+    init: function(_scene) {
       if (!AUDIO_ENABLED) return { initialized: false, disabled: true };
       if (initialized) return { initialized: true };
       
@@ -140,6 +161,7 @@ const AudioModule = (function() {
       }
     },
     
+    /** @returns {AudioStatus} */
     getStatus: function() {
       if (!AUDIO_ENABLED) {
         return { initialized: false, disabled: true, muted: true, playing: false };
@@ -162,7 +184,7 @@ const AudioModule = (function() {
     playPreloadedAudio: function() { return this.startAudio(); },
     resumeAudioContext: function() { return Promise.resolve(); },
     changeTrack: function() { return false; },
-    addAudioListener: function() {},
+    addAudioListener: function(_listener) {},
     showMessage: function(msg, duration = 3000) {
       // Keep message functionality
       const div = document.createElement('div');

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,3 +1,4 @@
+// @ts-check
 // auth.js - Firebase Authentication module for SnowGlider
 // Uses Firebase modular SDK (Popup-only Google Sign-In)
 
@@ -184,7 +185,7 @@ function updateUIForLoggedInUser(user) {
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
   const profileName = document.getElementById('profileName');
-  const profileAvatar = document.getElementById('profileAvatar');
+  const profileAvatar = /** @type {HTMLImageElement} */ (document.getElementById('profileAvatar'));
 
   if (!authUI || !profileUI) {
     console.error("updateUIForLoggedInUser: Could not find authUI or profileUI elements!");
@@ -234,7 +235,7 @@ function updateUIForLoggedOutUser() {
 
 // Reset login button to default state
 function resetLoginButton() {
-  const loginBtn = document.getElementById('loginBtn');
+  const loginBtn = /** @type {HTMLButtonElement} */ (document.getElementById('loginBtn'));
   if (loginBtn) {
     loginBtn.textContent = 'Login with Google';
     loginBtn.disabled = false;
@@ -247,7 +248,7 @@ function resetLoginButton() {
 // Set up login/logout button handlers
 function setupAuthButtons() {
   // Login button
-  const loginBtn = document.getElementById('loginBtn');
+  const loginBtn = /** @type {HTMLButtonElement} */ (document.getElementById('loginBtn'));
   if (loginBtn) {
     // Function to handle sign-in process using Popup
     const handleSignIn = (e) => {
@@ -306,7 +307,7 @@ function setupAuthButtons() {
   }
 
   // Logout button
-  const logoutBtn = document.getElementById('logoutBtn');
+  const logoutBtn = /** @type {HTMLButtonElement} */ (document.getElementById('logoutBtn'));
   if (logoutBtn) {
     // Prevent default touch behavior if needed
     logoutBtn.addEventListener('touchstart', (e) => {
@@ -399,7 +400,7 @@ function syncUserData(user) {
 
 /**
  * Gets the currently signed-in user object from Firebase Auth.
- * @returns {firebase.User|null} The current user object or null.
+ * @returns {import('firebase/auth').User | null} The current user object or null.
  */
 function getCurrentUser() {
   return currentUser;

--- a/src/avalanche.js
+++ b/src/avalanche.js
@@ -1,3 +1,4 @@
+// @ts-check
 // avalanche.js - Simple avalanche system for Snowglider
 // Triggered when player travels far enough downhill - burial = game over
 

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,3 +1,4 @@
+// @ts-check
 // camera.js - Camera management for SnowGlider
 
 class Camera {

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,4 +1,8 @@
+// @ts-check
 // controls.js - Keyboard and touch controls for SnowGlider game
+
+/** @typedef {{ x: number, y: number, width: number, height: number }} TouchRegion */
+/** @typedef {'left'|'right'|'up'|'down'|'jump'} ControlName */
 
 // Initialize controls state - used for both keyboard and touch
 const gameControls = {
@@ -10,6 +14,13 @@ const gameControls = {
 };
 
 // Touch state tracking
+/**
+ * @type {{
+ *   touches: Record<string, { x: number, y: number }>,
+ *   controlRegions: Partial<Record<ControlName, TouchRegion>>,
+ *   showVisualControls: boolean
+ * }}
+ */
 const touchState = {
   touches: {},         // Store active touch points
   controlRegions: {},  // Regions for touch controls on screen
@@ -264,15 +275,16 @@ function setupTouchControls() {
     if (touchState.showVisualControls && isActive) {
       const touchControls = document.querySelectorAll('.touch-control');
       touchControls.forEach(control => {
+        const el = /** @type {HTMLElement} */ (control);
         // Highlight the active control
         if ((control.classList.contains('touch-left') && gameControls.left) ||
             (control.classList.contains('touch-right') && gameControls.right) ||
             (control.classList.contains('touch-up') && gameControls.up) ||
             (control.classList.contains('touch-down') && gameControls.down) ||
             (control.classList.contains('touch-jump') && gameControls.jump)) {
-          control.style.backgroundColor = 'rgba(255, 255, 255, 0.4)';
+          el.style.backgroundColor = 'rgba(255, 255, 255, 0.4)';
         } else {
-          control.style.backgroundColor = 'rgba(255, 255, 255, 0.2)';
+          el.style.backgroundColor = 'rgba(255, 255, 255, 0.2)';
         }
       });
     }
@@ -445,10 +457,11 @@ function setupButtonTouchHandlers() {
   // when the game over screen appears
   const gameOverObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
-      if (mutation.type === 'attributes' && 
-          mutation.attributeName === 'style' && 
-          mutation.target.id === 'gameOverOverlay' &&
-          mutation.target.style.display === 'flex') {
+      const target = /** @type {HTMLElement} */ (mutation.target);
+      if (mutation.type === 'attributes' &&
+          mutation.attributeName === 'style' &&
+          target.id === 'gameOverOverlay' &&
+          target.style.display === 'flex') {
         
         // Game over overlay is now visible, add touch handler to restart button
         const restartButton = document.querySelector('#gameOverOverlay button');

--- a/src/course.js
+++ b/src/course.js
@@ -1,3 +1,4 @@
+// @ts-check
 // course.js - Course structure, split timing, ghost racing and result screen for SnowGlider
 //
 // This module turns the open slope into a timed course:

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,3 +1,4 @@
+// @ts-check
 // effects.js - Drama and "juice" effects for SnowGlider
 //
 // Two responsibilities:

--- a/src/mountains.js
+++ b/src/mountains.js
@@ -1,3 +1,4 @@
+// @ts-check
 // mountains.js - Terrain and mountain features for snowglider
 
 // --- SimplexNoise implementation ---
@@ -169,8 +170,10 @@ function createTerrain(scene) {
   scene.userData = scene.userData || {}; 
   scene.userData.terrainGeometry = geometry;
   
-  const vertices = geometry.attributes.position.array;
-  
+  // BufferAttribute.array is typed ArrayLike<number> (read-only); the concrete
+  // buffer is a writable Float32Array, which we mutate in place below.
+  const vertices = /** @type {Float32Array} */ (geometry.attributes.position.array);
+
   // Create Perlin noise for natural terrain variation
   const perlin = new SimplexNoise();
   
@@ -373,7 +376,8 @@ function createRock(size) {
   const geometry = new THREE.DodecahedronGeometry(size, 1);
   
   // Deform vertices slightly for more natural rock shape
-  const positions = geometry.attributes.position.array;
+  // (writable Float32Array under the read-only ArrayLike<number> type)
+  const positions = /** @type {Float32Array} */ (geometry.attributes.position.array);
   for (let i = 0; i < positions.length; i += 3) {
     const noise = Math.random() * 0.2;
     positions[i] *= (1 + noise);

--- a/src/scores.js
+++ b/src/scores.js
@@ -1,6 +1,7 @@
+// @ts-check
 /**
  * scores.js - User scoring and leaderboard module for SnowGlider
- * 
+ *
  * This module handles player scoring, personal best tracking, and the global 
  * leaderboard functionality. It was split from auth.js to provide better
  * separation of concerns.

--- a/src/snow.js
+++ b/src/snow.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Snow.js - Utility functions for the snowman skiing game
 
 // Mountains features are now in mountains.js

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -1,3 +1,4 @@
+// @ts-check
 // --- Import utilities ---
 // Note: In a real application, you would use: import * as Snow from './snow.js';
 // But for demonstration we assume Snow and Snowman are globally available
@@ -71,7 +72,7 @@ restartButton.style.border = 'none';
 restartButton.style.borderRadius = '8px';
 restartButton.style.cursor = 'pointer';
 restartButton.style.minWidth = '200px';
-restartButton.style.webkitTapHighlightColor = 'rgba(255, 255, 255, 0.5)';
+restartButton.style.setProperty('-webkit-tap-highlight-color', 'rgba(255, 255, 255, 0.5)');
 restartButton.style.touchAction = 'manipulation'; // Removes delay on mobile devices
 restartButton.style.userSelect = 'none';
 restartButton.addEventListener('mouseenter', () => {
@@ -375,7 +376,7 @@ cameraToggleBtn.style.backgroundColor = '#4a69bd'; // Different color from reset
 cameraToggleBtn.style.color = 'white';
 cameraToggleBtn.style.cursor = 'pointer';
 cameraToggleBtn.style.fontSize = '16px';
-cameraToggleBtn.style.webkitTapHighlightColor = 'rgba(255, 255, 255, 0.5)';
+cameraToggleBtn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255, 255, 255, 0.5)');
 cameraToggleBtn.style.touchAction = 'manipulation'; // Removes delay on mobile devices
 cameraToggleBtn.style.userSelect = 'none';
 
@@ -496,7 +497,10 @@ function animate(time) {
     // Only set up test hooks if they're missing
     if (!window.testHooks) {
       console.log("Test hooks missing in animation loop, reinstalling");
-      Snowman.addTestHooks(pos, showGameOver, gameActive, Snow.getTerrainHeight);
+      // addTestHooks(pos, showGameOver, getTerrainHeight) — matches the two other
+      // call sites; the stray `gameActive` arg here was a latent bug (it landed in
+      // the getTerrainHeight slot), surfaced by the type-checker.
+      Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
     }
     
     updateSnowman(delta);
@@ -662,7 +666,7 @@ function showGameOver(reason) {
     if (canRecordScore) {
       window.AuthModule.recordScore(currentTime);
     } else if (isNewBestTime) {
-      localStorage.setItem('snowgliderBestTime', currentTime);
+      localStorage.setItem('snowgliderBestTime', String(currentTime));
     }
 
     // Show appropriate message based on time

--- a/src/snowman.js
+++ b/src/snowman.js
@@ -1,3 +1,4 @@
+// @ts-check
 // snowman.js - Snowman model and functions for SnowGlider game
 
 // Create Snowman (Three Spheres)

--- a/src/trees.js
+++ b/src/trees.js
@@ -1,3 +1,4 @@
+// @ts-check
 // trees.js - Tree creation and management for snowglider
 
 // Create a more realistic tree with visible branches and variability

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.js", "types/**/*.d.ts"],
-  // src/audio.js is a not-yet-converted classic script; excluding it keeps its
-  // stub method signatures from leaking into the `AudioModule` global (which
-  // globals.d.ts intentionally types as `any` until audio.js is @ts-checked).
-  "exclude": ["node_modules", "dist", "coverage", "tests", "src/audio.js"]
+  "exclude": ["node_modules", "dist", "coverage", "tests"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.js", "types/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "coverage", "tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,8 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.js", "types/**/*.d.ts"],
-  "exclude": ["node_modules", "dist", "coverage", "tests"]
+  // src/audio.js is a not-yet-converted classic script; excluding it keeps its
+  // stub method signatures from leaking into the `AudioModule` global (which
+  // globals.d.ts intentionally types as `any` until audio.js is @ts-checked).
+  "exclude": ["node_modules", "dist", "coverage", "tests", "src/audio.js"]
 }

--- a/types/firebase-cdn.d.ts
+++ b/types/firebase-cdn.d.ts
@@ -1,0 +1,19 @@
+// auth.js / scores.js import Firebase from the gstatic CDN by full URL
+// (the same module specifiers index.html loads at runtime). Map those URLs to the
+// installed `firebase` v11 package's types so `// @ts-check` can resolve them
+// (Firebase ships its own types — see TYPESCRIPT_MIGRATION.md).
+//
+// Keep the version (11.5.0) in lockstep with the URLs in src/auth.js + src/scores.js
+// and the `firebase` devDependency.
+declare module "https://www.gstatic.com/firebasejs/11.5.0/firebase-app.js" {
+  export * from "firebase/app";
+}
+declare module "https://www.gstatic.com/firebasejs/11.5.0/firebase-auth.js" {
+  export * from "firebase/auth";
+}
+declare module "https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore.js" {
+  export * from "firebase/firestore";
+}
+declare module "https://www.gstatic.com/firebasejs/11.5.0/firebase-analytics.js" {
+  export * from "firebase/analytics";
+}

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,90 @@
+// Type-level twin of the `globals` block in eslint.config.js.
+// Keep these two in lockstep: when a module gets typed, tighten the type here
+// (and eventually remove the entry once it becomes a real ES-module import).
+//
+// Phase 1 strategy: start loose (`any` for not-yet-typed module namespaces),
+// give the well-understood primitives real three.js types, and tighten per module.
+import type * as THREE_NS from 'three';
+
+declare global {
+  // three.js r134, loaded as a CDN global (not an ES-module import yet).
+  const THREE: typeof THREE_NS;
+
+  /** Terrain height sampler injected via setTerrainFunction (see ARCHITECTURE.md §4). */
+  type TerrainHeightFn = (x: number, z: number) => number;
+
+  // Game module namespaces — attached to the global scope by classic scripts.
+  // Loose for now; tighten as each module is converted.
+  //
+  // IMPORTANT: a namespace is declared here ONLY while its defining module is not
+  // yet `// @ts-check`ed. Once you @ts-check the file that defines it, its own
+  // top-level `const`/`class` becomes the shared-script global, and keeping the
+  // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
+  // from this block in the same change that adds `// @ts-check` to that module.
+  //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
+  const AudioModule: any;
+  const AuthModule: any;
+  const Camera: any;
+  const Controls: any;
+  const CourseModule: any;
+  const EffectsModule: any;
+  const Mountains: any;
+  const ScoresModule: any;
+  const Snow: any;
+  const Snowman: any;
+  const Trees: any;
+  const Utils: any;
+
+  // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
+  const Howl: any;
+  const Howler: any;
+
+  // Shared injected functions (see ARCHITECTURE.md §3 global namespace / §4 seams).
+  const getTerrainHeight: TerrainHeightFn;
+  const resetSnowman: (...args: any[]) => any;
+  const showGameOver: (...args: any[]) => any;
+  const updateCamera: (...args: any[]) => any;
+  const updateSnowman: (...args: any[]) => any;
+
+  // Shared mutable game state (writable globals in eslint.config.js).
+  // NOTE: these are top-level `const`/`let` in src/snowglider.js, so they become
+  // real script-globals once that file is @ts-checked (Phase 3, last) — at which
+  // point these entries must be removed to avoid TS2451 (same rule as namespaces).
+  // Types here mirror the ACTUAL shapes in snowglider.js, not the guide's example:
+  // `velocity`/`pos` are plain `{x,z(,y)}` objects, NOT THREE.Vector3.
+  let scene: THREE_NS.Scene;
+  let snowman: THREE_NS.Object3D;
+  let velocity: { x: number; z: number; y?: number };
+  let pos: { x: number; z: number; y: number };
+  let camera: THREE_NS.PerspectiveCamera;
+  let cameraManager: any;
+  let avalanche: any;
+  let avalancheTriggered: boolean;
+  let bestTime: number;
+  let gameActive: boolean;
+  let isInAir: boolean;
+  let lastAvalancheZ: number;
+  let startTime: number;
+  let verticalVelocity: number;
+
+  // Classic scripts publish their namespaces onto window; allow those writes.
+  // NOTE: per ARCHITECTURE.md §3, `Snow` and `Camera` are *bare globals* and are
+  // NOT window properties (only `window.Utils` aliases `Snow`), so they are
+  // intentionally absent here.
+  interface Window {
+    AudioModule: any;
+    AuthModule: any;
+    Avalanche: any;
+    Controls: any;
+    CourseModule: any;
+    EffectsModule: any;
+    Mountains: any;
+    ScoresModule: any;
+    Snowman: any;
+    Trees: any;
+    Utils: any;
+    FIREBASE_MANUAL_INIT?: boolean;
+  }
+}
+
+export {};

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,11 +22,11 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
+  //   - course.js:    @ts-checked -> `CourseModule` lives in src/course.js, not here.
   const AudioModule: any;
   const AuthModule: any;
   const Camera: any;
   const Controls: any;
-  const CourseModule: any;
   const EffectsModule: any;
   const Mountains: any;
   const ScoresModule: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -29,9 +29,9 @@ declare global {
   //   - effects.js:   @ts-checked -> `EffectsModule` lives in src/effects.js, not here.
   //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
   //   - controls.js:  @ts-checked -> `Controls` lives in src/controls.js, not here.
+  //   - mountains.js: @ts-checked -> `Mountains` lives in src/mountains.js, not here.
   const AudioModule: any;
   const AuthModule: any;
-  const Mountains: any;
   const ScoresModule: any;
   const Snowman: any;
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -67,6 +67,7 @@ declare global {
     Trees: any;
     Utils: any;
     FIREBASE_MANUAL_INIT?: boolean;
+    __FIREBASE_DEFAULTS__?: any; // set by auth.js to stop Firebase auto-init 404s
     // Cross-module/test handles published by snowglider.js (ARCHITECTURE.md §3).
     terrainMesh?: any;
     treePositions?: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -30,10 +30,11 @@ declare global {
   //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
   //   - controls.js:  @ts-checked -> `Controls` lives in src/controls.js, not here.
   //   - mountains.js: @ts-checked -> `Mountains` lives in src/mountains.js, not here.
+  //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
+  //                   (top-level fns) live in src/snowman.js, not here.
   const AudioModule: any;
   const AuthModule: any;
   const ScoresModule: any;
-  const Snowman: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;
@@ -41,13 +42,12 @@ declare global {
 
   // Shared injected functions (see ARCHITECTURE.md §3 global namespace / §4 seams).
   // NOTE: the bare `getTerrainHeight` global is a top-level `function` in
-  // src/trees.js, so it's provided by that (now @ts-checked) file — declaring it
+  // src/trees.js, and `resetSnowman`/`updateSnowman` are top-level functions in
+  // src/snowman.js, so those (now @ts-checked) files provide them — declaring them
   // here too would be a TS2451 redeclare. `TerrainHeightFn` (above) is retained as
   // a domain type for Phase 3 strictNullChecks annotations.
-  const resetSnowman: (...args: any[]) => any;
   const showGameOver: (...args: any[]) => any;
   const updateCamera: (...args: any[]) => any;
-  const updateSnowman: (...args: any[]) => any;
 
   // Shared mutable game state (writable globals in eslint.config.js).
   // NOTE: these are top-level `const`/`let` in src/snowglider.js, so they become
@@ -97,6 +97,12 @@ declare global {
     restartGame?: () => unknown;
     showGameOver?: (...args: any[]) => unknown;
     initializeGameWithAudio?: (...args: any[]) => unknown;
+    // Test-only handles read/written by snowman.js test hooks + browser suites.
+    testHooks?: any;
+    treeCollisionRadius?: number;
+    testTreeJumpingCheck?: boolean;
+    testCollisionDetected?: boolean;
+    _treeCheckLogged?: boolean;
   }
 }
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -28,9 +28,9 @@ declare global {
   //                   (top-level fns) live in src/trees.js, not here.
   //   - effects.js:   @ts-checked -> `EffectsModule` lives in src/effects.js, not here.
   //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
+  //   - controls.js:  @ts-checked -> `Controls` lives in src/controls.js, not here.
   const AudioModule: any;
   const AuthModule: any;
-  const Controls: any;
   const Mountains: any;
   const ScoresModule: any;
   const Snowman: any;
@@ -91,6 +91,12 @@ declare global {
     terrainMesh?: any;
     treePositions?: any;
     isTestMode?: boolean;
+    // Lifecycle/input callbacks snowglider.js publishes for controls.js + buttons.
+    toggleCameraView?: () => unknown;
+    resetSnowman?: (...args: any[]) => unknown;
+    restartGame?: () => unknown;
+    showGameOver?: (...args: any[]) => unknown;
+    initializeGameWithAudio?: (...args: any[]) => unknown;
   }
 }
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -26,15 +26,14 @@ declare global {
   //   - camera.js:    @ts-checked -> `Camera` (class) lives in src/camera.js, not here.
   //   - trees.js:     @ts-checked -> `Trees` + `getTerrainHeight`/`getTerrainGradient`
   //                   (top-level fns) live in src/trees.js, not here.
+  //   - effects.js:   @ts-checked -> `EffectsModule` lives in src/effects.js, not here.
+  //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
   const AudioModule: any;
   const AuthModule: any;
   const Controls: any;
-  const EffectsModule: any;
   const Mountains: any;
   const ScoresModule: any;
-  const Snow: any;
   const Snowman: any;
-  const Utils: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -40,35 +40,15 @@ declare global {
   const Howl: any;
   const Howler: any;
 
-  // Shared injected functions (see ARCHITECTURE.md §3 global namespace / §4 seams).
-  // NOTE: the bare `getTerrainHeight` global is a top-level `function` in
-  // src/trees.js, and `resetSnowman`/`updateSnowman` are top-level functions in
-  // src/snowman.js, so those (now @ts-checked) files provide them — declaring them
-  // here too would be a TS2451 redeclare. `TerrainHeightFn` (above) is retained as
-  // a domain type for Phase 3 strictNullChecks annotations.
-  const showGameOver: (...args: any[]) => any;
-  const updateCamera: (...args: any[]) => any;
-
-  // Shared mutable game state (writable globals in eslint.config.js).
-  // NOTE: these are top-level `const`/`let` in src/snowglider.js, so they become
-  // real script-globals once that file is @ts-checked (Phase 3, last) — at which
-  // point these entries must be removed to avoid TS2451 (same rule as namespaces).
-  // Types here mirror the ACTUAL shapes in snowglider.js, not the guide's example:
-  // `velocity`/`pos` are plain `{x,z(,y)}` objects, NOT THREE.Vector3.
-  let scene: THREE_NS.Scene;
-  let snowman: THREE_NS.Object3D;
-  let velocity: { x: number; z: number; y?: number };
-  let pos: { x: number; z: number; y: number };
-  let camera: THREE_NS.PerspectiveCamera;
-  let cameraManager: any;
-  let avalanche: any;
-  let avalancheTriggered: boolean;
-  let bestTime: number;
-  let gameActive: boolean;
-  let isInAir: boolean;
-  let lastAvalancheZ: number;
-  let startTime: number;
-  let verticalVelocity: number;
+  // NOTE: snowglider.js (the orchestrator) is now @ts-checked too, so the shared
+  // injected functions (`showGameOver`, `updateCamera`) and ALL the shared mutable
+  // game state (`scene`, `snowman`, `velocity`, `pos`, `camera`, `cameraManager`,
+  // `avalanche`, `gameActive`, `isInAir`, `startTime`, `bestTime`, …) are real
+  // top-level `const`/`let` script-globals in src/snowglider.js — declaring any of
+  // them here would be a TS2451 redeclare, so they are intentionally absent.
+  // `getTerrainHeight`/`resetSnowman`/`updateSnowman` likewise live in trees.js /
+  // snowman.js. The Phase 3 step is to replace these ad-hoc globals with a typed
+  // GameState object; `TerrainHeightFn` (above) is kept for that work.
 
   // Classic scripts publish their namespaces onto window; allow those writes.
   // NOTE: per ARCHITECTURE.md §3, `Snow` and `Camera` are *bare globals* and are
@@ -103,6 +83,9 @@ declare global {
     testTreeJumpingCheck?: boolean;
     testCollisionDetected?: boolean;
     _treeCheckLogged?: boolean;
+    _testShowGameOverOverride?: (...args: any[]) => unknown;
+    // Firebase modular SDK handle wired up in index.html (analytics, etc.).
+    firebaseModules?: any;
   }
 }
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -32,7 +32,10 @@ declare global {
   //   - mountains.js: @ts-checked -> `Mountains` lives in src/mountains.js, not here.
   //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
   //                   (top-level fns) live in src/snowman.js, not here.
-  const AudioModule: any;
+  //   - audio.js:     @ts-checked -> `AudioModule` lives in src/audio.js, not here.
+  // AuthModule/ScoresModule stay: auth.js/scores.js are ES modules (not script
+  // globals), so they don't define these as bare globals — kept loose for any
+  // consumer that reads them by bare name.
   const AuthModule: any;
   const ScoresModule: any;
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -23,9 +23,9 @@ declare global {
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
   //   - course.js:    @ts-checked -> `CourseModule` lives in src/course.js, not here.
+  //   - camera.js:    @ts-checked -> `Camera` (class) lives in src/camera.js, not here.
   const AudioModule: any;
   const AuthModule: any;
-  const Camera: any;
   const Controls: any;
   const EffectsModule: any;
   const Mountains: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -24,6 +24,8 @@ declare global {
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
   //   - course.js:    @ts-checked -> `CourseModule` lives in src/course.js, not here.
   //   - camera.js:    @ts-checked -> `Camera` (class) lives in src/camera.js, not here.
+  //   - trees.js:     @ts-checked -> `Trees` + `getTerrainHeight`/`getTerrainGradient`
+  //                   (top-level fns) live in src/trees.js, not here.
   const AudioModule: any;
   const AuthModule: any;
   const Controls: any;
@@ -32,7 +34,6 @@ declare global {
   const ScoresModule: any;
   const Snow: any;
   const Snowman: any;
-  const Trees: any;
   const Utils: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
@@ -40,7 +41,10 @@ declare global {
   const Howler: any;
 
   // Shared injected functions (see ARCHITECTURE.md §3 global namespace / §4 seams).
-  const getTerrainHeight: TerrainHeightFn;
+  // NOTE: the bare `getTerrainHeight` global is a top-level `function` in
+  // src/trees.js, so it's provided by that (now @ts-checked) file — declaring it
+  // here too would be a TS2451 redeclare. `TerrainHeightFn` (above) is retained as
+  // a domain type for Phase 3 strictNullChecks annotations.
   const resetSnowman: (...args: any[]) => any;
   const showGameOver: (...args: any[]) => any;
   const updateCamera: (...args: any[]) => any;
@@ -84,6 +88,10 @@ declare global {
     Trees: any;
     Utils: any;
     FIREBASE_MANUAL_INIT?: boolean;
+    // Cross-module/test handles published by snowglider.js (ARCHITECTURE.md §3).
+    terrainMesh?: any;
+    treePositions?: any;
+    isTestMode?: boolean;
   }
 }
 


### PR DESCRIPTION
## TypeScript migration — Phase 1 (complete)

Gradual, test-gated migration toward type-checked source, per `TYPESCRIPT_MIGRATION.md`. **Zero change to how the game loads or deploys** — `tsconfig` emits nothing; the CDN `THREE` global and `<script>` load order are untouched. Phase 1 turns on static type-checking across the existing JS; Phases 2–3 (bundler/ESM, then `.ts` + strict) are future work.

### Scope — every `src/*.js` is now `// @ts-check`ed
- **Toolchain:** `typescript@6` + `@types/three@0.134` (matches the r134 CDN build); `tsconfig.json` (`allowJs` + `checkJs:false` + `noEmit`, per-file opt-in); `types/globals.d.ts` (type-twin of the eslint globals) + `types/firebase-cdn.d.ts`; `typecheck` npm script.
- **CI gate:** `ci.yml` runs `tsc --noEmit` as a blocking step after lint.
- **10 game modules:** avalanche, course, camera, trees, controls, effects, snow, mountains, snowman, snowglider.
- **2 Firebase ES modules:** auth, scores (CDN URL imports mapped to the installed `firebase` v11 types).
- **audio** (native HTML5; high-risk per CLAUDE.md) — converted last; back-compat stubs typed honestly.

### Real bugs the type-checker caught (fixed, behavior-preserving)
- `snowglider.js animate()` called `Snowman.addTestHooks(pos, showGameOver, gameActive, getTerrainHeight)` — 4 args to a 3-param fn, so `gameActive` landed in the `getTerrainHeight` slot. Now matches the other two call sites.
- `localStorage.setItem('snowgliderBestTime', currentTime)` passed a `number` where a `string` is required → wrapped in `String(...)` (runtime already coerced; reader uses `parseFloat`).

### Notable corrections to the (unverified) proposed guide
- `checkJs:false` + per-file `// @ts-check` (guide said `checkJs:true`, which doesn't compose with per-file opt-in).
- `globals.d.ts` mirrors the **full** eslint globals; `Snow`/`Camera` are bare globals, not `window` props (ARCHITECTURE.md §3).
- Core mechanic the guide omits: `@ts-check`ing a file that *defines* a global (namespace const / top-level fn / shared `let`) requires removing that symbol from `globals.d.ts`, or tsc raises TS2451.
- Other concrete fixes: `geometry.attributes.position.array` is read-only `ArrayLike<number>` → `Float32Array` cast; `webkitTapHighlightColor` → `style.setProperty(...)`; DOM `.src`/`.disabled` casts; `firebase.User` JSDoc → `import('firebase/auth').User`.

### Verification
`npm run lint`, `npm run typecheck`, `npm test`, and the puppeteer browser suite (79/0) all green on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)