### PR TITLE
[codex] Fix deferred start before game scripts load

### DIFF
--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -94,6 +94,11 @@
     }, 500);
   }
 
+  function announceGameScriptsReady() {
+    /** @type {any} */ (window).SnowGliderGameScriptsReady = true;
+    window.dispatchEvent(new CustomEvent('snowglider:game-scripts-ready'));
+  }
+
   function initializeGameScripts() {
     const firebaseBoot = window.SnowGliderFirebase;
     const authReady = firebaseBoot && typeof firebaseBoot.waitForAuthModule === 'function'
@@ -111,6 +116,7 @@
       .then(() => {
         loadTests();
         console.log("Main game script loaded.");
+        announceGameScriptsReady();
         preloadAudio();
       })
       .catch((error) => {
@@ -124,6 +130,7 @@
     loadScript,
     loadScriptsInOrder,
     loadTests,
-    initializeGameScripts
+    initializeGameScripts,
+    announceGameScriptsReady
   };
 })();

--- a/src/ui/start-menu.js
+++ b/src/ui/start-menu.js
@@ -1,5 +1,7 @@
 // @ts-check
 (function () {
+  let startGamePending = false;
+
   function addBuildBadge() {
     const buildMeta = document.querySelector('meta[name="build-id"]');
     const build = buildMeta instanceof HTMLMetaElement
@@ -26,18 +28,57 @@
   }
 
   function startGame() {
+    const gameCanvas = document.getElementById('gameCanvas');
+    const canInitializeGame = typeof window.initializeGameWithAudio === 'function';
+
+    if (!gameCanvas || !canInitializeGame) {
+      startGamePending = true;
+      setStartButtonWaiting(true);
+      console.log("Start requested before game scripts finished loading; deferring until ready.");
+      return false;
+    }
+
+    startGamePending = false;
+    setStartButtonWaiting(false);
+
     const startContainer = document.getElementById('startGameContainer');
     if (startContainer) {
       startContainer.style.display = 'none';
     }
 
+    gameCanvas.style.display = 'block';
+
+    window.initializeGameWithAudio();
+    return true;
+  }
+
+  function startPendingGameIfReady() {
     const gameCanvas = document.getElementById('gameCanvas');
-    if (gameCanvas) {
-      gameCanvas.style.display = 'block';
+    if (!gameCanvas || typeof window.initializeGameWithAudio !== 'function') {
+      return false;
     }
 
-    if (typeof window.initializeGameWithAudio === 'function') {
-      window.initializeGameWithAudio();
+    setStartButtonWaiting(false);
+
+    if (startGamePending) {
+      console.log("Starting game from deferred start request.");
+      return startGame();
+    }
+
+    return true;
+  }
+
+  function setStartButtonWaiting(waiting) {
+    const startButton = document.getElementById('startGameButton');
+    if (!(startButton instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    startButton.disabled = waiting;
+    if (waiting) {
+      startButton.setAttribute('aria-busy', 'true');
+    } else {
+      startButton.removeAttribute('aria-busy');
     }
   }
 
@@ -67,6 +108,9 @@
 
   function initializeStartMenu() {
     addBuildBadge();
+    if (/** @type {any} */ (window).SnowGliderGameScriptsReady) {
+      startPendingGameIfReady();
+    }
 
     const startGameButton = document.getElementById('startGameButton');
     if (startGameButton) {
@@ -125,11 +169,13 @@
   }
 
   document.addEventListener('DOMContentLoaded', initializeStartMenu);
+  window.addEventListener('snowglider:game-scripts-ready', startPendingGameIfReady);
 
   window.SnowGliderStartMenu = {
     startGame,
     showAbout,
     hideAbout,
-    initializeStartMenu
+    initializeStartMenu,
+    startPendingGameIfReady
   };
 })();

--- a/src/ui/start-menu.js
+++ b/src/ui/start-menu.js
@@ -58,13 +58,14 @@
       return false;
     }
 
-    setStartButtonWaiting(false);
-
     if (startGamePending) {
-      console.log("Starting game from deferred start request.");
-      return startGame();
+      startGamePending = false;
+      setStartButtonWaiting(false);
+      console.log("Game scripts ready after deferred start request; waiting for a fresh start gesture.");
+      return true;
     }
 
+    setStartButtonWaiting(false);
     return true;
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -758,6 +758,12 @@ canvas { display: block; }
   transform: scale(0.98);
 }
 
+.menu-button:disabled {
+  cursor: wait;
+  opacity: 0.85;
+  transform: none;
+}
+
 .build-badge {
   margin-left: .5rem;
   padding: .15rem .4rem;

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -129,6 +129,21 @@ async function runStartMenuRaceRegression(browser) {
     releaseSnowgliderScript();
 
     await page.waitForFunction(() => {
+      const button = document.getElementById('startGameButton');
+      const startContainer = document.getElementById('startGameContainer');
+      const gameCanvas = document.getElementById('gameCanvas');
+      return button &&
+        startContainer &&
+        gameCanvas &&
+        !button.disabled &&
+        button.getAttribute('aria-busy') !== 'true' &&
+        startContainer.style.display !== 'none' &&
+        typeof window.initializeGameWithAudio === 'function';
+    }, { timeout: 30000 });
+
+    await page.click('#startGameButton');
+
+    await page.waitForFunction(() => {
       const startContainer = document.getElementById('startGameContainer');
       const gameCanvas = document.getElementById('gameCanvas');
       return startContainer &&
@@ -141,7 +156,7 @@ async function runStartMenuRaceRegression(browser) {
       throw new Error(`Unexpected null DOM access error: ${errors.join('; ')}`);
     }
 
-    console.log('PASS: start menu defers first click until game scripts are ready');
+    console.log('PASS: start menu re-enables Start for a gesture-backed deferred start');
   } finally {
     releaseSnowgliderScript();
     await page.close();

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -58,6 +58,96 @@ async function startServer() {
   });
 }
 
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function runStartMenuRaceRegression(browser) {
+  console.log('Running start menu race regression...');
+
+  const page = await browser.newPage();
+  const errors = [];
+  let releaseSnowgliderScript;
+  let snowgliderRequestSeen;
+
+  const releaseSnowgliderScriptPromise = new Promise(resolve => {
+    releaseSnowgliderScript = resolve;
+  });
+  const snowgliderRequestSeenPromise = new Promise(resolve => {
+    snowgliderRequestSeen = resolve;
+  });
+
+  page.on('pageerror', (err) => {
+    errors.push(err.message);
+  });
+
+  await page.setRequestInterception(true);
+  page.on('request', async (request) => {
+    if (request.url().endsWith('/src/snowglider.js')) {
+      snowgliderRequestSeen();
+      await releaseSnowgliderScriptPromise;
+    }
+    request.continue();
+  });
+
+  try {
+    await page.goto(`http://localhost:${PORT}/index.html`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000
+    });
+
+    await page.waitForSelector('#startGameButton', { timeout: 10000 });
+    await page.click('#startGameButton');
+
+    await page.waitForFunction(() => {
+      const button = document.getElementById('startGameButton');
+      return button && button.disabled && button.getAttribute('aria-busy') === 'true';
+    }, { timeout: 5000 });
+
+    const pendingState = await page.evaluate(() => {
+      const startContainer = document.getElementById('startGameContainer');
+      const gameCanvas = document.getElementById('gameCanvas');
+
+      return {
+        startContainerDisplay: startContainer ? startContainer.style.display : null,
+        gameCanvasExists: !!gameCanvas,
+        canInitializeGame: typeof window.initializeGameWithAudio === 'function'
+      };
+    });
+
+    if (pendingState.startContainerDisplay === 'none') {
+      throw new Error('Start screen hid before the game canvas was ready');
+    }
+
+    await Promise.race([
+      snowgliderRequestSeenPromise,
+      wait(30000).then(() => {
+        throw new Error('Timed out waiting for delayed snowglider.js request');
+      })
+    ]);
+
+    releaseSnowgliderScript();
+
+    await page.waitForFunction(() => {
+      const startContainer = document.getElementById('startGameContainer');
+      const gameCanvas = document.getElementById('gameCanvas');
+      return startContainer &&
+        gameCanvas &&
+        startContainer.style.display === 'none' &&
+        gameCanvas.style.display === 'block';
+    }, { timeout: 30000 });
+
+    if (errors.some(error => error.includes("Cannot read properties of null"))) {
+      throw new Error(`Unexpected null DOM access error: ${errors.join('; ')}`);
+    }
+
+    console.log('PASS: start menu defers first click until game scripts are ready');
+  } finally {
+    releaseSnowgliderScript();
+    await page.close();
+  }
+}
+
 async function runBrowserTests() {
   let server;
   let browser;
@@ -78,6 +168,8 @@ async function runBrowserTests() {
         '--autoplay-policy=no-user-gesture-required'
       ]
     });
+
+    await runStartMenuRaceRegression(browser);
     
     const page = await browser.newPage();
     


### PR DESCRIPTION
## Summary

Fixes the first-click cold-load race where the Start button could be clicked before `src/snowglider.js` had created `#gameCanvas` and exported `window.initializeGameWithAudio`.

The start menu now records an early start request, leaves the start overlay visible, marks the Start button busy while scripts finish loading, then re-enables Start once the game is ready so the actual game start still happens from a fresh user gesture. This preserves the mobile-audio path that requires `HTMLAudioElement.play()` to be gesture-initiated.

## Root Cause

On a fresh GitHub Pages rebuild/deploy, Firebase/auth and game scripts can still be loading while the start menu is already interactive. A first click during that window could hide the start UI before the canvas and initializer existed, producing the stuck blue-screen/HUD state that only a refresh resolved.

## Changes

- Add a `snowglider:game-scripts-ready` signal from the script loader after the game scripts finish loading.
- Defer `startGame()` until both `#gameCanvas` and `window.initializeGameWithAudio` exist.
- Add a disabled/busy visual state to the Start button while the early click is pending.
- Re-enable Start after scripts are ready and require another click/tap, preserving a gesture-backed audio start path.
- Add a Puppeteer regression that delays `src/snowglider.js`, clicks Start early, verifies the overlay stays up and Start re-enables, then clicks Start again and verifies the game starts.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:browser`
- `npm run build`

Note: local checks were run with Node v23.10.0 from `~/.nvm` because the default Node 14/npm 6 cannot read this repo's package-lock v3.