### PR TITLE
chore(ts): ratchet checkJs:true — Phase 1 hardening before Phase 2

### DIFF
--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -4,9 +4,15 @@
 
 ## Status
 
-- **Current:** ES2022 JavaScript with the Phase 1 checker in place. Classic `<script>` modules
-  (global namespaces), three.js **r160** loaded as a CDN global, no bundler, no build step.
-  `auth.js` / `scores.js` are ES modules for Firebase.
+- **Current:** Phase 1 **complete and hardened.** Every `src/**/*.js` carries `// @ts-check`,
+  `tsc --noEmit` is green and **blocking in CI**, and `tsconfig` now sets `"checkJs": true` so any
+  *new* source file is type-checked by default (the per-file directives are now a belt-and-suspenders
+  ratchet, not the gate). Still classic `<script>` modules (global namespaces), three.js **r160**
+  loaded as a CDN global. `auth.js` / `scores.js` are ES modules for Firebase.
+- **Build today:** a Vite step exists but currently only **copies** the static source tree into
+  `dist/` (see `vite.config.js` `copyStaticAppFiles`) — it does **not** yet bundle an ES-module
+  graph. `index.html` still loads CDN `THREE` and injects `src/*.js` via `src/boot/script-loader.js`.
+  Turning that copy step into a real module bundle is the substance of Phase 2.
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "noEmit": true,
     "strict": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## What

The safe lead-in step for **Phase 2** of the TypeScript migration (plan: #84).

- Flip `tsconfig.json` `"checkJs": false` → `"checkJs": true`.
- Update `docs/TYPESCRIPT_MIGRATION.md` to record Phase 1 as complete + hardened, and to clarify that the current Vite step only **copies** the static tree into `dist/` (it does not yet bundle an ES-module graph).

## Why

All 17 `src/**/*.js` files already carry `// @ts-check`, and `tsc --noEmit` is already green and blocking in CI. With `checkJs:false`, type-checking depends entirely on remembering the per-file directive — a *new* source file added without it would silently skip the type gate. Setting `checkJs:true` makes type-checking the default for everything under `src/`, so the gate can't be bypassed by omission. The existing `// @ts-check` directives stay as harmless belt-and-suspenders.

This is intentionally a zero-behavior-change ratchet to de-risk the larger Phase 2 module/bundler work that follows.

## Verification

- `npm run lint` — green.
- `npm run typecheck` (`tsc --noEmit`) with `checkJs:true` — green, **no new errors** (confirmed all `src` files already clean under full `checkJs`).
- No runtime/deploy change: `index.html`, the script-loader, and the Vite copy build are untouched.

## Follow-ups (tracked in #84)
PR 2.0 stands up a real Vite bundle alongside the existing CDN+script-loader path; PRs 2.1–2.9 convert one module (and its test) per PR; PR 2.10 retires the classic loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ajuF72zP5HaNNUZBmsaTJ)_