### PR TITLE
build(ts): PR 2.0 — Vite emits a real ES-module bundle (three from npm)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/scores.js"],
+    files: ["src/auth.js", "src/main.js", "src/scores.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,20 @@
+// @ts-check
+import * as THREE from 'three';
+
+// Phase 2.0 (issue #84): a real ES-module entry that Vite bundles into a
+// hashed asset, importing three.js from the npm package instead of the CDN
+// global. The live game still boots through the classic CDN + script-loader
+// path in index.html until the per-module conversions (PR 2.1 onward) move
+// each game module onto this bundle. This entry exists only to stand up and
+// verify the bundling pipeline without changing how the game currently loads.
+
+/** Revision of the three.js build pulled from npm and bundled by Vite. */
+export const BUNDLED_THREE_REVISION = THREE.REVISION;
+
+if (typeof window !== 'undefined') {
+  /** @type {any} */ (window).__SNOWGLIDER_BUNDLE__ = {
+    threeRevision: THREE.REVISION
+  };
+}
+
+console.log(`[snowglider] bundled three.js r${THREE.REVISION}`);

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,7 +43,18 @@ export default defineConfig({
   base: '/',
   build: {
     outDir,
-    sourcemap: true
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        // Keep the existing page as Vite's HTML entry so dist/index.html is
+        // emitted exactly as before (classic CDN + script-loader boot path).
+        index: path.resolve(rootDir, 'index.html'),
+        // Phase 2.0 (issue #84): a real ES-module bundle (three.js from npm)
+        // emitted alongside the page to stand up the bundling pipeline. It is
+        // not yet referenced by index.html; per-module conversions wire it in.
+        bundle: path.resolve(rootDir, 'src/main.js')
+      }
+    }
   },
   plugins: [copyStaticAppFiles()]
 });


### PR DESCRIPTION
## Phase 2.0 of the TypeScript migration (issue #84)

Stands up a working **bundled entry alongside the existing classic load path**, without rewriting any game module yet. This is the infra step that makes `vite build` produce a real bundle instead of a file copy, so PRs 2.1+ have a bundle to move modules onto.

### Changes (3 files, +33 / -2)
- **`src/main.js`** (new) — a real ES-module entry that does `import * as THREE from 'three'`, pulling three.js from the npm package (`three@0.160.0`) instead of the CDN global. It is **not** referenced by `index.html`; per-module conversions (PR 2.1 onward) will wire game modules onto it.
- **`vite.config.js`** — set `build.rollupOptions.input` with both `index.html` (so `dist/index.html` is emitted exactly as before — classic CDN + `script-loader` boot path stays intact) and `src/main.js`, so `vite build` now produces a hashed JS bundle instead of only copying static files + extracting CSS.
- **`eslint.config.js`** — parse `src/main.js` as an ES module (it uses `import`).

### Exit criteria (all met)
- `npm run build` emits `dist/assets/bundle-<hash>.js` (+ sourcemap). The bundle tree-shakes to `threeRevision:160`, proving `import 'three'` resolves to the npm package and Rollup bundles it — the bundle path no longer depends on the CDN.
- CI's **"Verify Pages artifact contents"** checks still pass; `dist/index.html` still loads the game via the CDN three + `script-loader.js` path and does not reference the new bundle.
- Guardrail green locally: `npm run lint`, `tsc --noEmit`, `npm test`, and `npm run build`.

### Risk / scope
Infra only — no module rewrites, no test changes, no change to how the live game boots. The new bundle is deployed-but-unreferenced until module conversions begin, by design (issue #84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G17gnuCkc6H23wcaSFmDRk

---
_Generated by [Claude Code](https://claude.ai/code/session_01G17gnuCkc6H23wcaSFmDRk)_