### PR TITLE
refactor(ts): PR 2.1 — convert avalanche.js to an ES module (issue #84)

### DIFF
--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -4,15 +4,25 @@
 
 ## Status
 
-- **Current:** Phase 1 **complete and hardened.** Every `src/**/*.js` carries `// @ts-check`,
-  `tsc --noEmit` is green and **blocking in CI**, and `tsconfig` now sets `"checkJs": true` so any
-  *new* source file is type-checked by default (the per-file directives are now a belt-and-suspenders
-  ratchet, not the gate). Still classic `<script>` modules (global namespaces), three.js **r160**
-  loaded as a CDN global. `auth.js` / `scores.js` are ES modules for Firebase.
-- **Build today:** a Vite step exists but currently only **copies** the static source tree into
-  `dist/` (see `vite.config.js` `copyStaticAppFiles`) — it does **not** yet bundle an ES-module
-  graph. `index.html` still loads CDN `THREE` and injects `src/*.js` via `src/boot/script-loader.js`.
-  Turning that copy step into a real module bundle is the substance of Phase 2.
+- **Current:** Phase 1 **complete and hardened**; **Phase 2 in progress** (see issue #84 for the
+  per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking in
+  CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
+  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry) and
+  **`src/avalanche.js`** are now ES modules too. The remaining game modules are still classic
+  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+- **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
+  `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
+  each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
+  still copies the static tree so the **classic CDN + script-loader path keeps booting the game**
+  during the staged conversion. Until the loader is retired (PR 2.10), converted modules also load
+  through the bundle and re-publish their `window.*` namespace so the still-classic `snowglider.js`
+  keeps finding them — which means three.js is loaded twice transitionally (CDN UMD for classic
+  scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
+  An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
+  as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
+- **Converted so far (PR 2.1):** `src/avalanche.js` — `import * as THREE from 'three'` + `export class
+  AvalancheSystem`. Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and
+  real three instead of the old `new Function(src)` + mock-THREE injection.
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,6 @@ module.exports = [
         ...globals.node,
         AudioModule: "readonly",
         AuthModule: "readonly",
-        Avalanche: "readonly",
         Camera: "readonly",
         Controls: "readonly",
         CourseModule: "readonly",
@@ -72,7 +71,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/main.js", "src/scores.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/main.js", "src/scores.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,22 @@
   <meta name="build-id" content="2025.10.06-mobile-audio-v3">
   <title>Skiing Snowman</title>
   <link rel="stylesheet" href="styles/main.css">
+  <!--
+    Import map for the ES-module bundle path (issue #84, Phase 2). It only takes
+    effect when index.html is served as raw source (the puppeteer suite and
+    `npm start`), where converted modules' bare `import * as THREE from 'three'`
+    needs a resolvable URL. In the Vite build that ships to snowglider.ai, three
+    is bundled into the hashed chunk, so this map is inert there. Pinned to the
+    same r160 as the classic CDN <script> below to avoid version skew while both
+    load paths coexist (the classic loader is retired in PR 2.10).
+  -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.module.min.js"
+    }
+  }
+  </script>
   <script src="src/boot/local-auth.js"></script>
   <script src="src/boot/firebase-bootstrap.js"></script>
 </head>
@@ -147,6 +163,14 @@
   <div id="leaderboard" style="display:none;"></div>
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.min.js" integrity="sha512-vnmn/Qqn6aG0POAc9mIGzjq0IybrvxJXYDafNvp9JSnDGxeF3pbkSqLvf+YGd5ku63pT7sa/jxHn7/d0mU8+tA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <!--
+    ES-module bundle entry (issue #84, Phase 2). Deferred like every module
+    script, so it runs after the classic CDN three.js above is in place but
+    before DOMContentLoaded — i.e. before script-loader.js pulls in the classic
+    game modules. Converted modules (avalanche.js so far) publish their
+    window.* bridge here so the still-classic snowglider.js keeps finding them.
+  -->
+  <script type="module" src="src/main.js"></script>
   <!-- Audio: Simplified implementation using native HTML5 Audio (no library dependencies) -->
   <script src="src/boot/script-loader.js"></script>
   <script src="src/ui/start-menu.js"></script>

--- a/src/avalanche.js
+++ b/src/avalanche.js
@@ -1,8 +1,16 @@
 // @ts-check
 // avalanche.js - Simple avalanche system for Snowglider
 // Triggered when player travels far enough downhill - burial = game over
+//
+// Phase 2.1 (issue #84): first module converted off the classic global model.
+// `THREE` now comes from the npm package via a real ES-module import instead of
+// the CDN global, and the class is `export`ed. The window.Avalanche assignment
+// below is kept so the still-classic consumer (snowglider.js, converted last in
+// PR 2.9) keeps working during the staged migration; it is loaded into the page
+// through the bundle entry (src/main.js) rather than the classic script-loader.
+import * as THREE from 'three';
 
-class AvalancheSystem {
+export class AvalancheSystem {
   constructor(scene, count = 120) {
     this.scene = scene;
     this.count = count;
@@ -216,7 +224,9 @@ class AvalancheSystem {
   }
 }
 
-// Export globally like other modules
+// Backward-compat global export for the still-classic consumer (snowglider.js
+// reads `window.Avalanche.AvalancheSystem`). Drop this once snowglider.js is
+// converted to import AvalancheSystem directly (PR 2.9, issue #84).
 const Avalanche = {
   AvalancheSystem
 };

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -8,7 +8,8 @@
     'src/snowman.js',
     'src/audio.js',
     'src/controls.js',
-    'src/avalanche.js',
+    // avalanche.js converted to an ES module (issue #84, PR 2.1); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/effects.js',
     'src/course.js',
     'src/snowglider.js'

--- a/src/main.js
+++ b/src/main.js
@@ -3,10 +3,15 @@ import * as THREE from 'three';
 
 // Phase 2.0 (issue #84): a real ES-module entry that Vite bundles into a
 // hashed asset, importing three.js from the npm package instead of the CDN
-// global. The live game still boots through the classic CDN + script-loader
-// path in index.html until the per-module conversions (PR 2.1 onward) move
-// each game module onto this bundle. This entry exists only to stand up and
-// verify the bundling pipeline without changing how the game currently loads.
+// global. Per-module conversions (PR 2.1 onward) move each game module onto
+// this bundle, which index.html now loads as `<script type="module">`.
+//
+// Phase 2.1: avalanche.js is the first converted module. Importing it here for
+// its side effect runs its `window.Avalanche = …` bridge before the classic
+// script-loader pulls in snowglider.js, so the still-classic consumer keeps
+// finding the avalanche system. As more modules convert, add them here too
+// until the classic loader is retired (PR 2.10).
+import './avalanche.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/tests/avalanche-tests.js
+++ b/tests/avalanche-tests.js
@@ -1,175 +1,20 @@
 /**
- * Avalanche system tests for SnowGlider
+ * Avalanche system tests for SnowGlider.
+ *
+ * Phase 2.1 (issue #84): these run against the REAL `src/avalanche.js` ES module
+ * and real three.js from npm. The previous version evaluated the source with
+ * `new Function(src)` and a hand-rolled THREE mock plus a parallel
+ * `TestAvalancheSystem` reimplementation; that injection pattern can't load a
+ * module that uses `import`/`export`, so it's gone. We now `import()` the actual
+ * class and exercise it directly — every assertion validates shipped code.
+ *
+ * three's geometry/material/mesh constructors need no WebGL context, so the real
+ * AvalancheSystem constructs fine headless under Node (no renderer involved).
  */
 
-// Mock THREE.js objects for testing
-const mockTHREE = {
-  Object3D: class {
-    constructor() {
-      this.position = { x: 0, y: 0, z: 0, set: function(x, y, z) { this.x = x; this.y = y; this.z = z; } };
-      this.rotation = { x: 0, y: 0, z: 0, set: function(x, y, z) { this.x = x; this.y = y; this.z = z; } };
-      this.scale = { setScalar: function() {} };
-      this.matrix = {};
-    }
-    updateMatrix() {}
-  },
-  IcosahedronGeometry: class {
-    dispose() {}
-  },
-  MeshStandardMaterial: class {
-    dispose() {}
-  },
-  InstancedMesh: class {
-    constructor() {
-      this.instanceMatrix = { setUsage: function() {}, needsUpdate: false };
-      this.castShadow = false;
-      this.receiveShadow = false;
-      this.frustumCulled = true; // three default; avalanche.js must turn this off (r160 culling)
-    }
-    setMatrixAt() {}
-  },
-  DynamicDrawUsage: 35048
-};
+'use strict';
 
-// Set up global THREE mock
-global.THREE = mockTHREE;
-
-// Mock scene
-const mockScene = {
-  children: [],
-  add: function(obj) { this.children.push(obj); },
-  remove: function(obj) { 
-    const idx = this.children.indexOf(obj);
-    if (idx > -1) this.children.splice(idx, 1);
-  }
-};
-
-// Simple AvalancheSystem implementation for testing (mirrors avalanche.js logic)
-class TestAvalancheSystem {
-  constructor(scene, count = 120) {
-    this.scene = scene;
-    this.count = count;
-    this.active = false;
-    this.getTerrainHeight = null;
-    
-    // Physics data arrays
-    this.positions = new Float32Array(count * 3);
-    this.velocities = new Float32Array(count * 3);
-    this.sizes = new Float32Array(count);
-    
-    // Initialize sizes
-    for (let i = 0; i < count; i++) {
-      this.sizes[i] = 0.8; // Default size for testing
-    }
-  }
-  
-  setTerrainFunction(fn) {
-    this.getTerrainHeight = fn;
-  }
-  
-  trigger(playerPos) {
-    this.active = true;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      
-      // Spawn behind player (uphill)
-      const angle = (Math.random() - 0.5) * Math.PI * 0.6;
-      const dist = 25 + Math.random() * 15;
-      
-      this.positions[idx]     = playerPos.x + Math.sin(angle) * dist;
-      this.positions[idx + 1] = playerPos.y + 8 + Math.random() * 6;
-      this.positions[idx + 2] = playerPos.z + dist * Math.cos(angle);
-      
-      // Velocity toward player (downhill)
-      this.velocities[idx]     = (Math.random() - 0.5) * 2;
-      this.velocities[idx + 1] = 0;
-      this.velocities[idx + 2] = -(8 + Math.random() * 4);
-      
-      this.sizes[i] = 0.4 + Math.random() * 1.2;
-    }
-  }
-  
-  update(dt) {
-    if (!this.active) return;
-    
-    const gravity = 18;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      
-      // Apply gravity
-      this.velocities[idx + 1] -= gravity * dt;
-      
-      // Update positions
-      this.positions[idx]     += this.velocities[idx] * dt;
-      this.positions[idx + 1] += this.velocities[idx + 1] * dt;
-      this.positions[idx + 2] += this.velocities[idx + 2] * dt;
-      
-      // Ground collision
-      let floorY = 0;
-      if (this.getTerrainHeight) {
-        floorY = this.getTerrainHeight(this.positions[idx], this.positions[idx + 2]);
-      }
-      
-      if (this.positions[idx + 1] < floorY + this.sizes[i]) {
-        this.positions[idx + 1] = floorY + this.sizes[i];
-        this.velocities[idx + 1] *= -0.25;
-      }
-    }
-  }
-  
-  checkBurial(playerPos, hitRadius = 2) {
-    if (!this.active) return false;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      const dx = this.positions[idx] - playerPos.x;
-      const dy = this.positions[idx + 1] - playerPos.y;
-      const dz = this.positions[idx + 2] - playerPos.z;
-      const distSq = dx * dx + dy * dy + dz * dz;
-      const threshold = hitRadius + this.sizes[i];
-      
-      if (distSq < threshold * threshold) {
-        return true;
-      }
-    }
-    return false;
-  }
-  
-  getClosestDistance(playerPos) {
-    if (!this.active) return Infinity;
-    
-    let minDist = Infinity;
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      const dx = this.positions[idx] - playerPos.x;
-      const dz = this.positions[idx + 2] - playerPos.z;
-      const dist = Math.sqrt(dx * dx + dz * dz);
-      if (dist < minDist) minDist = dist;
-    }
-    return minDist;
-  }
-  
-  hasPassed(playerPos) {
-    if (!this.active) return false;
-    
-    let passedCount = 0;
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      if (this.positions[idx + 2] < playerPos.z - 10) {
-        passedCount++;
-      }
-    }
-    return passedCount > this.count * 0.8;
-  }
-  
-  reset() {
-    this.active = false;
-  }
-}
-
-// Custom assert functions
+// Custom assert helpers
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message || 'Assertion failed');
@@ -191,7 +36,6 @@ function assertApprox(a, b, tolerance, message) {
   return true;
 }
 
-// Run tests
 let passCount = 0;
 let failCount = 0;
 
@@ -207,204 +51,223 @@ function runTest(name, testFn) {
   }
 }
 
-console.log('\n🏔️ SNOWGLIDER AVALANCHE TESTS 🏔️');
-console.log('==================================\n');
+async function main() {
+  // Real three.js (npm) and the real avalanche module under test.
+  const THREE = await import('three');
+  const { AvalancheSystem } = await import('../src/avalanche.js');
 
-// Test 1: Avalanche Initialization
-runTest('Avalanche Initialization', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 50);
-  
-  assertEquals(avalanche.count, 50, 'Avalanche should have specified count');
-  assertEquals(avalanche.active, false, 'Avalanche should start inactive');
-  assert(avalanche.positions instanceof Float32Array, 'Positions should be Float32Array');
-  assert(avalanche.velocities instanceof Float32Array, 'Velocities should be Float32Array');
-});
+  // Each test gets a fresh real scene; the system adds its InstancedMesh to it.
+  const makeSystem = (count) => new AvalancheSystem(new THREE.Scene(), count);
 
-// Test 2: Terrain Function Connection
-runTest('Terrain Function Connection', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  const mockTerrainFn = (x, z) => x * 0.1 + z * 0.1;
-  avalanche.setTerrainFunction(mockTerrainFn);
-  
-  assert(avalanche.getTerrainHeight !== null, 'Terrain function should be set');
-  assertApprox(avalanche.getTerrainHeight(10, 20), 3, 0.01, 'Terrain function should work');
-});
+  console.log('\n🏔️ SNOWGLIDER AVALANCHE TESTS 🏔️');
+  console.log('==================================\n');
 
-// Test 3: Avalanche Trigger
-runTest('Avalanche Trigger', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 20);
-  const playerPos = { x: 0, y: 10, z: -50 };
-  
-  assertEquals(avalanche.active, false, 'Should start inactive');
-  
-  avalanche.trigger(playerPos);
-  
-  assertEquals(avalanche.active, true, 'Should be active after trigger');
-  
-  // Check that boulders are spawned behind player (positive Z offset)
-  let behindCount = 0;
-  for (let i = 0; i < avalanche.count; i++) {
-    if (avalanche.positions[i * 3 + 2] > playerPos.z) {
-      behindCount++;
+  // Test 1: Avalanche Initialization
+  runTest('Avalanche Initialization', () => {
+    const avalanche = makeSystem(50);
+
+    assertEquals(avalanche.count, 50, 'Avalanche should have specified count');
+    assertEquals(avalanche.active, false, 'Avalanche should start inactive');
+    assert(avalanche.positions instanceof Float32Array, 'Positions should be Float32Array');
+    assert(avalanche.velocities instanceof Float32Array, 'Velocities should be Float32Array');
+  });
+
+  // Test 2: Terrain Function Connection
+  runTest('Terrain Function Connection', () => {
+    const avalanche = makeSystem(10);
+
+    const mockTerrainFn = (x, z) => x * 0.1 + z * 0.1;
+    avalanche.setTerrainFunction(mockTerrainFn);
+
+    assert(avalanche.getTerrainHeight !== null, 'Terrain function should be set');
+    assertApprox(avalanche.getTerrainHeight(10, 20), 3, 0.01, 'Terrain function should work');
+  });
+
+  // Test 3: Avalanche Trigger
+  runTest('Avalanche Trigger', () => {
+    const avalanche = makeSystem(20);
+    const playerPos = { x: 0, y: 10, z: -50 };
+
+    assertEquals(avalanche.active, false, 'Should start inactive');
+
+    avalanche.trigger(playerPos);
+
+    assertEquals(avalanche.active, true, 'Should be active after trigger');
+
+    // Check that boulders are spawned behind player (positive Z offset)
+    let behindCount = 0;
+    for (let i = 0; i < avalanche.count; i++) {
+      if (avalanche.positions[i * 3 + 2] > playerPos.z) {
+        behindCount++;
+      }
     }
-  }
-  assert(behindCount > avalanche.count * 0.8, 'Most boulders should spawn behind player');
-});
+    assert(behindCount > avalanche.count * 0.8, 'Most boulders should spawn behind player');
+  });
 
-// Test 4: Avalanche Physics Update
-runTest('Avalanche Physics Update', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  avalanche.setTerrainFunction(() => 0); // Flat terrain
-  
-  avalanche.trigger({ x: 0, y: 10, z: -50 });
-  
-  // Store initial positions
-  const initialZ = [];
-  for (let i = 0; i < avalanche.count; i++) {
-    initialZ.push(avalanche.positions[i * 3 + 2]);
-  }
-  
-  // Update for several frames
-  for (let i = 0; i < 10; i++) {
-    avalanche.update(0.016); // ~60fps
-  }
-  
-  // Check that boulders moved downhill (negative Z)
-  let movedDownhill = 0;
-  for (let i = 0; i < avalanche.count; i++) {
-    if (avalanche.positions[i * 3 + 2] < initialZ[i]) {
-      movedDownhill++;
+  // Test 4: Avalanche Physics Update
+  runTest('Avalanche Physics Update', () => {
+    const avalanche = makeSystem(10);
+    avalanche.setTerrainFunction(() => 0); // Flat terrain
+
+    avalanche.trigger({ x: 0, y: 10, z: -50 });
+
+    // Store initial positions
+    const initialZ = [];
+    for (let i = 0; i < avalanche.count; i++) {
+      initialZ.push(avalanche.positions[i * 3 + 2]);
     }
-  }
-  assert(movedDownhill > avalanche.count * 0.8, 'Most boulders should move downhill');
-});
 
-// Test 5: Burial Detection
-runTest('Burial Detection (Collision)', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  // Manually place a boulder at the player position
-  avalanche.active = true;
-  avalanche.positions[0] = 0;  // x
-  avalanche.positions[1] = 5;  // y
-  avalanche.positions[2] = -50; // z
-  avalanche.sizes[0] = 1;
-  
-  // Player at same position
-  const playerAtBoulder = { x: 0, y: 5, z: -50 };
-  assert(avalanche.checkBurial(playerAtBoulder), 'Should detect burial when player at boulder');
-  
-  // Player far away
-  const playerFarAway = { x: 100, y: 5, z: 100 };
-  assert(!avalanche.checkBurial(playerFarAway), 'Should not detect burial when player far away');
-});
-
-// Test 6: Closest Distance Calculation
-runTest('Closest Distance Calculation', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 3);
-  
-  avalanche.active = true;
-  // Place all boulders at known positions
-  avalanche.positions[0] = 10; avalanche.positions[1] = 0; avalanche.positions[2] = 0;
-  avalanche.positions[3] = 20; avalanche.positions[4] = 0; avalanche.positions[5] = 0;
-  avalanche.positions[6] = 30; avalanche.positions[7] = 0; avalanche.positions[8] = 0;
-  
-  const playerPos = { x: 0, y: 0, z: 0 };
-  const closest = avalanche.getClosestDistance(playerPos);
-  
-  assertApprox(closest, 10, 0.1, 'Closest distance should be 10');
-});
-
-// Test 7: Avalanche Passed Detection
-runTest('Avalanche Passed Detection', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  avalanche.active = true;
-  // Place all boulders far ahead of player (downhill)
-  for (let i = 0; i < avalanche.count; i++) {
-    avalanche.positions[i * 3 + 2] = -100; // Far downhill
-  }
-  
-  const playerPos = { x: 0, y: 0, z: -50 };
-  assert(avalanche.hasPassed(playerPos), 'Should detect avalanche has passed');
-  
-  // Reset and place boulders behind player
-  for (let i = 0; i < avalanche.count; i++) {
-    avalanche.positions[i * 3 + 2] = -30; // Behind player
-  }
-  assert(!avalanche.hasPassed(playerPos), 'Should not detect passed when boulders behind');
-});
-
-// Test 8: Avalanche Reset
-runTest('Avalanche Reset', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  avalanche.trigger({ x: 0, y: 10, z: -50 });
-  assertEquals(avalanche.active, true, 'Should be active after trigger');
-  
-  avalanche.reset();
-  assertEquals(avalanche.active, false, 'Should be inactive after reset');
-});
-
-// Test 9: No Burial When Inactive
-runTest('No Burial When Inactive', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  // Place boulder at player position but don't activate
-  avalanche.positions[0] = 0;
-  avalanche.positions[1] = 5;
-  avalanche.positions[2] = -50;
-  avalanche.sizes[0] = 1;
-  
-  const playerPos = { x: 0, y: 5, z: -50 };
-  assert(!avalanche.checkBurial(playerPos), 'Should not detect burial when avalanche inactive');
-});
-
-// Test 10: Distance Trigger Integration
-runTest('Distance Trigger Logic', () => {
-  // Simulate the trigger logic from snowglider.js
-  const startZ = -15;
-  const triggerDistance = 80;
-  let avalancheTriggered = false;
-  let lastAvalancheZ = startZ;
-  
-  // Simulate player moving downhill
-  const positions = [-15, -30, -50, -80, -100];
-  
-  for (const posZ of positions) {
-    const distanceTraveled = lastAvalancheZ - posZ;
-    
-    if (!avalancheTriggered && distanceTraveled > triggerDistance) {
-      avalancheTriggered = true;
+    // Update for several frames
+    for (let i = 0; i < 10; i++) {
+      avalanche.update(0.016); // ~60fps
     }
-  }
-  
-  assert(avalancheTriggered, 'Avalanche should trigger after traveling 80 units');
+
+    // Check that boulders moved downhill (negative Z)
+    let movedDownhill = 0;
+    for (let i = 0; i < avalanche.count; i++) {
+      if (avalanche.positions[i * 3 + 2] < initialZ[i]) {
+        movedDownhill++;
+      }
+    }
+    assert(movedDownhill > avalanche.count * 0.8, 'Most boulders should move downhill');
+  });
+
+  // Test 5: Burial Detection
+  runTest('Burial Detection (Collision)', () => {
+    const avalanche = makeSystem(10);
+
+    // Manually place a boulder at the player position
+    avalanche.active = true;
+    avalanche.positions[0] = 0;  // x
+    avalanche.positions[1] = 5;  // y
+    avalanche.positions[2] = -50; // z
+    avalanche.sizes[0] = 1;
+
+    // Player at same position
+    const playerAtBoulder = { x: 0, y: 5, z: -50 };
+    assert(avalanche.checkBurial(playerAtBoulder), 'Should detect burial when player at boulder');
+
+    // Player far away
+    const playerFarAway = { x: 100, y: 5, z: 100 };
+    assert(!avalanche.checkBurial(playerFarAway), 'Should not detect burial when player far away');
+  });
+
+  // Test 6: Closest Distance Calculation
+  runTest('Closest Distance Calculation', () => {
+    const avalanche = makeSystem(3);
+
+    avalanche.active = true;
+    // Place all boulders at known positions
+    avalanche.positions[0] = 10; avalanche.positions[1] = 0; avalanche.positions[2] = 0;
+    avalanche.positions[3] = 20; avalanche.positions[4] = 0; avalanche.positions[5] = 0;
+    avalanche.positions[6] = 30; avalanche.positions[7] = 0; avalanche.positions[8] = 0;
+
+    const playerPos = { x: 0, y: 0, z: 0 };
+    const closest = avalanche.getClosestDistance(playerPos);
+
+    assertApprox(closest, 10, 0.1, 'Closest distance should be 10');
+  });
+
+  // Test 7: Avalanche Passed Detection
+  runTest('Avalanche Passed Detection', () => {
+    const avalanche = makeSystem(10);
+
+    avalanche.active = true;
+    // Place all boulders far ahead of player (downhill)
+    for (let i = 0; i < avalanche.count; i++) {
+      avalanche.positions[i * 3 + 2] = -100; // Far downhill
+    }
+
+    const playerPos = { x: 0, y: 0, z: -50 };
+    assert(avalanche.hasPassed(playerPos), 'Should detect avalanche has passed');
+
+    // Reset and place boulders behind player
+    for (let i = 0; i < avalanche.count; i++) {
+      avalanche.positions[i * 3 + 2] = -30; // Behind player
+    }
+    assert(!avalanche.hasPassed(playerPos), 'Should not detect passed when boulders behind');
+  });
+
+  // Test 8: Avalanche Reset
+  runTest('Avalanche Reset', () => {
+    const avalanche = makeSystem(10);
+
+    avalanche.trigger({ x: 0, y: 10, z: -50 });
+    assertEquals(avalanche.active, true, 'Should be active after trigger');
+
+    avalanche.reset();
+    assertEquals(avalanche.active, false, 'Should be inactive after reset');
+  });
+
+  // Test 9: No Burial When Inactive
+  runTest('No Burial When Inactive', () => {
+    const avalanche = makeSystem(10);
+
+    // Place boulder at player position but don't activate
+    avalanche.positions[0] = 0;
+    avalanche.positions[1] = 5;
+    avalanche.positions[2] = -50;
+    avalanche.sizes[0] = 1;
+
+    const playerPos = { x: 0, y: 5, z: -50 };
+    assert(!avalanche.checkBurial(playerPos), 'Should not detect burial when avalanche inactive');
+  });
+
+  // Test 10: Distance Trigger Integration
+  runTest('Distance Trigger Logic', () => {
+    // Simulate the trigger logic from snowglider.js
+    const startZ = -15;
+    const triggerDistance = 80;
+    let avalancheTriggered = false;
+    const lastAvalancheZ = startZ;
+
+    // Simulate player moving downhill
+    const positions = [-15, -30, -50, -80, -100];
+
+    for (const posZ of positions) {
+      const distanceTraveled = lastAvalancheZ - posZ;
+
+      if (!avalancheTriggered && distanceTraveled > triggerDistance) {
+        avalancheTriggered = true;
+      }
+    }
+
+    assert(avalancheTriggered, 'Avalanche should trigger after traveling 80 units');
+  });
+
+  // Test 11: Real module disables frustum culling (r160 regression guard)
+  // From three r160 an InstancedMesh frustum-culls against bounds cached while
+  // _hideAll() parks the boulders offscreen, which would make a triggered
+  // avalanche invisible. The fix is mesh.frustumCulled = false in the
+  // constructor — assert it on the real mesh built with real three.
+  runTest('Real AvalancheSystem disables frustum culling (r160)', () => {
+    const realSystem = makeSystem(8);
+    assert(realSystem.mesh && realSystem.mesh.isInstancedMesh === true,
+      'avalanche.js should build a real THREE.InstancedMesh');
+    assertEquals(realSystem.mesh.frustumCulled, false,
+      'InstancedMesh.frustumCulled must be false so hidden-then-moved boulders are not culled');
+  });
+
+  // Test 12: Mesh is added to the provided scene
+  runTest('Avalanche mesh is added to the scene', () => {
+    const scene = new THREE.Scene();
+    const avalanche = new AvalancheSystem(scene, 8);
+    assert(scene.children.includes(avalanche.mesh),
+      'Constructor should add its InstancedMesh to the scene');
+    avalanche.dispose();
+    assert(!scene.children.includes(avalanche.mesh),
+      'dispose() should remove the mesh from the scene');
+  });
+
+  // Print test summary
+  console.log(`\n==================================`);
+  console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
+
+  // Exit with appropriate code for CI integration
+  process.exit(failCount > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Avalanche test harness crashed:', err);
+  process.exit(1);
 });
-
-// Test 11: Real module disables frustum culling (r160 regression guard)
-// The tests above mirror the logic in a local class; this one loads the ACTUAL
-// src/avalanche.js so it catches a regression in the shipped code: from three r160
-// an InstancedMesh frustum-culls against bounds cached while _hideAll() parks the
-// boulders offscreen, which would make a triggered avalanche invisible. The fix is
-// mesh.frustumCulled = false in the constructor — assert it on the real mesh.
-runTest('Real AvalancheSystem disables frustum culling (r160)', () => {
-  const fs = require('fs');
-  const path = require('path');
-  const src = fs.readFileSync(path.join(__dirname, '..', 'src', 'avalanche.js'), 'utf8');
-  // Evaluate the real source with the mock THREE and no window, returning Avalanche.
-  const factory = new Function('THREE', 'window', 'console', src + '\n;return Avalanche;');
-  const RealAvalanche = factory(mockTHREE, undefined, console);
-  assert(RealAvalanche && RealAvalanche.AvalancheSystem, 'real avalanche.js should export AvalancheSystem');
-  const realSystem = new RealAvalanche.AvalancheSystem(mockScene, 8);
-  assertEquals(realSystem.mesh.frustumCulled, false,
-    'InstancedMesh.frustumCulled must be false so hidden-then-moved boulders are not culled');
-});
-
-// Print test summary
-console.log(`\n==================================`);
-console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
-
-// Exit with appropriate code for CI integration
-process.exit(failCount > 0 ? 1 : 0);

--- a/vite.config.js
+++ b/vite.config.js
@@ -46,13 +46,12 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       input: {
-        // Keep the existing page as Vite's HTML entry so dist/index.html is
-        // emitted exactly as before (classic CDN + script-loader boot path).
-        index: path.resolve(rootDir, 'index.html'),
-        // Phase 2.0 (issue #84): a real ES-module bundle (three.js from npm)
-        // emitted alongside the page to stand up the bundling pipeline. It is
-        // not yet referenced by index.html; per-module conversions wire it in.
-        bundle: path.resolve(rootDir, 'src/main.js')
+        // index.html is Vite's HTML entry. As of Phase 2.1 (issue #84) it loads
+        // the ES-module bundle via `<script type="module" src="src/main.js">`,
+        // so Vite discovers src/main.js (and its imports: three + avalanche.js)
+        // from the page itself and emits one hashed chunk referenced by
+        // dist/index.html — no separate standalone input needed anymore.
+        index: path.resolve(rootDir, 'index.html')
       }
     }
   },


### PR DESCRIPTION
First per-module step of Phase 2: avalanche.js now imports three from npm
(`import * as THREE from 'three'`) and `export`s `AvalancheSystem` instead of
reading the CDN global and assigning `window.Avalanche`. It still publishes the
`window.Avalanche` bridge so the still-classic `snowglider.js` consumer keeps
working until it is converted (PR 2.9).

Loading: avalanche.js is removed from the classic `GAME_SCRIPT_ORDER` and now
loads via the bundle entry (`src/main.js`), which `index.html` includes as
`<script type="module">`. Deferred module execution runs the bridge before the
script-loader pulls in `snowglider.js`. An import map resolves the bare `three`
specifier when the page is served as raw source (puppeteer suite, `npm start`);
it is inert in the Vite build, where three is bundled into the hashed chunk.

Test migration: tests/avalanche-tests.js drops the `new Function(src)` +
mock-THREE injection (which can't load an `import`/`export` module) and the
parallel TestAvalancheSystem reimplementation. It now `import()`s the real
module and real three, exercising shipped code directly (12 checks, incl. the
r160 frustum-culling guard and a scene add/dispose check).

Also: drop the standalone `bundle` rollup input (index.html now discovers
main.js itself), remove the `Avalanche` eslint script-global, add avalanche.js
to the eslint module sourceType list, and update the migration doc status.

During the transition three.js loads twice (CDN UMD for classic scripts, npm
ESM for the bundle); verified offline that a UMD WebGLRenderer renders the
ESM-three InstancedMesh without error. Resolved when the classic loader is
retired (PR 2.10).

npm test, npm run lint, tsc --noEmit, and the Pages build all green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01REUMYpcJWpDwjE6cSHzPsw