### PR TITLE
[codex] fix: reject impossible score times

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,10 +904,20 @@
           console.log("ScoresModule: setCurrentUser called in local mode"); 
         },
         recordScore: function(time) {
+          if (typeof time !== 'number' || !Number.isFinite(time) || time < 4) {
+            console.warn("Skipping local score record (Invalid time value):", time);
+            return;
+          }
           // Store in localStorage
           const localBestTimeStr = localStorage.getItem('snowgliderBestTime');
           const localBestTime = localBestTimeStr ? parseFloat(localBestTimeStr) : null;
-          const isNewPersonalBest = localBestTime === null || time < localBestTime;
+          const hasValidLocalBest = typeof localBestTime === 'number' &&
+            Number.isFinite(localBestTime) && localBestTime >= 4;
+          if (localBestTimeStr && !hasValidLocalBest) {
+            console.warn("Ignoring invalid local best time:", localBestTimeStr);
+            localStorage.removeItem('snowgliderBestTime');
+          }
+          const isNewPersonalBest = !hasValidLocalBest || time < localBestTime;
 
           if (isNewPersonalBest) {
             localStorage.setItem('snowgliderBestTime', time.toString());
@@ -930,7 +940,10 @@
         updateLeaderboard: function(userId, time) { 
           console.log("updateLeaderboard not available in local file mode"); 
         },
-        isFirestoreAvailable: function() { return false; }
+        isFirestoreAvailable: function() { return false; },
+        isValidScoreTime: function(time) {
+          return typeof time === 'number' && Number.isFinite(time) && time >= 4;
+        }
       };
 
       // Do not include the module scripts at all in file:// mode
@@ -1162,6 +1175,10 @@
                     }
                 },
                 recordScore: function(time) {
+                    if (typeof time !== 'number' || !Number.isFinite(time) || time < 4) {
+                        console.warn("Skipping local score record (Invalid time value):", time);
+                        return;
+                    }
                     // Forward to ScoresModule which we've already defined above
                     if (window.ScoresModule && typeof window.ScoresModule.recordScore === 'function') {
                         window.ScoresModule.recordScore(time);

--- a/src/auth.js
+++ b/src/auth.js
@@ -383,6 +383,11 @@ function syncUserData(user) {
       const localBestTime = localStorage.getItem('snowgliderBestTime');
       if (localBestTime) {
         const bestTime = parseFloat(localBestTime);
+        if (!ScoresModule.isValidScoreTime(bestTime)) {
+          console.warn("Ignoring invalid local best time during sign-in sync:", localBestTime);
+          localStorage.removeItem('snowgliderBestTime');
+          return;
+        }
         console.log("Found local best time, attempting to sync:", bestTime);
         // Use ScoresModule to update best time
         ScoresModule.updateUserBestTime(user.uid, bestTime);

--- a/src/scores.js
+++ b/src/scores.js
@@ -37,6 +37,31 @@ let firestore = null; // Local cache of firestore instance, updated by initializ
 let analytics = null;
 let currentUser = null;
 
+// The timed course runs from z=-15 to z=-195 (180 world metres). Four seconds is
+// deliberately loose: it rejects timer/startup artifacts like 0.01s while allowing
+// any physically plausible descent the current game can produce.
+const MIN_VALID_SCORE_TIME = 4;
+
+function isValidScoreTime(time) {
+  return typeof time === 'number' && Number.isFinite(time) && time >= MIN_VALID_SCORE_TIME;
+}
+
+function readLocalBestTime() {
+  const localBestTimeStr = localStorage.getItem('snowgliderBestTime');
+  if (!localBestTimeStr) {
+    return null;
+  }
+
+  const localBestTime = parseFloat(localBestTimeStr);
+  if (isValidScoreTime(localBestTime)) {
+    return localBestTime;
+  }
+
+  console.warn("Ignoring invalid local best time:", localBestTimeStr);
+  localStorage.removeItem('snowgliderBestTime');
+  return null;
+}
+
 /**
  * Initialize the scores module with Firebase services
  * @param {Object|null} firestoreInstance - Initialized Firestore instance (or null)
@@ -101,7 +126,7 @@ function updateUserBestTime(userId, time) {
     console.warn("Skipping best time update (User ID missing).");
     return;
   }
-  if (typeof time !== 'number' || isNaN(time)) {
+  if (!isValidScoreTime(time)) {
     console.warn("Skipping best time update (Invalid time value):", time);
     return;
   }
@@ -118,7 +143,10 @@ function updateUserBestTime(userId, time) {
     getDoc(userDocRef)
       .then(docSnap => {
         const storedBest = docSnap.exists() ? docSnap.data().bestTime : null;
-        const hasStoredBest = typeof storedBest === 'number';
+        const hasStoredBest = isValidScoreTime(storedBest);
+        if (storedBest !== null && !hasStoredBest) {
+          console.warn(`Ignoring invalid stored best for user ${userId}:`, storedBest);
+        }
         // The authoritative best is the better of the stored value and this run. This is
         // the value the leaderboard must reflect — never the raw run time, which may be
         // slower than a best already stored from another device/tab.
@@ -172,6 +200,11 @@ function updateUserBestTime(userId, time) {
  * @param {number} time - Run completion time in seconds
  */
 function updateLeaderboard(userId, time) {
+  if (!isValidScoreTime(time)) {
+    console.warn("Skipping leaderboard update (Invalid time value):", time);
+    return;
+  }
+
   // Check AuthModule first for availability
   if (!window.AuthModule?.isFirebaseAvailable?.().firestore) {
     console.log("Skipping leaderboard update (Firestore unavailable according to AuthModule).");
@@ -199,7 +232,10 @@ function updateLeaderboard(userId, time) {
     getDoc(leaderboardDocRef)
       .then(leaderboardSnap => {
         const leaderboardBest = leaderboardSnap.exists() ? leaderboardSnap.data().time : null;
-        if (typeof leaderboardBest === 'number' && time > leaderboardBest) {
+        if (leaderboardBest !== null && !isValidScoreTime(leaderboardBest)) {
+          console.warn(`Replacing invalid leaderboard entry for user ${userId}:`, leaderboardBest);
+        }
+        if (isValidScoreTime(leaderboardBest) && time > leaderboardBest) {
           console.log(`Leaderboard already has a faster entry for user ${userId}. No update needed.`);
           return;
         }
@@ -254,7 +290,7 @@ function getLeaderboard() {
         snapshot.forEach(docSnap => {
           const data = docSnap.data();
           // Ensure data has expected fields before pushing
-          if (data && typeof data.time === 'number' && data.user) {
+          if (data && isValidScoreTime(data.time) && data.user) {
             scores.push({
               userId: docSnap.id, // The user ID is the document ID
               time: data.time,
@@ -473,12 +509,15 @@ function displayLeaderboard() {
  * @param {number} time - Run completion time in seconds
  */
 function recordScore(time) {
+  if (!isValidScoreTime(time)) {
+    console.warn("Skipping score record (Invalid time value):", time);
+    return;
+  }
+
   // Always store locally first as a fallback and for immediate personal best tracking
   try {
-    const localBestTimeStr = localStorage.getItem('snowgliderBestTime');
-    const localBestTime = localBestTimeStr ? parseFloat(localBestTimeStr) : null;
-    const hasValidLocalBest = typeof localBestTime === 'number' && !isNaN(localBestTime);
-    const isNewLocalBest = !hasValidLocalBest || time < localBestTime;
+    const localBestTime = readLocalBestTime();
+    const isNewLocalBest = localBestTime === null || time < localBestTime;
 
     if (isNewLocalBest) {
       localStorage.setItem('snowgliderBestTime', time.toString());
@@ -540,7 +579,9 @@ function recordScore(time) {
     console.error("Error in recordScore:", error);
     // Attempt to save locally even if other parts fail
     try {
-      localStorage.setItem('snowgliderBestTime', time.toString());
+      if (isValidScoreTime(time)) {
+        localStorage.setItem('snowgliderBestTime', time.toString());
+      }
     } catch (e) {
       console.error("LocalStorage error during fallback save:", e);
     }
@@ -568,7 +609,8 @@ const ScoresModule = {
   getLeaderboard,
   updateUserBestTime,
   updateLeaderboard,
-  isFirestoreAvailable
+  isFirestoreAvailable,
+  isValidScoreTime
 };
 
 // Export as both a module and a global for flexibility

--- a/src/scores.js
+++ b/src/scores.js
@@ -24,6 +24,7 @@ import {
   setDoc,
   getDoc,
   collection,
+  where,
   orderBy,
   query,
   limit,
@@ -281,7 +282,12 @@ function getLeaderboard() {
   try {
     const leaderboardRef = collection(firestore, 'leaderboard');
     // Query for top 10 scores, ordered by time ascending
-    const q = query(leaderboardRef, orderBy('time', 'asc'), limit(10));
+    const q = query(
+      leaderboardRef,
+      where('time', '>=', MIN_VALID_SCORE_TIME),
+      orderBy('time', 'asc'),
+      limit(10)
+    );
 
     console.log("Fetching leaderboard data...");
     return getDocs(q)

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -218,7 +218,32 @@ let turnAmplitude = 3.0;
 
 // Add timer and best time tracking
 let startTime = 0;
-let bestTime = localStorage.getItem('snowgliderBestTime') ? parseFloat(localStorage.getItem('snowgliderBestTime')) : Infinity;
+const MIN_VALID_SCORE_TIME = 4;
+
+function isValidScoreTime(time) {
+  if (window.ScoresModule && typeof window.ScoresModule.isValidScoreTime === 'function') {
+    return window.ScoresModule.isValidScoreTime(time);
+  }
+  return typeof time === 'number' && Number.isFinite(time) && time >= MIN_VALID_SCORE_TIME;
+}
+
+function readStoredBestTime() {
+  const storedBestTime = localStorage.getItem('snowgliderBestTime');
+  if (!storedBestTime) {
+    return Infinity;
+  }
+
+  const parsedBestTime = parseFloat(storedBestTime);
+  if (isValidScoreTime(parsedBestTime)) {
+    return parsedBestTime;
+  }
+
+  console.warn("Ignoring invalid stored best time:", storedBestTime);
+  localStorage.removeItem('snowgliderBestTime');
+  return Infinity;
+}
+
+let bestTime = readStoredBestTime();
 
 // Initialize game stats functionality
 function initializeGameStats() {
@@ -629,6 +654,7 @@ function showGameOver(reason) {
   // would be saved as a new record while the course screen sees elapsed >= previousBest,
   // skips persisting the new ghost/splits, and shows a time that disagrees with the score.
   const finishTime = (performance.now() - startTime) / 1000;
+  const hasValidFinishTime = isValidScoreTime(finishTime);
 
   // Remove game-active class from body for styling
   document.body.classList.remove('game-active');
@@ -656,7 +682,7 @@ function showGameOver(reason) {
   }
   
   // Only update times if player reached the end successfully
-  if (reason === "You reached the end of the slope!") {
+  if (reason === "You reached the end of the slope!" && hasValidFinishTime) {
     const currentTime = finishTime;
     const isNewBestTime = currentTime < bestTime;
     const canRecordScore = window.AuthModule && typeof window.AuthModule.recordScore === 'function';
@@ -713,6 +739,12 @@ function showGameOver(reason) {
     } catch (e) {
       console.log("Analytics tracking skipped:", e.message);
     }
+  } else if (reason === "You reached the end of the slope!") {
+    console.warn("Finish reached with invalid elapsed time; score not recorded:", finishTime);
+    bestTimeDisplay.textContent = bestTime !== Infinity ?
+      `Best Time: ${bestTime.toFixed(2)}s` :
+      'No best time yet';
+    bestTimeDisplay.style.color = 'white';
   } else {
     // For failures (tree collision, falling, etc.), don't record or update best time
     bestTimeDisplay.textContent = bestTime !== Infinity ? `Best Time: ${bestTime.toFixed(2)}s` : 'No best time yet';
@@ -753,7 +785,7 @@ function showGameOver(reason) {
     const staleResult = document.getElementById('courseResult');
     if (staleResult && staleResult.parentNode) staleResult.parentNode.removeChild(staleResult);
     
-    if (reason === "You reached the end of the slope!") {
+    if (reason === "You reached the end of the slope!" && hasValidFinishTime) {
       try {
         const panel = CourseModule.onFinish(finishTime, previousBest);
         if (panel) gameOverOverlay.insertBefore(panel, restartButton);

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -76,7 +76,8 @@ const mocks = {
     setCurrentUser: () => {},
     updateUserBestTime: () => {},
     displayLeaderboard: () => {},
-    recordScore: () => {}
+    recordScore: () => {},
+    isValidScoreTime: time => typeof time === 'number' && Number.isFinite(time) && time >= 4
   }
 };
 

--- a/tests/regression-tests.js
+++ b/tests/regression-tests.js
@@ -456,6 +456,15 @@ runTest('Impossible Score Times Are Rejected And Repairable', () => {
     "Invalid leaderboard entries should be filtered out of displayed results");
   assertEquals(fetchedLeaderboardTimes[0], 14.67,
     "The first displayed leaderboard time should be the first valid score");
+
+  const rawOrderedTimes = Array(10).fill(0.01).concat([14.67, 58.64]);
+  const validAfterQueryFilter = rawOrderedTimes
+    .filter(isValidScoreTime)
+    .slice(0, 10);
+  assertEquals(validAfterQueryFilter.length, 2,
+    "Leaderboard query should fetch past leading invalid scores before applying the limit");
+  assertEquals(validAfterQueryFilter[0], 14.67,
+    "The top valid score should remain visible even when corrupt scores sort before it");
 });
 
 runTest('Personal Best Sync Survives A Leaderboard Write Failure', () => {

--- a/tests/regression-tests.js
+++ b/tests/regression-tests.js
@@ -411,6 +411,53 @@ runTest('Leaderboard Always Reflects The Authoritative Best, Never A Slower Loca
   assertEquals(r.leaderboardValue, 17.0, "Leaderboard keeps the faster existing entry");
 });
 
+runTest('Impossible Score Times Are Rejected And Repairable', () => {
+  const minValidScoreTime = 4;
+  function isValidScoreTime(time) {
+    return typeof time === 'number' && Number.isFinite(time) && time >= minValidScoreTime;
+  }
+
+  function resolve(time, storedBest, leaderboardBest) {
+    if (!isValidScoreTime(time)) {
+      return {
+        accepted: false,
+        writeUser: false,
+        writeLeaderboard: false,
+        userValue: storedBest,
+        leaderboardValue: leaderboardBest
+      };
+    }
+
+    const hasStored = isValidScoreTime(storedBest);
+    const writeUser = !hasStored || time <= storedBest;
+    const authoritativeBest = hasStored ? Math.min(storedBest, time) : time;
+    const writeLeaderboard = !isValidScoreTime(leaderboardBest) || authoritativeBest <= leaderboardBest;
+    return {
+      accepted: true,
+      writeUser,
+      writeLeaderboard,
+      userValue: writeUser ? authoritativeBest : storedBest,
+      leaderboardValue: writeLeaderboard ? authoritativeBest : leaderboardBest
+    };
+  }
+
+  let r = resolve(0.01, null, null);
+  assertEquals(r.accepted, false, "A 0.01s run should never be accepted as a score");
+  assertEquals(r.writeUser, false, "Invalid runs must not write the user best");
+  assertEquals(r.writeLeaderboard, false, "Invalid runs must not write the leaderboard");
+
+  r = resolve(19.43, 0.01, 0.01);
+  assertEquals(r.accepted, true, "A realistic run should still be accepted");
+  assertEquals(r.userValue, 19.43, "Invalid stored user best should be replaced by a valid time");
+  assertEquals(r.leaderboardValue, 19.43, "Invalid leaderboard best should be repairable by a valid time");
+
+  const fetchedLeaderboardTimes = [0.01, 14.67, 58.64].filter(isValidScoreTime);
+  assertEquals(fetchedLeaderboardTimes.length, 2,
+    "Invalid leaderboard entries should be filtered out of displayed results");
+  assertEquals(fetchedLeaderboardTimes[0], 14.67,
+    "The first displayed leaderboard time should be the first valid score");
+});
+
 runTest('Personal Best Sync Survives A Leaderboard Write Failure', () => {
   // Models scores.js: updateUserBestTime writes the user best (setDoc) and calls
   // updateLeaderboard as a SEPARATE write. If Firestore rules allow users/{uid} but


### PR DESCRIPTION
## What

Reject impossible score times before they can be stored, synced, or displayed as valid leaderboard entries.

- Add a shared minimum valid score threshold (`4s`) for the 180m timed course.
- Ignore and clear invalid local best times during game startup and sign-in sync.
- Prevent invalid run times from updating localStorage, user best docs, or leaderboard docs.
- Treat existing invalid Firestore best/leaderboard values as repairable instead of preserving them as "faster" scores.
- Filter invalid leaderboard entries from display.
- Keep the local `file://` fallback aligned with the production score guard.

## Why

A `0.01s` leaderboard entry can become sticky because lower times are treated as better. Once an impossible time reaches localStorage or Firestore, the existing compare-and-write logic preserves it and blocks realistic times like `19.43s` from repairing the entry.

## Impact

Future accidental or corrupt sub-4s score writes are rejected. Existing corrupt `0.01s` entries are hidden from leaderboard display and can be replaced the next time the user syncs a valid best.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
