### PR TITLE
[codex] add Firestore rules test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      
+
+      - name: Setup Java for Firebase emulator
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Install dependencies
         run: npm ci
 
@@ -50,6 +56,9 @@ jobs:
 
       - name: Run Node.js tests with coverage
         run: npm run test:coverage
+
+      - name: Run Firestore rules tests
+        run: npm run test:firebase
       
       - name: Install Puppeteer browser
         run: |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ The application uses the following Firestore collections:
 - `users` - User profiles and best times
 - `leaderboard` - Global leaderboard entries
 
+Firestore Security Rules are tracked in `firestore.rules`. Run
+`npm run test:firebase` to validate the rules against the Firebase emulator
+(requires a local Java runtime).
+
 #### GitHub Pages Deployment
 1. Push your changes to GitHub repository
 2. Enable GitHub Pages in repository settings

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,122 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    function isValidScoreTime(time) {
+      return time is number && time >= 4 && time <= 600;
+    }
+
+    function userDocPath(userId) {
+      return /databases/$(database)/documents/users/$(userId);
+    }
+
+    function validUserKeys(data) {
+      return data.keys().hasOnly([
+        'displayName',
+        'email',
+        'photoURL',
+        'lastLogin',
+        'bestTime',
+        'updatedAt'
+      ]);
+    }
+
+    function validUserDoc(data) {
+      return validUserKeys(data)
+        && (!('displayName' in data) || data.displayName == null || data.displayName is string)
+        && (!('email' in data) || data.email == null || data.email is string)
+        && (!('photoURL' in data) || data.photoURL == null || data.photoURL is string)
+        && (!('lastLogin' in data) || data.lastLogin is timestamp)
+        && (!('bestTime' in data) || isValidScoreTime(data.bestTime))
+        && (!('updatedAt' in data) || data.updatedAt is timestamp);
+    }
+
+    function changedUserKeys() {
+      return request.resource.data.diff(resource.data).affectedKeys();
+    }
+
+    function validChangedUserFields() {
+      return validUserKeys(request.resource.data)
+        && changedUserKeys().hasOnly([
+          'displayName',
+          'email',
+          'photoURL',
+          'lastLogin',
+          'bestTime',
+          'updatedAt'
+        ])
+        && (!changedUserKeys().hasAny(['displayName']) ||
+          request.resource.data.displayName == null ||
+          request.resource.data.displayName is string)
+        && (!changedUserKeys().hasAny(['email']) ||
+          request.resource.data.email == null ||
+          request.resource.data.email is string)
+        && (!changedUserKeys().hasAny(['photoURL']) ||
+          request.resource.data.photoURL == null ||
+          request.resource.data.photoURL is string)
+        && (!changedUserKeys().hasAny(['lastLogin']) ||
+          request.resource.data.lastLogin is timestamp)
+        && (!changedUserKeys().hasAny(['updatedAt']) ||
+          request.resource.data.updatedAt is timestamp);
+    }
+
+    function validBestTimeUpdate() {
+      return !changedUserKeys().hasAny(['bestTime'])
+        || (
+          isValidScoreTime(request.resource.data.bestTime)
+          && (!('bestTime' in resource.data) ||
+            !isValidScoreTime(resource.data.bestTime) ||
+            request.resource.data.bestTime <= resource.data.bestTime)
+        );
+    }
+
+    function validLeaderboardKeys(data) {
+      return data.keys().hasOnly(['user', 'time', 'achievedAt']);
+    }
+
+    function validLeaderboardDoc(userId, data) {
+      return validLeaderboardKeys(data)
+        && data.user == userDocPath(userId)
+        && isValidScoreTime(data.time)
+        && (!('achievedAt' in data) || data.achievedAt is timestamp);
+    }
+
+    function validLeaderboardUpdate(userId) {
+      return validLeaderboardDoc(userId, request.resource.data)
+        && (!('time' in resource.data) ||
+          !isValidScoreTime(resource.data.time) ||
+          request.resource.data.time <= resource.data.time);
+    }
+
+    match /users/{userId} {
+      allow get: if isOwner(userId);
+      allow list: if false;
+      allow create: if isOwner(userId) && validUserDoc(request.resource.data);
+      allow update: if isOwner(userId) && validChangedUserFields() && validBestTimeUpdate();
+      allow delete: if false;
+    }
+
+    match /leaderboard/{userId} {
+      allow get, list: if isSignedIn();
+      allow create: if isOwner(userId)
+        && exists(userDocPath(userId))
+        && validLeaderboardDoc(userId, request.resource.data);
+      allow update: if isOwner(userId)
+        && exists(userDocPath(userId))
+        && validLeaderboardUpdate(userId);
+      allow delete: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@firebase/rules-unit-testing": "^4.0.1",
         "@types/three": "0.160.0",
         "c8": "^10.1.2",
         "eslint": "^9.39.4",
@@ -1022,6 +1023,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
       "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^11.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:avalanche": "node tests/avalanche-tests.js",
     "test:auth": "node tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",
     "test:scores": "node tests/scores-tests.js",
+    "test:firebase": "npx -y firebase-tools@15.20.0 emulators:exec --project snowglider-rules-test --only firestore \"node tests/firestore-rules-tests.js\"",
     "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node tests/verification/dom_smoke_test.js",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@types/three": "0.160.0",
     "c8": "^10.1.2",
     "eslint": "^9.39.4",

--- a/src/boot/local-auth.js
+++ b/src/boot/local-auth.js
@@ -1,8 +1,14 @@
 // @ts-check
 (function () {
+  const MIN_VALID_SCORE_TIME = 4;
+  const MAX_VALID_SCORE_TIME = 600;
+
   /** @param {number} time */
   function isValidScoreTime(time) {
-    return typeof time === 'number' && Number.isFinite(time) && time >= 4;
+    return typeof time === 'number' &&
+      Number.isFinite(time) &&
+      time >= MIN_VALID_SCORE_TIME &&
+      time <= MAX_VALID_SCORE_TIME;
   }
 
   function installScoresModule() {
@@ -22,8 +28,13 @@
 
         const localBestTimeStr = localStorage.getItem('snowgliderBestTime');
         const localBestTime = localBestTimeStr ? parseFloat(localBestTimeStr) : null;
+        // Inline (not isValidScoreTime) so the `typeof` check narrows localBestTime
+        // from `number | null` to `number` for the `time < localBestTime` use below
+        // under strictNullChecks.
         const hasValidLocalBest = typeof localBestTime === 'number' &&
-          Number.isFinite(localBestTime) && localBestTime >= 4;
+          Number.isFinite(localBestTime) &&
+          localBestTime >= MIN_VALID_SCORE_TIME &&
+          localBestTime <= MAX_VALID_SCORE_TIME;
         if (localBestTimeStr && !hasValidLocalBest) {
           console.warn("Ignoring invalid local best time:", localBestTimeStr);
           localStorage.removeItem('snowgliderBestTime');

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -49,11 +49,16 @@ let currentUser: User | null = null;
 
 // The timed course runs from z=-15 to z=-195 (180 world metres). Four seconds is
 // deliberately loose: it rejects timer/startup artifacts like 0.01s while allowing
-// any physically plausible descent the current game can produce.
+// any physically plausible descent the current game can produce. Ten minutes is
+// a generous upper bound for completed runs and matches the Firestore rules cap.
 const MIN_VALID_SCORE_TIME = 4;
+const MAX_VALID_SCORE_TIME = 600;
 
 function isValidScoreTime(time: number) {
-  return typeof time === 'number' && Number.isFinite(time) && time >= MIN_VALID_SCORE_TIME;
+  return typeof time === 'number' &&
+    Number.isFinite(time) &&
+    time >= MIN_VALID_SCORE_TIME &&
+    time <= MAX_VALID_SCORE_TIME;
 }
 
 function readLocalBestTime() {

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -290,12 +290,16 @@ const velocity = player.velocity;
 
 // Add timer and best time tracking (state.startTime / state.bestTime)
 const MIN_VALID_SCORE_TIME = 4;
+const MAX_VALID_SCORE_TIME = 600;
 
 function isValidScoreTime(time: number) {
   if (window.ScoresModule && typeof window.ScoresModule.isValidScoreTime === 'function') {
     return window.ScoresModule.isValidScoreTime(time);
   }
-  return typeof time === 'number' && Number.isFinite(time) && time >= MIN_VALID_SCORE_TIME;
+  return typeof time === 'number' &&
+    Number.isFinite(time) &&
+    time >= MIN_VALID_SCORE_TIME &&
+    time <= MAX_VALID_SCORE_TIME;
 }
 
 function readStoredBestTime() {

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,7 @@ npm run test:tree-collision # Tree collision tests
 npm run test:avalanche      # Avalanche physics tests
 npm run test:auth           # Auth module tests with mocked Firebase
 npm run test:scores         # Scores module tests with mocked Firestore
+npm run test:firebase       # Firestore Security Rules tests (requires Java)
 npm run test:verify         # Verification harness (physics invariant + DOM smoke)
 ```
 
@@ -119,6 +120,10 @@ suites, so they now report real browser coverage too. CI runs `test:coverage`,
 then the browser suite with `BROWSER_COVERAGE`, then `coverage:merge`, and uploads
 the merged LCOV to Codecov as an informational, non-gating report; no coverage
 threshold is enforced.
+
+`npm run test:firebase` starts the Firestore emulator with `firebase-tools` and
+runs `firestore.rules` through `tests/firestore-rules-tests.js`. It is separate
+from `npm test` because the emulator requires a local Java runtime.
 
 ### Browser Tests
 

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -77,7 +77,10 @@ const mocks = {
     updateUserBestTime: () => {},
     displayLeaderboard: () => {},
     recordScore: () => {},
-    isValidScoreTime: time => typeof time === 'number' && Number.isFinite(time) && time >= 4
+    isValidScoreTime: time => typeof time === 'number' &&
+      Number.isFinite(time) &&
+      time >= 4 &&
+      time <= 600
   }
 };
 

--- a/tests/firestore-rules-tests.js
+++ b/tests/firestore-rules-tests.js
@@ -1,0 +1,273 @@
+// firestore-rules-tests.js
+// Firestore Security Rules coverage for SnowGlider score/profile data.
+//
+// Run with: npm run test:firebase
+// The script starts the Firestore emulator via firebase-tools, then this file
+// exercises the checked-in firestore.rules with @firebase/rules-unit-testing.
+const fs = require('fs');
+const path = require('path');
+const {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment
+} = require('@firebase/rules-unit-testing');
+const {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  where
+} = require('firebase/firestore');
+
+const REPO = path.join(__dirname, '..');
+const PROJECT_ID = 'snowglider-rules-test';
+
+let testEnv;
+let pass = 0;
+let fail = 0;
+
+function profile(name = 'Alice') {
+  return {
+    displayName: name,
+    email: `${name.toLowerCase()}@snowglider.test`,
+    photoURL: null,
+    lastLogin: serverTimestamp()
+  };
+}
+
+function bestTime(time) {
+  return {
+    bestTime: time,
+    updatedAt: serverTimestamp()
+  };
+}
+
+function leaderboardEntry(db, userId, time) {
+  return {
+    user: doc(db, 'users', userId),
+    time,
+    achievedAt: serverTimestamp()
+  };
+}
+
+function dbFor(uid) {
+  return testEnv.authenticatedContext(uid, {
+    email: `${uid}@snowglider.test`
+  }).firestore();
+}
+
+function anonDb() {
+  return testEnv.unauthenticatedContext().firestore();
+}
+
+async function seed(seedFn) {
+  await testEnv.withSecurityRulesDisabled(async context => {
+    await seedFn(context.firestore());
+  });
+}
+
+async function reset() {
+  await testEnv.clearFirestore();
+}
+
+async function runTest(name, testFn) {
+  try {
+    await reset();
+    await testFn();
+    console.log(`  PASS: ${name}`);
+    pass++;
+  } catch (error) {
+    console.log(`  FAIL: ${name}`);
+    console.log(`    ${error.message}`);
+    fail++;
+  }
+}
+
+async function main() {
+  if (!process.env.FIRESTORE_EMULATOR_HOST) {
+    console.error('FIRESTORE_EMULATOR_HOST is not set. Run this with `npm run test:firebase`.');
+    process.exit(1);
+  }
+
+  const rules = fs.readFileSync(path.join(REPO, 'firestore.rules'), 'utf8');
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules
+    }
+  });
+
+  console.log('--- Firestore rules: users ---');
+  await runTest('signed-in users can create and read their own profile', async () => {
+    const alice = dbFor('alice');
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), profile(), { merge: true }));
+    await assertSucceeds(getDoc(doc(alice, 'users', 'alice')));
+  });
+
+  await runTest('users cannot read or write another user profile', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'bob'), profile('Bob'));
+    });
+
+    await assertFails(getDoc(doc(alice, 'users', 'bob')));
+    await assertFails(setDoc(doc(alice, 'users', 'bob'), profile('Bob'), { merge: true }));
+  });
+
+  await runTest('user best times must be plausible score values', async () => {
+    const alice = dbFor('alice');
+
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(14.67), { merge: true }));
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(3.99), { merge: true }));
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(601), { merge: true }));
+  });
+
+  await runTest('user best times cannot be downgraded to a slower time', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), bestTime(14));
+    });
+
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(19), { merge: true }));
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(13.5), { merge: true }));
+  });
+
+  await runTest('valid user best times can repair a corrupt stored best', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), bestTime(0.01));
+    });
+
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(19.43), { merge: true }));
+  });
+
+  await runTest('unexpected user document fields are rejected', async () => {
+    const alice = dbFor('alice');
+
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), {
+      ...profile(),
+      isAdmin: true
+    }, { merge: true }));
+  });
+
+  console.log('\n--- Firestore rules: leaderboard ---');
+  await runTest('signed-in users can write their own valid leaderboard entry', async () => {
+    const alice = dbFor('alice');
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), profile(), { merge: true }));
+
+    await assertSucceeds(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 14.67)
+    ));
+  });
+
+  await runTest('signed-in users can query leaderboard entries', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), profile());
+      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 14.67));
+    });
+
+    await assertSucceeds(getDocs(query(
+      collection(alice, 'leaderboard'),
+      where('time', '>=', 4),
+      orderBy('time', 'asc'),
+      limit(10)
+    )));
+  });
+
+  await runTest('anonymous users cannot read or write leaderboard data', async () => {
+    const anon = anonDb();
+
+    await assertFails(getDocs(query(
+      collection(anon, 'leaderboard'),
+      where('time', '>=', 4),
+      orderBy('time', 'asc'),
+      limit(10)
+    )));
+    await assertFails(setDoc(
+      doc(anon, 'leaderboard', 'alice'),
+      leaderboardEntry(anon, 'alice', 14.67)
+    ));
+  });
+
+  await runTest('leaderboard writes require the matching user document and reference', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), profile());
+      await setDoc(doc(admin, 'users', 'bob'), profile('Bob'));
+    });
+
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'bob', 14.67)
+    ));
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'bob'),
+      leaderboardEntry(alice, 'bob', 14.67)
+    ));
+  });
+
+  await runTest('leaderboard times must be plausible score values', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), profile());
+    });
+
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 0.01)
+    ));
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 601)
+    ));
+  });
+
+  await runTest('leaderboard entries cannot be downgraded to a slower time', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), profile());
+      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 14));
+    });
+
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 19)
+    ));
+    await assertSucceeds(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 13.5)
+    ));
+  });
+
+  await runTest('valid leaderboard times can repair a corrupt stored entry', async () => {
+    const alice = dbFor('alice');
+    await seed(async admin => {
+      await setDoc(doc(admin, 'users', 'alice'), profile());
+      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 0.01));
+    });
+
+    await assertSucceeds(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 19.43)
+    ));
+  });
+
+  console.log(`\nFIRESTORE RULES TEST TOTAL: ${pass} passed, ${fail} failed`);
+  await testEnv.cleanup();
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch(async error => {
+  console.error(error);
+  if (testEnv) {
+    await testEnv.cleanup();
+  }
+  process.exit(1);
+});

--- a/tests/regression-tests.js
+++ b/tests/regression-tests.js
@@ -362,8 +362,12 @@ runTest('Leaderboard Always Reflects The Authoritative Best, Never A Slower Loca
 
 runTest('Impossible Score Times Are Rejected And Repairable', () => {
   const minValidScoreTime = 4;
+  const maxValidScoreTime = 600;
   function isValidScoreTime(time) {
-    return typeof time === 'number' && Number.isFinite(time) && time >= minValidScoreTime;
+    return typeof time === 'number' &&
+      Number.isFinite(time) &&
+      time >= minValidScoreTime &&
+      time <= maxValidScoreTime;
   }
 
   function resolve(time, storedBest, leaderboardBest) {
@@ -394,6 +398,11 @@ runTest('Impossible Score Times Are Rejected And Repairable', () => {
   assertEquals(r.accepted, false, "A 0.01s run should never be accepted as a score");
   assertEquals(r.writeUser, false, "Invalid runs must not write the user best");
   assertEquals(r.writeLeaderboard, false, "Invalid runs must not write the leaderboard");
+
+  r = resolve(600.01, null, null);
+  assertEquals(r.accepted, false, "A run over 600s should never be accepted as a score");
+  assertEquals(r.writeUser, false, "Over-cap runs must not write the user best");
+  assertEquals(r.writeLeaderboard, false, "Over-cap runs must not write the leaderboard");
 
   r = resolve(19.43, 0.01, 0.01);
   assertEquals(r.accepted, true, "A realistic run should still be accepted");

--- a/tests/scores-tests.js
+++ b/tests/scores-tests.js
@@ -314,16 +314,21 @@ async function main() {
       'isFirestoreAvailable', 'isValidScoreTime'].every(key => typeof ScoresModule[key] === 'function'));
   check('score validation rejects impossible and non-finite times',
     ScoresModule.isValidScoreTime(0.01) === false &&
+    ScoresModule.isValidScoreTime(600.01) === false &&
     ScoresModule.isValidScoreTime(Infinity) === false &&
     ScoresModule.isValidScoreTime('14') === false);
   check('score validation accepts plausible numeric times',
     ScoresModule.isValidScoreTime(4) === true &&
+    ScoresModule.isValidScoreTime(600) === true &&
     ScoresModule.isValidScoreTime(14.67) === true);
 
   console.log('\n--- Local score recording ---');
   resetState(ScoresModule);
   ScoresModule.recordScore(0.01);
   check('invalid runs are not stored locally',
+    localStorage.getItem('snowgliderBestTime') === null);
+  ScoresModule.recordScore(600.01);
+  check('over-cap runs are not stored locally',
     localStorage.getItem('snowgliderBestTime') === null);
   localStorage.setItem('snowgliderBestTime', 'bogus');
   ScoresModule.recordScore(21.5);


### PR DESCRIPTION
## Summary
- add checked-in Firestore Security Rules for `users/{uid}` and `leaderboard/{uid}`
- add `firebase.json` emulator config and `tests/firestore-rules-tests.js` using `@firebase/rules-unit-testing`
- add `npm run test:firebase` and wire it into CI with a Java runtime for the Firestore emulator
- keep client score validation in sync with the rules by enforcing the same 4s-600s score window in `scores.js`, `snowglider.js`, and local fallback auth

## Why
Score validation was only enforced in client code. The rules now enforce the same core constraints server-side: signed-in ownership, plausible score bounds, matching leaderboard user references, and no slower-time downgrades. The tests cover allowed profile/score writes, denied cross-user/anonymous writes, invalid score rejection, leaderboard query access, and repair of legacy corrupt score documents.

## Validation
- `npm run lint` passed
- `npm run typecheck` passed
- `npm test` passed
- `npm run test:coverage` passed
- `npm run test:firebase` was attempted locally but could not start the Firestore emulator because this machine has no Java runtime (`java -version` exits 1). CI now installs Temurin 21 before running this target.