### PR TITLE
refactor(ts): PR 2.1 — convert avalanche.js to an ES module (issue #84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Install dependencies: `npm ci`
 - Run development server: `npm start` (uses http-server on port 8080)
 - Open locally: `open index.html` or use URL parameters for tests
+  - **Caveat (Phase 2 migration):** modules already converted to ES modules
+    (`avalanche.js`, `course.js`, loaded via `src/main.js` as `<script type="module">`)
+    do **not** load over `file://` in Chrome — module + import-map loading is blocked
+    by CORS (null origin). Opening `index.html` directly still boots the rest of the
+    game, but those converted features are silently disabled (`snowglider.js` falls
+    into its "module not loaded" path). Use `npm start` (or `npm run build` + serve
+    `dist/`) to exercise the full game. This is an intended consequence of the move to
+    a bundler/server run model; `file://` direct-open is being retired by PR 2.10.
 - Run lint: `npm run lint` (eslint)
 - Run all Node tests: `npm test`
 - Run Node tests with coverage: `npm run test:coverage`

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -4,15 +4,25 @@
 
 ## Status
 
-- **Current:** Phase 1 **complete and hardened.** Every `src/**/*.js` carries `// @ts-check`,
-  `tsc --noEmit` is green and **blocking in CI**, and `tsconfig` now sets `"checkJs": true` so any
-  *new* source file is type-checked by default (the per-file directives are now a belt-and-suspenders
-  ratchet, not the gate). Still classic `<script>` modules (global namespaces), three.js **r160**
-  loaded as a CDN global. `auth.js` / `scores.js` are ES modules for Firebase.
-- **Build today:** a Vite step exists but currently only **copies** the static source tree into
-  `dist/` (see `vite.config.js` `copyStaticAppFiles`) — it does **not** yet bundle an ES-module
-  graph. `index.html` still loads CDN `THREE` and injects `src/*.js` via `src/boot/script-loader.js`.
-  Turning that copy step into a real module bundle is the substance of Phase 2.
+- **Current:** Phase 1 **complete and hardened**; **Phase 2 in progress** (see issue #84 for the
+  per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking in
+  CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
+  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry) and
+  **`src/avalanche.js`** are now ES modules too. The remaining game modules are still classic
+  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+- **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
+  `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
+  each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
+  still copies the static tree so the **classic CDN + script-loader path keeps booting the game**
+  during the staged conversion. Until the loader is retired (PR 2.10), converted modules also load
+  through the bundle and re-publish their `window.*` namespace so the still-classic `snowglider.js`
+  keeps finding them — which means three.js is loaded twice transitionally (CDN UMD for classic
+  scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
+  An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
+  as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
+- **Converted so far (PR 2.1):** `src/avalanche.js` — `import * as THREE from 'three'` + `export class
+  AvalancheSystem`. Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and
+  real three instead of the old `new Function(src)` + mock-THREE injection.
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -7,9 +7,10 @@
 - **Current:** Phase 1 **complete and hardened**; **Phase 2 in progress** (see issue #84 for the
   per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking in
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
-  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry) and
-  **`src/avalanche.js`** are now ES modules too. The remaining game modules are still classic
-  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
+  **`src/avalanche.js`** and **`src/course.js`** are now ES modules too. The remaining game modules
+  are still classic `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160**
+  as a CDN global.
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
@@ -20,9 +21,16 @@
   scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
   An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
   as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
-- **Converted so far (PR 2.1):** `src/avalanche.js` — `import * as THREE from 'three'` + `export class
-  AvalancheSystem`. Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and
-  real three instead of the old `new Function(src)` + mock-THREE injection.
+- **Converted so far:**
+  - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
+    Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead
+    of the old `new Function(src)` + mock-THREE injection.
+  - **PR 2.2 — `src/course.js`:** `import * as THREE from 'three'` + `export const CourseModule`. Its
+    headless coverage (`tests/verification/dom_smoke_test.js`) now `import()`s the real module + real
+    three for the CourseModule section; the still-classic `effects.js` keeps the mock-THREE
+    `new Function` loader there until it is converted. Note `snowglider.js` reads `CourseModule` by
+    **bare** name (not just `window.CourseModule`), so its eslint global + `types/globals.d.ts`
+    declaration are kept (like `AuthModule`/`ScoresModule`) until `snowglider.js` is converted (PR 2.9).
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -21,6 +21,13 @@
   scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
   An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
   as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
+  - **`file://` caveat:** because converted modules load via `<script type="module">`, opening
+    `index.html` directly (`file://`) no longer loads them — Chrome blocks module + import-map loading
+    from a null origin (CORS). The classic-script part of the game still boots, but converted features
+    (avalanche, course) are silently disabled by `snowglider.js`'s "module not loaded" fallback. Use
+    `npm start` or a build to run the full game. This is an intended consequence of the bundler/server
+    run model (`file://` direct-open is retired by PR 2.10), not a regression; it was raised in Codex
+    review of PR 2.1 and applies equally to every later conversion.
 - **Converted so far:**
   - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
     Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,6 @@ module.exports = [
         ...globals.node,
         AudioModule: "readonly",
         AuthModule: "readonly",
-        Avalanche: "readonly",
         Camera: "readonly",
         Controls: "readonly",
         CourseModule: "readonly",
@@ -72,7 +71,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/main.js", "src/scores.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/main.js", "src/scores.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,10 @@ module.exports = [
         AuthModule: "readonly",
         Camera: "readonly",
         Controls: "readonly",
+        // course.js is now an ES module (PR 2.2), but the still-classic
+        // snowglider.js reads `CourseModule` by bare name, so keep it declared
+        // here until snowglider.js is converted (PR 2.9). (Contrast avalanche.js,
+        // which is only read as `window.Avalanche`, so its global was dropped.)
         CourseModule: "readonly",
         EffectsModule: "readonly",
         Howl: "readonly",
@@ -71,7 +75,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/main.js", "src/scores.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/course.js", "src/main.js", "src/scores.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,22 @@
   <meta name="build-id" content="2025.10.06-mobile-audio-v3">
   <title>Skiing Snowman</title>
   <link rel="stylesheet" href="styles/main.css">
+  <!--
+    Import map for the ES-module bundle path (issue #84, Phase 2). It only takes
+    effect when index.html is served as raw source (the puppeteer suite and
+    `npm start`), where converted modules' bare `import * as THREE from 'three'`
+    needs a resolvable URL. In the Vite build that ships to snowglider.ai, three
+    is bundled into the hashed chunk, so this map is inert there. Pinned to the
+    same r160 as the classic CDN <script> below to avoid version skew while both
+    load paths coexist (the classic loader is retired in PR 2.10).
+  -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.module.min.js"
+    }
+  }
+  </script>
   <script src="src/boot/local-auth.js"></script>
   <script src="src/boot/firebase-bootstrap.js"></script>
 </head>
@@ -147,6 +163,14 @@
   <div id="leaderboard" style="display:none;"></div>
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.min.js" integrity="sha512-vnmn/Qqn6aG0POAc9mIGzjq0IybrvxJXYDafNvp9JSnDGxeF3pbkSqLvf+YGd5ku63pT7sa/jxHn7/d0mU8+tA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <!--
+    ES-module bundle entry (issue #84, Phase 2). Deferred like every module
+    script, so it runs after the classic CDN three.js above is in place but
+    before DOMContentLoaded — i.e. before script-loader.js pulls in the classic
+    game modules. Converted modules (avalanche.js so far) publish their
+    window.* bridge here so the still-classic snowglider.js keeps finding them.
+  -->
+  <script type="module" src="src/main.js"></script>
   <!-- Audio: Simplified implementation using native HTML5 Audio (no library dependencies) -->
   <script src="src/boot/script-loader.js"></script>
   <script src="src/ui/start-menu.js"></script>

--- a/src/avalanche.js
+++ b/src/avalanche.js
@@ -1,8 +1,16 @@
 // @ts-check
 // avalanche.js - Simple avalanche system for Snowglider
 // Triggered when player travels far enough downhill - burial = game over
+//
+// Phase 2.1 (issue #84): first module converted off the classic global model.
+// `THREE` now comes from the npm package via a real ES-module import instead of
+// the CDN global, and the class is `export`ed. The window.Avalanche assignment
+// below is kept so the still-classic consumer (snowglider.js, converted last in
+// PR 2.9) keeps working during the staged migration; it is loaded into the page
+// through the bundle entry (src/main.js) rather than the classic script-loader.
+import * as THREE from 'three';
 
-class AvalancheSystem {
+export class AvalancheSystem {
   constructor(scene, count = 120) {
     this.scene = scene;
     this.count = count;
@@ -216,7 +224,9 @@ class AvalancheSystem {
   }
 }
 
-// Export globally like other modules
+// Backward-compat global export for the still-classic consumer (snowglider.js
+// reads `window.Avalanche.AvalancheSystem`). Drop this once snowglider.js is
+// converted to import AvalancheSystem directly (PR 2.9, issue #84).
 const Avalanche = {
   AvalancheSystem
 };

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -8,7 +8,8 @@
     'src/snowman.js',
     'src/audio.js',
     'src/controls.js',
-    'src/avalanche.js',
+    // avalanche.js converted to an ES module (issue #84, PR 2.1); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/effects.js',
     'src/course.js',
     'src/snowglider.js'

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -11,7 +11,8 @@
     // avalanche.js converted to an ES module (issue #84, PR 2.1); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
     'src/effects.js',
-    'src/course.js',
+    // course.js converted to an ES module (issue #84, PR 2.2); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/snowglider.js'
   ];
 

--- a/src/course.js
+++ b/src/course.js
@@ -15,8 +15,17 @@
 //     system; they exist to mark the line and the split points.
 //   - Best splits and the best-run trajectory are persisted in localStorage and only
 //     committed when a run sets a new personal best, so the ghost is always your best.
+//
+// Phase 2.2 (issue #84): second module converted off the classic global model.
+// `THREE` now comes from the npm package via a real ES-module import instead of
+// the CDN global, and `CourseModule` is `export`ed. The window.CourseModule
+// assignment below is kept so the still-classic consumer (snowglider.js, which
+// reads it by bare name and as window.CourseModule, converted last in PR 2.9)
+// keeps working during the staged migration; it is loaded into the page through
+// the bundle entry (src/main.js) rather than the classic script-loader.
+import * as THREE from 'three';
 
-const CourseModule = (function () {
+export const CourseModule = (function () {
   'use strict';
 
   // --- Course geometry (world units; 1 unit == 1 metre for the HUD) ---
@@ -584,6 +593,9 @@ const CourseModule = (function () {
   };
 })();
 
+// Backward-compat global export for the still-classic consumer (snowglider.js
+// reads `CourseModule`/`window.CourseModule`). Drop this once snowglider.js is
+// converted to import CourseModule directly (PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
   window.CourseModule = CourseModule;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,10 +3,15 @@ import * as THREE from 'three';
 
 // Phase 2.0 (issue #84): a real ES-module entry that Vite bundles into a
 // hashed asset, importing three.js from the npm package instead of the CDN
-// global. The live game still boots through the classic CDN + script-loader
-// path in index.html until the per-module conversions (PR 2.1 onward) move
-// each game module onto this bundle. This entry exists only to stand up and
-// verify the bundling pipeline without changing how the game currently loads.
+// global. Per-module conversions (PR 2.1 onward) move each game module onto
+// this bundle, which index.html now loads as `<script type="module">`.
+//
+// Phase 2.1: avalanche.js is the first converted module. Importing it here for
+// its side effect runs its `window.Avalanche = …` bridge before the classic
+// script-loader pulls in snowglider.js, so the still-classic consumer keeps
+// finding the avalanche system. As more modules convert, add them here too
+// until the classic loader is retired (PR 2.10).
+import './avalanche.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,9 @@ import * as THREE from 'three';
 // finding the avalanche system. As more modules convert, add them here too
 // until the classic loader is retired (PR 2.10).
 import './avalanche.js';
+// Phase 2.2: course.js, imported for its `window.CourseModule = …` bridge so the
+// still-classic snowglider.js keeps finding the course system.
+import './course.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/tests/avalanche-tests.js
+++ b/tests/avalanche-tests.js
@@ -1,175 +1,20 @@
 /**
- * Avalanche system tests for SnowGlider
+ * Avalanche system tests for SnowGlider.
+ *
+ * Phase 2.1 (issue #84): these run against the REAL `src/avalanche.js` ES module
+ * and real three.js from npm. The previous version evaluated the source with
+ * `new Function(src)` and a hand-rolled THREE mock plus a parallel
+ * `TestAvalancheSystem` reimplementation; that injection pattern can't load a
+ * module that uses `import`/`export`, so it's gone. We now `import()` the actual
+ * class and exercise it directly — every assertion validates shipped code.
+ *
+ * three's geometry/material/mesh constructors need no WebGL context, so the real
+ * AvalancheSystem constructs fine headless under Node (no renderer involved).
  */
 
-// Mock THREE.js objects for testing
-const mockTHREE = {
-  Object3D: class {
-    constructor() {
-      this.position = { x: 0, y: 0, z: 0, set: function(x, y, z) { this.x = x; this.y = y; this.z = z; } };
-      this.rotation = { x: 0, y: 0, z: 0, set: function(x, y, z) { this.x = x; this.y = y; this.z = z; } };
-      this.scale = { setScalar: function() {} };
-      this.matrix = {};
-    }
-    updateMatrix() {}
-  },
-  IcosahedronGeometry: class {
-    dispose() {}
-  },
-  MeshStandardMaterial: class {
-    dispose() {}
-  },
-  InstancedMesh: class {
-    constructor() {
-      this.instanceMatrix = { setUsage: function() {}, needsUpdate: false };
-      this.castShadow = false;
-      this.receiveShadow = false;
-      this.frustumCulled = true; // three default; avalanche.js must turn this off (r160 culling)
-    }
-    setMatrixAt() {}
-  },
-  DynamicDrawUsage: 35048
-};
+'use strict';
 
-// Set up global THREE mock
-global.THREE = mockTHREE;
-
-// Mock scene
-const mockScene = {
-  children: [],
-  add: function(obj) { this.children.push(obj); },
-  remove: function(obj) { 
-    const idx = this.children.indexOf(obj);
-    if (idx > -1) this.children.splice(idx, 1);
-  }
-};
-
-// Simple AvalancheSystem implementation for testing (mirrors avalanche.js logic)
-class TestAvalancheSystem {
-  constructor(scene, count = 120) {
-    this.scene = scene;
-    this.count = count;
-    this.active = false;
-    this.getTerrainHeight = null;
-    
-    // Physics data arrays
-    this.positions = new Float32Array(count * 3);
-    this.velocities = new Float32Array(count * 3);
-    this.sizes = new Float32Array(count);
-    
-    // Initialize sizes
-    for (let i = 0; i < count; i++) {
-      this.sizes[i] = 0.8; // Default size for testing
-    }
-  }
-  
-  setTerrainFunction(fn) {
-    this.getTerrainHeight = fn;
-  }
-  
-  trigger(playerPos) {
-    this.active = true;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      
-      // Spawn behind player (uphill)
-      const angle = (Math.random() - 0.5) * Math.PI * 0.6;
-      const dist = 25 + Math.random() * 15;
-      
-      this.positions[idx]     = playerPos.x + Math.sin(angle) * dist;
-      this.positions[idx + 1] = playerPos.y + 8 + Math.random() * 6;
-      this.positions[idx + 2] = playerPos.z + dist * Math.cos(angle);
-      
-      // Velocity toward player (downhill)
-      this.velocities[idx]     = (Math.random() - 0.5) * 2;
-      this.velocities[idx + 1] = 0;
-      this.velocities[idx + 2] = -(8 + Math.random() * 4);
-      
-      this.sizes[i] = 0.4 + Math.random() * 1.2;
-    }
-  }
-  
-  update(dt) {
-    if (!this.active) return;
-    
-    const gravity = 18;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      
-      // Apply gravity
-      this.velocities[idx + 1] -= gravity * dt;
-      
-      // Update positions
-      this.positions[idx]     += this.velocities[idx] * dt;
-      this.positions[idx + 1] += this.velocities[idx + 1] * dt;
-      this.positions[idx + 2] += this.velocities[idx + 2] * dt;
-      
-      // Ground collision
-      let floorY = 0;
-      if (this.getTerrainHeight) {
-        floorY = this.getTerrainHeight(this.positions[idx], this.positions[idx + 2]);
-      }
-      
-      if (this.positions[idx + 1] < floorY + this.sizes[i]) {
-        this.positions[idx + 1] = floorY + this.sizes[i];
-        this.velocities[idx + 1] *= -0.25;
-      }
-    }
-  }
-  
-  checkBurial(playerPos, hitRadius = 2) {
-    if (!this.active) return false;
-    
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      const dx = this.positions[idx] - playerPos.x;
-      const dy = this.positions[idx + 1] - playerPos.y;
-      const dz = this.positions[idx + 2] - playerPos.z;
-      const distSq = dx * dx + dy * dy + dz * dz;
-      const threshold = hitRadius + this.sizes[i];
-      
-      if (distSq < threshold * threshold) {
-        return true;
-      }
-    }
-    return false;
-  }
-  
-  getClosestDistance(playerPos) {
-    if (!this.active) return Infinity;
-    
-    let minDist = Infinity;
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      const dx = this.positions[idx] - playerPos.x;
-      const dz = this.positions[idx + 2] - playerPos.z;
-      const dist = Math.sqrt(dx * dx + dz * dz);
-      if (dist < minDist) minDist = dist;
-    }
-    return minDist;
-  }
-  
-  hasPassed(playerPos) {
-    if (!this.active) return false;
-    
-    let passedCount = 0;
-    for (let i = 0; i < this.count; i++) {
-      const idx = i * 3;
-      if (this.positions[idx + 2] < playerPos.z - 10) {
-        passedCount++;
-      }
-    }
-    return passedCount > this.count * 0.8;
-  }
-  
-  reset() {
-    this.active = false;
-  }
-}
-
-// Custom assert functions
+// Custom assert helpers
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message || 'Assertion failed');
@@ -191,7 +36,6 @@ function assertApprox(a, b, tolerance, message) {
   return true;
 }
 
-// Run tests
 let passCount = 0;
 let failCount = 0;
 
@@ -207,204 +51,223 @@ function runTest(name, testFn) {
   }
 }
 
-console.log('\n🏔️ SNOWGLIDER AVALANCHE TESTS 🏔️');
-console.log('==================================\n');
+async function main() {
+  // Real three.js (npm) and the real avalanche module under test.
+  const THREE = await import('three');
+  const { AvalancheSystem } = await import('../src/avalanche.js');
 
-// Test 1: Avalanche Initialization
-runTest('Avalanche Initialization', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 50);
-  
-  assertEquals(avalanche.count, 50, 'Avalanche should have specified count');
-  assertEquals(avalanche.active, false, 'Avalanche should start inactive');
-  assert(avalanche.positions instanceof Float32Array, 'Positions should be Float32Array');
-  assert(avalanche.velocities instanceof Float32Array, 'Velocities should be Float32Array');
-});
+  // Each test gets a fresh real scene; the system adds its InstancedMesh to it.
+  const makeSystem = (count) => new AvalancheSystem(new THREE.Scene(), count);
 
-// Test 2: Terrain Function Connection
-runTest('Terrain Function Connection', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  const mockTerrainFn = (x, z) => x * 0.1 + z * 0.1;
-  avalanche.setTerrainFunction(mockTerrainFn);
-  
-  assert(avalanche.getTerrainHeight !== null, 'Terrain function should be set');
-  assertApprox(avalanche.getTerrainHeight(10, 20), 3, 0.01, 'Terrain function should work');
-});
+  console.log('\n🏔️ SNOWGLIDER AVALANCHE TESTS 🏔️');
+  console.log('==================================\n');
 
-// Test 3: Avalanche Trigger
-runTest('Avalanche Trigger', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 20);
-  const playerPos = { x: 0, y: 10, z: -50 };
-  
-  assertEquals(avalanche.active, false, 'Should start inactive');
-  
-  avalanche.trigger(playerPos);
-  
-  assertEquals(avalanche.active, true, 'Should be active after trigger');
-  
-  // Check that boulders are spawned behind player (positive Z offset)
-  let behindCount = 0;
-  for (let i = 0; i < avalanche.count; i++) {
-    if (avalanche.positions[i * 3 + 2] > playerPos.z) {
-      behindCount++;
+  // Test 1: Avalanche Initialization
+  runTest('Avalanche Initialization', () => {
+    const avalanche = makeSystem(50);
+
+    assertEquals(avalanche.count, 50, 'Avalanche should have specified count');
+    assertEquals(avalanche.active, false, 'Avalanche should start inactive');
+    assert(avalanche.positions instanceof Float32Array, 'Positions should be Float32Array');
+    assert(avalanche.velocities instanceof Float32Array, 'Velocities should be Float32Array');
+  });
+
+  // Test 2: Terrain Function Connection
+  runTest('Terrain Function Connection', () => {
+    const avalanche = makeSystem(10);
+
+    const mockTerrainFn = (x, z) => x * 0.1 + z * 0.1;
+    avalanche.setTerrainFunction(mockTerrainFn);
+
+    assert(avalanche.getTerrainHeight !== null, 'Terrain function should be set');
+    assertApprox(avalanche.getTerrainHeight(10, 20), 3, 0.01, 'Terrain function should work');
+  });
+
+  // Test 3: Avalanche Trigger
+  runTest('Avalanche Trigger', () => {
+    const avalanche = makeSystem(20);
+    const playerPos = { x: 0, y: 10, z: -50 };
+
+    assertEquals(avalanche.active, false, 'Should start inactive');
+
+    avalanche.trigger(playerPos);
+
+    assertEquals(avalanche.active, true, 'Should be active after trigger');
+
+    // Check that boulders are spawned behind player (positive Z offset)
+    let behindCount = 0;
+    for (let i = 0; i < avalanche.count; i++) {
+      if (avalanche.positions[i * 3 + 2] > playerPos.z) {
+        behindCount++;
+      }
     }
-  }
-  assert(behindCount > avalanche.count * 0.8, 'Most boulders should spawn behind player');
-});
+    assert(behindCount > avalanche.count * 0.8, 'Most boulders should spawn behind player');
+  });
 
-// Test 4: Avalanche Physics Update
-runTest('Avalanche Physics Update', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  avalanche.setTerrainFunction(() => 0); // Flat terrain
-  
-  avalanche.trigger({ x: 0, y: 10, z: -50 });
-  
-  // Store initial positions
-  const initialZ = [];
-  for (let i = 0; i < avalanche.count; i++) {
-    initialZ.push(avalanche.positions[i * 3 + 2]);
-  }
-  
-  // Update for several frames
-  for (let i = 0; i < 10; i++) {
-    avalanche.update(0.016); // ~60fps
-  }
-  
-  // Check that boulders moved downhill (negative Z)
-  let movedDownhill = 0;
-  for (let i = 0; i < avalanche.count; i++) {
-    if (avalanche.positions[i * 3 + 2] < initialZ[i]) {
-      movedDownhill++;
+  // Test 4: Avalanche Physics Update
+  runTest('Avalanche Physics Update', () => {
+    const avalanche = makeSystem(10);
+    avalanche.setTerrainFunction(() => 0); // Flat terrain
+
+    avalanche.trigger({ x: 0, y: 10, z: -50 });
+
+    // Store initial positions
+    const initialZ = [];
+    for (let i = 0; i < avalanche.count; i++) {
+      initialZ.push(avalanche.positions[i * 3 + 2]);
     }
-  }
-  assert(movedDownhill > avalanche.count * 0.8, 'Most boulders should move downhill');
-});
 
-// Test 5: Burial Detection
-runTest('Burial Detection (Collision)', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  // Manually place a boulder at the player position
-  avalanche.active = true;
-  avalanche.positions[0] = 0;  // x
-  avalanche.positions[1] = 5;  // y
-  avalanche.positions[2] = -50; // z
-  avalanche.sizes[0] = 1;
-  
-  // Player at same position
-  const playerAtBoulder = { x: 0, y: 5, z: -50 };
-  assert(avalanche.checkBurial(playerAtBoulder), 'Should detect burial when player at boulder');
-  
-  // Player far away
-  const playerFarAway = { x: 100, y: 5, z: 100 };
-  assert(!avalanche.checkBurial(playerFarAway), 'Should not detect burial when player far away');
-});
-
-// Test 6: Closest Distance Calculation
-runTest('Closest Distance Calculation', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 3);
-  
-  avalanche.active = true;
-  // Place all boulders at known positions
-  avalanche.positions[0] = 10; avalanche.positions[1] = 0; avalanche.positions[2] = 0;
-  avalanche.positions[3] = 20; avalanche.positions[4] = 0; avalanche.positions[5] = 0;
-  avalanche.positions[6] = 30; avalanche.positions[7] = 0; avalanche.positions[8] = 0;
-  
-  const playerPos = { x: 0, y: 0, z: 0 };
-  const closest = avalanche.getClosestDistance(playerPos);
-  
-  assertApprox(closest, 10, 0.1, 'Closest distance should be 10');
-});
-
-// Test 7: Avalanche Passed Detection
-runTest('Avalanche Passed Detection', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  avalanche.active = true;
-  // Place all boulders far ahead of player (downhill)
-  for (let i = 0; i < avalanche.count; i++) {
-    avalanche.positions[i * 3 + 2] = -100; // Far downhill
-  }
-  
-  const playerPos = { x: 0, y: 0, z: -50 };
-  assert(avalanche.hasPassed(playerPos), 'Should detect avalanche has passed');
-  
-  // Reset and place boulders behind player
-  for (let i = 0; i < avalanche.count; i++) {
-    avalanche.positions[i * 3 + 2] = -30; // Behind player
-  }
-  assert(!avalanche.hasPassed(playerPos), 'Should not detect passed when boulders behind');
-});
-
-// Test 8: Avalanche Reset
-runTest('Avalanche Reset', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  avalanche.trigger({ x: 0, y: 10, z: -50 });
-  assertEquals(avalanche.active, true, 'Should be active after trigger');
-  
-  avalanche.reset();
-  assertEquals(avalanche.active, false, 'Should be inactive after reset');
-});
-
-// Test 9: No Burial When Inactive
-runTest('No Burial When Inactive', () => {
-  const avalanche = new TestAvalancheSystem(mockScene, 10);
-  
-  // Place boulder at player position but don't activate
-  avalanche.positions[0] = 0;
-  avalanche.positions[1] = 5;
-  avalanche.positions[2] = -50;
-  avalanche.sizes[0] = 1;
-  
-  const playerPos = { x: 0, y: 5, z: -50 };
-  assert(!avalanche.checkBurial(playerPos), 'Should not detect burial when avalanche inactive');
-});
-
-// Test 10: Distance Trigger Integration
-runTest('Distance Trigger Logic', () => {
-  // Simulate the trigger logic from snowglider.js
-  const startZ = -15;
-  const triggerDistance = 80;
-  let avalancheTriggered = false;
-  let lastAvalancheZ = startZ;
-  
-  // Simulate player moving downhill
-  const positions = [-15, -30, -50, -80, -100];
-  
-  for (const posZ of positions) {
-    const distanceTraveled = lastAvalancheZ - posZ;
-    
-    if (!avalancheTriggered && distanceTraveled > triggerDistance) {
-      avalancheTriggered = true;
+    // Update for several frames
+    for (let i = 0; i < 10; i++) {
+      avalanche.update(0.016); // ~60fps
     }
-  }
-  
-  assert(avalancheTriggered, 'Avalanche should trigger after traveling 80 units');
+
+    // Check that boulders moved downhill (negative Z)
+    let movedDownhill = 0;
+    for (let i = 0; i < avalanche.count; i++) {
+      if (avalanche.positions[i * 3 + 2] < initialZ[i]) {
+        movedDownhill++;
+      }
+    }
+    assert(movedDownhill > avalanche.count * 0.8, 'Most boulders should move downhill');
+  });
+
+  // Test 5: Burial Detection
+  runTest('Burial Detection (Collision)', () => {
+    const avalanche = makeSystem(10);
+
+    // Manually place a boulder at the player position
+    avalanche.active = true;
+    avalanche.positions[0] = 0;  // x
+    avalanche.positions[1] = 5;  // y
+    avalanche.positions[2] = -50; // z
+    avalanche.sizes[0] = 1;
+
+    // Player at same position
+    const playerAtBoulder = { x: 0, y: 5, z: -50 };
+    assert(avalanche.checkBurial(playerAtBoulder), 'Should detect burial when player at boulder');
+
+    // Player far away
+    const playerFarAway = { x: 100, y: 5, z: 100 };
+    assert(!avalanche.checkBurial(playerFarAway), 'Should not detect burial when player far away');
+  });
+
+  // Test 6: Closest Distance Calculation
+  runTest('Closest Distance Calculation', () => {
+    const avalanche = makeSystem(3);
+
+    avalanche.active = true;
+    // Place all boulders at known positions
+    avalanche.positions[0] = 10; avalanche.positions[1] = 0; avalanche.positions[2] = 0;
+    avalanche.positions[3] = 20; avalanche.positions[4] = 0; avalanche.positions[5] = 0;
+    avalanche.positions[6] = 30; avalanche.positions[7] = 0; avalanche.positions[8] = 0;
+
+    const playerPos = { x: 0, y: 0, z: 0 };
+    const closest = avalanche.getClosestDistance(playerPos);
+
+    assertApprox(closest, 10, 0.1, 'Closest distance should be 10');
+  });
+
+  // Test 7: Avalanche Passed Detection
+  runTest('Avalanche Passed Detection', () => {
+    const avalanche = makeSystem(10);
+
+    avalanche.active = true;
+    // Place all boulders far ahead of player (downhill)
+    for (let i = 0; i < avalanche.count; i++) {
+      avalanche.positions[i * 3 + 2] = -100; // Far downhill
+    }
+
+    const playerPos = { x: 0, y: 0, z: -50 };
+    assert(avalanche.hasPassed(playerPos), 'Should detect avalanche has passed');
+
+    // Reset and place boulders behind player
+    for (let i = 0; i < avalanche.count; i++) {
+      avalanche.positions[i * 3 + 2] = -30; // Behind player
+    }
+    assert(!avalanche.hasPassed(playerPos), 'Should not detect passed when boulders behind');
+  });
+
+  // Test 8: Avalanche Reset
+  runTest('Avalanche Reset', () => {
+    const avalanche = makeSystem(10);
+
+    avalanche.trigger({ x: 0, y: 10, z: -50 });
+    assertEquals(avalanche.active, true, 'Should be active after trigger');
+
+    avalanche.reset();
+    assertEquals(avalanche.active, false, 'Should be inactive after reset');
+  });
+
+  // Test 9: No Burial When Inactive
+  runTest('No Burial When Inactive', () => {
+    const avalanche = makeSystem(10);
+
+    // Place boulder at player position but don't activate
+    avalanche.positions[0] = 0;
+    avalanche.positions[1] = 5;
+    avalanche.positions[2] = -50;
+    avalanche.sizes[0] = 1;
+
+    const playerPos = { x: 0, y: 5, z: -50 };
+    assert(!avalanche.checkBurial(playerPos), 'Should not detect burial when avalanche inactive');
+  });
+
+  // Test 10: Distance Trigger Integration
+  runTest('Distance Trigger Logic', () => {
+    // Simulate the trigger logic from snowglider.js
+    const startZ = -15;
+    const triggerDistance = 80;
+    let avalancheTriggered = false;
+    const lastAvalancheZ = startZ;
+
+    // Simulate player moving downhill
+    const positions = [-15, -30, -50, -80, -100];
+
+    for (const posZ of positions) {
+      const distanceTraveled = lastAvalancheZ - posZ;
+
+      if (!avalancheTriggered && distanceTraveled > triggerDistance) {
+        avalancheTriggered = true;
+      }
+    }
+
+    assert(avalancheTriggered, 'Avalanche should trigger after traveling 80 units');
+  });
+
+  // Test 11: Real module disables frustum culling (r160 regression guard)
+  // From three r160 an InstancedMesh frustum-culls against bounds cached while
+  // _hideAll() parks the boulders offscreen, which would make a triggered
+  // avalanche invisible. The fix is mesh.frustumCulled = false in the
+  // constructor — assert it on the real mesh built with real three.
+  runTest('Real AvalancheSystem disables frustum culling (r160)', () => {
+    const realSystem = makeSystem(8);
+    assert(realSystem.mesh && realSystem.mesh.isInstancedMesh === true,
+      'avalanche.js should build a real THREE.InstancedMesh');
+    assertEquals(realSystem.mesh.frustumCulled, false,
+      'InstancedMesh.frustumCulled must be false so hidden-then-moved boulders are not culled');
+  });
+
+  // Test 12: Mesh is added to the provided scene
+  runTest('Avalanche mesh is added to the scene', () => {
+    const scene = new THREE.Scene();
+    const avalanche = new AvalancheSystem(scene, 8);
+    assert(scene.children.includes(avalanche.mesh),
+      'Constructor should add its InstancedMesh to the scene');
+    avalanche.dispose();
+    assert(!scene.children.includes(avalanche.mesh),
+      'dispose() should remove the mesh from the scene');
+  });
+
+  // Print test summary
+  console.log(`\n==================================`);
+  console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
+
+  // Exit with appropriate code for CI integration
+  process.exit(failCount > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Avalanche test harness crashed:', err);
+  process.exit(1);
 });
-
-// Test 11: Real module disables frustum culling (r160 regression guard)
-// The tests above mirror the logic in a local class; this one loads the ACTUAL
-// src/avalanche.js so it catches a regression in the shipped code: from three r160
-// an InstancedMesh frustum-culls against bounds cached while _hideAll() parks the
-// boulders offscreen, which would make a triggered avalanche invisible. The fix is
-// mesh.frustumCulled = false in the constructor — assert it on the real mesh.
-runTest('Real AvalancheSystem disables frustum culling (r160)', () => {
-  const fs = require('fs');
-  const path = require('path');
-  const src = fs.readFileSync(path.join(__dirname, '..', 'src', 'avalanche.js'), 'utf8');
-  // Evaluate the real source with the mock THREE and no window, returning Avalanche.
-  const factory = new Function('THREE', 'window', 'console', src + '\n;return Avalanche;');
-  const RealAvalanche = factory(mockTHREE, undefined, console);
-  assert(RealAvalanche && RealAvalanche.AvalancheSystem, 'real avalanche.js should export AvalancheSystem');
-  const realSystem = new RealAvalanche.AvalancheSystem(mockScene, 8);
-  assertEquals(realSystem.mesh.frustumCulled, false,
-    'InstancedMesh.frustumCulled must be false so hidden-then-moved boulders are not culled');
-});
-
-// Print test summary
-console.log(`\n==================================`);
-console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
-
-// Exit with appropriate code for CI integration
-process.exit(failCount > 0 ? 1 : 0);

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -1,7 +1,15 @@
 // dom_smoke_test.js
-// Load course.js + effects.js under jsdom with a mocked THREE, then exercise
-// init/reset/update/onFinish/avalanche/camera and assert sane behavior — headless
-// coverage for the two new modules without a browser. Requires jsdom (devDependency).
+// Headless coverage for course.js + effects.js under jsdom, without a browser.
+// Requires jsdom (devDependency).
+//
+// Phase 2.2 (issue #84): course.js is now an ES module that does
+// `import * as THREE from 'three'`, so it can no longer be evaluated with the
+// `new Function(src)` + mock-THREE injection used here — that pattern can't load
+// `import`/`export`. The CourseModule section now `import()`s the REAL module and
+// REAL three (three's geometry/material/texture constructors need no WebGL, so
+// they build fine headless under Node), exercising shipped code directly. The
+// still-classic effects.js keeps the mock-THREE `new Function` loader until it is
+// converted; switch it over the same way then.
 const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
@@ -57,102 +65,120 @@ class ColorMock { constructor() {} lerp() { return this; } }
 THREE.Color = ColorMock;
 global.THREE = THREE; window.THREE = THREE;
 
-// Load the modules into the jsdom global scope.
+// Load a still-classic module (effects.js) into the jsdom global scope with the
+// mock THREE. course.js is no longer loadable this way (it's an ES module) — it
+// is import()ed against real three in the CourseModule section below.
 function loadInWindow(file) {
   const code = fs.readFileSync(path.join(REPO, file), 'utf8');
   // Evaluate with access to our globals (THREE, document, window, localStorage).
-  const fn = new Function('THREE', 'document', 'window', 'localStorage', 'console', code + '\n;return (typeof CourseModule!=="undefined"?CourseModule:(typeof EffectsModule!=="undefined"?EffectsModule:null));');
+  const fn = new Function('THREE', 'document', 'window', 'localStorage', 'console', code + '\n;return (typeof EffectsModule!=="undefined"?EffectsModule:null);');
   return fn(THREE, window.document, window, global.localStorage, console);
 }
 
 let pass = 0, fail = 0;
 function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
 
-// ---- EffectsModule ----
-console.log('--- EffectsModule ---');
-const Effects = loadInWindow('src/effects.js');
-check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
-Effects.init();
-const banner = window.document.body.querySelector('div');
-check('init builds DOM overlays without throwing', !!banner);
-// Inactive avalanche hides things, active shows + sets danger
-Effects.updateAvalanche(false, Infinity);
-Effects.updateAvalanche(true, 40);
-Effects.updateAvalanche(true, 8); // very close
-check('updateAvalanche(active, near) runs', true);
-// Camera FOV widens with speed and shake offset returned
-const cam = { fov: 75, position: { x: 0, y: 0, z: 0 }, updateProjectionMatrix() { this._u = (this._u || 0) + 1; } };
-Effects.addShake(1.0);
-let off = Effects.tickCamera(cam, 1 / 60, 30);
-check('tickCamera returns an offset object', off && typeof off.x === 'number');
-check('high speed widens FOV above base 75', cam.fov > 75.0);
-Effects.reset();
-check('reset() runs without throwing', true);
+async function main() {
+  // ---- EffectsModule (still classic: mock THREE + new Function loader) ----
+  console.log('--- EffectsModule ---');
+  const Effects = loadInWindow('src/effects.js');
+  check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
+  Effects.init();
+  const banner = window.document.body.querySelector('div');
+  check('init builds DOM overlays without throwing', !!banner);
+  // Inactive avalanche hides things, active shows + sets danger
+  Effects.updateAvalanche(false, Infinity);
+  Effects.updateAvalanche(true, 40);
+  Effects.updateAvalanche(true, 8); // very close
+  check('updateAvalanche(active, near) runs', true);
+  // Camera FOV widens with speed and shake offset returned
+  const cam = { fov: 75, position: { x: 0, y: 0, z: 0 }, updateProjectionMatrix() { this._u = (this._u || 0) + 1; } };
+  Effects.addShake(1.0);
+  let off = Effects.tickCamera(cam, 1 / 60, 30);
+  check('tickCamera returns an offset object', off && typeof off.x === 'number');
+  check('high speed widens FOV above base 75', cam.fov > 75.0);
+  Effects.reset();
+  check('reset() runs without throwing', true);
 
-// ---- CourseModule ----
-console.log('\n--- CourseModule ---');
-const fakeCreateSnowman = () => { const g = new THREE.Group(); g.add(new THREE.Mesh()); return g; };
-const Course = loadInWindow('src/course.js');
-check('module exports init/update/onFinish', !!Course && typeof Course.update === 'function' && typeof Course.onFinish === 'function');
+  // ---- CourseModule (real ES module + real three, PR 2.2) ----
+  console.log('\n--- CourseModule ---');
+  // course.js now `import`s three from npm, so we import the REAL module + REAL
+  // three rather than evaluating the source with a mock. The fake snowman is a
+  // real three Group whose mesh carries a MeshStandardMaterial so buildGhost's
+  // material.clone()/color.lerp()/emissive path exercises shipped code.
+  const RealTHREE = await import('three');
+  const { CourseModule: Course } = await import('../../src/course.js');
+  const fakeCreateSnowman = () => {
+    const g = new RealTHREE.Group();
+    g.add(new RealTHREE.Mesh(new RealTHREE.BoxGeometry(1, 1, 1), new RealTHREE.MeshStandardMaterial()));
+    return g;
+  };
+  check('module exports init/update/onFinish', !!Course && typeof Course.update === 'function' && typeof Course.onFinish === 'function');
 
-const terrain = (x, z) => 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40) + (z < -30 ? (z + 30) * 0.12 : 0);
-Course.init({ scene: new THREE.Group(), getTerrainHeight: terrain, createSnowman: fakeCreateSnowman });
-check('init builds gates + HUD', true);
+  const terrain = (x, z) => 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40) + (z < -30 ? (z + 30) * 0.12 : 0);
+  Course.init({ scene: new RealTHREE.Scene(), getTerrainHeight: terrain, createSnowman: fakeCreateSnowman });
+  check('init builds gates + HUD', true);
 
-// Simulate a clean run reaching every split.
-global.localStorage.clear();
-Course.reset();
-const cfg = Course._config;
-const splitZ = cfg.splitPoints.map(s => s.z);
-let crossed = 0;
-const snowmanMock = { rotation: { y: Math.PI } };
-let t = 0;
-for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
-  t += 0.12; // ~ seconds; arbitrary monotonic clock
-  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t, snowmanMock);
-  // count how many split thresholds we've now passed
-  crossed = splitZ.filter(sz => z <= sz).length;
+  // Simulate a clean run reaching every split.
+  global.localStorage.clear();
+  Course.reset();
+  const cfg = Course._config;
+  const splitZ = cfg.splitPoints.map(s => s.z);
+  let crossed = 0;
+  const snowmanMock = { rotation: { y: Math.PI } };
+  let t = 0;
+  for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+    t += 0.12; // ~ seconds; arbitrary monotonic clock
+    Course.update({ x: 1.5, y: terrain(1.5, z), z }, t, snowmanMock);
+    // count how many split thresholds we've now passed
+    crossed = splitZ.filter(sz => z <= sz).length;
+  }
+  check('all checkpoints + finish are reachable', crossed === splitZ.length);
+
+  // First finish: should be a "first descent" (no previous best) and persist a ghost.
+  const panel1 = Course.onFinish(t, Infinity);
+  check('onFinish returns a result panel node', !!panel1 && panel1.id === 'courseResult');
+  check('ghost trajectory persisted to localStorage', !!global.localStorage.getItem('snowgliderGhost'));
+  check('best splits persisted to localStorage', !!global.localStorage.getItem('snowgliderBestSplits'));
+  const panelText1 = panel1.textContent || '';
+  check('first finish shows a medal/result text', /descent|record|Finish/i.test(panelText1));
+
+  // Gap 3 regression: the persisted ghost's final sample keeps the player's real x
+  // (not a hardcoded 0) so it doesn't snap to center at the line.
+  const ghostSaved = JSON.parse(global.localStorage.getItem('snowgliderGhost'));
+  const ghostLast = ghostSaved[ghostSaved.length - 1];
+  check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
+
+  // Second run, faster: should read as a new record and a ghost should now exist + interpolate.
+  Course.reset(); // loads the stored ghost AND best splits (Gap 2 fix)
+  let t2 = 0;
+  for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+    t2 += 0.09; // faster pace than run 1 (0.12)
+    Course.update({ x: 1.5, y: terrain(1.5, z), z }, t2, snowmanMock);
+  }
+  const previousBest = t; // run 1 total
+  const panel2 = Course.onFinish(t2, previousBest);
+  const panelText2 = panel2.textContent || '';
+  check('faster second run reports a new record', /record/i.test(panelText2));
+  check('result panel contains a split table (Δ Best)', /Δ Best/.test(panelText2));
+
+  // Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
+  // second run's result table shows real per-split deltas instead of the "—" placeholder.
+  // (Scope the check to the split table — the "X — new personal best!" line legitimately
+  // uses an em dash as a separator, so checking the whole panel would false-positive.)
+  const EM_DASH = String.fromCharCode(0x2014);
+  const deltaTable = panel2.lastElementChild; // split table is appended last in the panel
+  check('best-split deltas not stale after PB (Gap 2)',
+    !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
+
+  Course.hideHud();
+  check('hideHud() runs without throwing', true);
+
+  console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
 }
-check('all checkpoints + finish are reachable', crossed === splitZ.length);
 
-// First finish: should be a "first descent" (no previous best) and persist a ghost.
-const panel1 = Course.onFinish(t, Infinity);
-check('onFinish returns a result panel node', !!panel1 && panel1.id === 'courseResult');
-check('ghost trajectory persisted to localStorage', !!global.localStorage.getItem('snowgliderGhost'));
-check('best splits persisted to localStorage', !!global.localStorage.getItem('snowgliderBestSplits'));
-const panelText1 = panel1.textContent || '';
-check('first finish shows a medal/result text', /descent|record|Finish/i.test(panelText1));
-
-// Gap 3 regression: the persisted ghost's final sample keeps the player's real x
-// (not a hardcoded 0) so it doesn't snap to center at the line.
-const ghostSaved = JSON.parse(global.localStorage.getItem('snowgliderGhost'));
-const ghostLast = ghostSaved[ghostSaved.length - 1];
-check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
-
-// Second run, faster: should read as a new record and a ghost should now exist + interpolate.
-Course.reset(); // loads the stored ghost AND best splits (Gap 2 fix)
-let t2 = 0;
-for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
-  t2 += 0.09; // faster pace than run 1 (0.12)
-  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t2, snowmanMock);
-}
-const previousBest = t; // run 1 total
-const panel2 = Course.onFinish(t2, previousBest);
-const panelText2 = panel2.textContent || '';
-check('faster second run reports a new record', /record/i.test(panelText2));
-check('result panel contains a split table (Δ Best)', /Δ Best/.test(panelText2));
-
-// Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
-// second run's result table shows real per-split deltas instead of the "—" placeholder.
-// (Scope the check to the split table — the "X — new personal best!" line legitimately
-// uses an em dash as a separator, so checking the whole panel would false-positive.)
-const EM_DASH = String.fromCharCode(0x2014);
-const deltaTable = panel2.lastElementChild; // split table is appended last in the panel
-check('best-split deltas not stale after PB (Gap 2)',
-  !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
-
-Course.hideHud();
-check('hideHud() runs without throwing', true);
-
-console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
-process.exit(fail ? 1 : 0);
+main().catch((err) => {
+  console.error('Smoke test harness crashed:', err);
+  process.exit(1);
+});

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,7 +22,6 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
-  //   - course.js:    @ts-checked -> `CourseModule` lives in src/course.js, not here.
   //   - camera.js:    @ts-checked -> `Camera` (class) lives in src/camera.js, not here.
   //   - trees.js:     @ts-checked -> `Trees` + `getTerrainHeight`/`getTerrainGradient`
   //                   (top-level fns) live in src/trees.js, not here.
@@ -33,11 +32,14 @@ declare global {
   //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
   //                   (top-level fns) live in src/snowman.js, not here.
   //   - audio.js:     @ts-checked -> `AudioModule` lives in src/audio.js, not here.
-  // AuthModule/ScoresModule stay: auth.js/scores.js are ES modules (not script
-  // globals), so they don't define these as bare globals — kept loose for any
-  // consumer that reads them by bare name.
+  // AuthModule/ScoresModule/CourseModule stay: auth.js/scores.js (and, as of
+  // PR 2.2, course.js) are ES modules — their `CourseModule`/etc. are module-
+  // scoped, not script globals — yet the still-classic snowglider.js reads them
+  // by bare name. Keep them declared loose here until snowglider.js is converted
+  // (PR 2.9). (Once a module's bare consumer is gone, drop its entry.)
   const AuthModule: any;
   const ScoresModule: any;
+  const CourseModule: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;

--- a/vite.config.js
+++ b/vite.config.js
@@ -46,13 +46,12 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       input: {
-        // Keep the existing page as Vite's HTML entry so dist/index.html is
-        // emitted exactly as before (classic CDN + script-loader boot path).
-        index: path.resolve(rootDir, 'index.html'),
-        // Phase 2.0 (issue #84): a real ES-module bundle (three.js from npm)
-        // emitted alongside the page to stand up the bundling pipeline. It is
-        // not yet referenced by index.html; per-module conversions wire it in.
-        bundle: path.resolve(rootDir, 'src/main.js')
+        // index.html is Vite's HTML entry. As of Phase 2.1 (issue #84) it loads
+        // the ES-module bundle via `<script type="module" src="src/main.js">`,
+        // so Vite discovers src/main.js (and its imports: three + avalanche.js)
+        // from the page itself and emits one hashed chunk referenced by
+        // dist/index.html — no separate standalone input needed anymore.
+        index: path.resolve(rootDir, 'index.html')
       }
     }
   },


### PR DESCRIPTION
First per-module step of Phase 2: avalanche.js now imports three from npm
(`import * as THREE from 'three'`) and `export`s `AvalancheSystem` instead of
reading the CDN global and assigning `window.Avalanche`. It still publishes the
`window.Avalanche` bridge so the still-classic `snowglider.js` consumer keeps
working until it is converted (PR 2.9).

Loading: avalanche.js is removed from the classic `GAME_SCRIPT_ORDER` and now
loads via the bundle entry (`src/main.js`), which `index.html` includes as
`<script type="module">`. Deferred module execution runs the bridge before the
script-loader pulls in `snowglider.js`. An import map resolves the bare `three`
specifier when the page is served as raw source (puppeteer suite, `npm start`);
it is inert in the Vite build, where three is bundled into the hashed chunk.

Test migration: tests/avalanche-tests.js drops the `new Function(src)` +
mock-THREE injection (which can't load an `import`/`export` module) and the
parallel TestAvalancheSystem reimplementation. It now `import()`s the real
module and real three, exercising shipped code directly (12 checks, incl. the
r160 frustum-culling guard and a scene add/dispose check).

Also: drop the standalone `bundle` rollup input (index.html now discovers
main.js itself), remove the `Avalanche` eslint script-global, add avalanche.js
to the eslint module sourceType list, and update the migration doc status.

During the transition three.js loads twice (CDN UMD for classic scripts, npm
ESM for the bundle); verified offline that a UMD WebGLRenderer renders the
ESM-three InstancedMesh without error. Resolved when the classic loader is
retired (PR 2.10).

npm test, npm run lint, tsc --noEmit, and the Pages build all green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01REUMYpcJWpDwjE6cSHzPsw