### PR TITLE
refactor(ts): PR 2.2 — convert course.js to an ES module (issue #84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Install dependencies: `npm ci`
 - Run development server: `npm start` (uses http-server on port 8080)
 - Open locally: `open index.html` or use URL parameters for tests
+  - **Caveat (Phase 2 migration):** modules already converted to ES modules
+    (`avalanche.js`, `course.js`, loaded via `src/main.js` as `<script type="module">`)
+    do **not** load over `file://` in Chrome — module + import-map loading is blocked
+    by CORS (null origin). Opening `index.html` directly still boots the rest of the
+    game, but those converted features are silently disabled (`snowglider.js` falls
+    into its "module not loaded" path). Use `npm start` (or `npm run build` + serve
+    `dist/`) to exercise the full game. This is an intended consequence of the move to
+    a bundler/server run model; `file://` direct-open is being retired by PR 2.10.
 - Run lint: `npm run lint` (eslint)
 - Run all Node tests: `npm test`
 - Run Node tests with coverage: `npm run test:coverage`

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -7,9 +7,10 @@
 - **Current:** Phase 1 **complete and hardened**; **Phase 2 in progress** (see issue #84 for the
   per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking in
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
-  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry) and
-  **`src/avalanche.js`** are now ES modules too. The remaining game modules are still classic
-  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+  `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
+  **`src/avalanche.js`** and **`src/course.js`** are now ES modules too. The remaining game modules
+  are still classic `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160**
+  as a CDN global.
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
@@ -20,9 +21,16 @@
   scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
   An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
   as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
-- **Converted so far (PR 2.1):** `src/avalanche.js` — `import * as THREE from 'three'` + `export class
-  AvalancheSystem`. Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and
-  real three instead of the old `new Function(src)` + mock-THREE injection.
+- **Converted so far:**
+  - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
+    Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead
+    of the old `new Function(src)` + mock-THREE injection.
+  - **PR 2.2 — `src/course.js`:** `import * as THREE from 'three'` + `export const CourseModule`. Its
+    headless coverage (`tests/verification/dom_smoke_test.js`) now `import()`s the real module + real
+    three for the CourseModule section; the still-classic `effects.js` keeps the mock-THREE
+    `new Function` loader there until it is converted. Note `snowglider.js` reads `CourseModule` by
+    **bare** name (not just `window.CourseModule`), so its eslint global + `types/globals.d.ts`
+    declaration are kept (like `AuthModule`/`ScoresModule`) until `snowglider.js` is converted (PR 2.9).
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -21,6 +21,13 @@
   scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
   An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
   as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
+  - **`file://` caveat:** because converted modules load via `<script type="module">`, opening
+    `index.html` directly (`file://`) no longer loads them — Chrome blocks module + import-map loading
+    from a null origin (CORS). The classic-script part of the game still boots, but converted features
+    (avalanche, course) are silently disabled by `snowglider.js`'s "module not loaded" fallback. Use
+    `npm start` or a build to run the full game. This is an intended consequence of the bundler/server
+    run model (`file://` direct-open is retired by PR 2.10), not a regression; it was raised in Codex
+    review of PR 2.1 and applies equally to every later conversion.
 - **Converted so far:**
   - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
     Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead

--- a/docs/session-reports/PR-2.2-course-es-module-session.md
+++ b/docs/session-reports/PR-2.2-course-es-module-session.md
@@ -1,0 +1,170 @@
+# Session Report — PR 2.2: Convert `course.js` to an ES module
+
+**Repository:** `den-run-ai/snowglider`
+**Date:** 2026-06-17
+**Issue:** #84 (TypeScript migration, Phase 2)
+**Development branch:** `claude/avalanche-es-module-j6cc3o`
+**Model:** `claude-opus-4-8[1m]`
+
+---
+
+## 1. Objective
+
+Continue the staged TypeScript/ES-module migration (issue #84). The requested next
+unit of work was **PR 2.2 — convert `src/course.js` from a classic `window.*`
+global script to an ES module**, following the pattern established by PR 2.1
+(`avalanche.js`). A secondary request was to **review and act on the Codex bot
+feedback** left on the previous PR (#87).
+
+---
+
+## 2. Starting state (reconciliation)
+
+On entry, the picture required untangling:
+
+| Fact | Finding |
+|------|---------|
+| Assigned branch | `claude/avalanche-es-module-j6cc3o`, freshly cut from `main` (`09d6e55`, PR 2.0) |
+| `avalanche.js` here | **still a classic script** — PR 2.1's work was *not* in `main` or on this branch |
+| PR 2.1 status | **open as PR #87** on `claude/typescript-phase-2-1-xv5i3g`, **not merged** |
+| Branch-name vs task | Branch is named "avalanche-es-module" but the task was course.js (PR 2.2) |
+
+**Decision:** Because PR 2.2 depends on PR 2.1's module-loading infrastructure
+(`src/main.js` bundle entry + import map in `index.html`) that isn't in `main`
+yet, the branch was **stacked on PR 2.1's tip** (`git reset --hard
+origin/claude/typescript-phase-2-1-xv5i3g`) so the course work builds on a
+working module-loading base.
+
+---
+
+## 3. Changes made (PR 2.2)
+
+### Source / config
+- **`src/course.js`** — added `import * as THREE from 'three'` and changed
+  `const CourseModule = …` to `export const CourseModule = …`. Kept the
+  `window.CourseModule` bridge so the still-classic `snowglider.js` keeps finding
+  it (converted last, PR 2.9).
+- **`src/main.js`** — added `import './course.js'` so the bundle runs the course
+  window-bridge before the classic script-loader pulls in `snowglider.js`.
+- **`src/boot/script-loader.js`** — removed `src/course.js` from the classic
+  `GAME_SCRIPT_ORDER`.
+- **`eslint.config.js`** — added `src/course.js` to the module `sourceType` list.
+  **Kept** `CourseModule` in the readonly globals (with an explanatory comment).
+- **`types/globals.d.ts`** — added `const CourseModule: any;` to the `declare
+  global` block and updated the surrounding comments.
+
+### Key asymmetry vs PR 2.1
+`snowglider.js` reads `Avalanche` **only** as `window.Avalanche`, but reads
+`CourseModule` by **bare name** in several places (lines 194, 379, 546, 799,
+805). So, unlike avalanche, the `CourseModule` global declaration had to be
+**kept** in both eslint and `types/globals.d.ts` (declared loose, like
+`AuthModule`/`ScoresModule`) until `snowglider.js` is converted. `no-redeclare`
+is off, so the global + the module's local `const` coexist cleanly.
+
+### Tests
+- **`tests/verification/dom_smoke_test.js`** — the `CourseModule` section dropped
+  the `new Function(src)` + mock-THREE loader (which can't evaluate an
+  `import`/`export` module) and now `import()`s the **real** module + **real**
+  three, building fixtures with real three. Execution wrapped in `async main()`.
+  The still-classic `effects.js` section keeps the mock-THREE `new Function`
+  loader. Result: **18/18 pass**.
+
+### Docs
+- **`docs/TYPESCRIPT_MIGRATION.md`** — marked `course.js` converted; added the
+  `file://` caveat.
+- **`CLAUDE.md`** (and `AGENTS.md` symlink) — added the `file://` run-mode caveat
+  to the Commands section.
+
+---
+
+## 4. Verification
+
+| Gate | Result |
+|------|--------|
+| `npm run lint` (eslint) | ✅ pass |
+| `npm run typecheck` (`tsc --noEmit`) | ✅ pass |
+| `npm test` (full Node suite) | ✅ pass — incl. avalanche 12/12, smoke 18/18 |
+| `npm run build` (Vite) | ✅ pass — bundle ~478 kB (three + avalanche + course) |
+| Pages artifact checks | ✅ `dist/index.html` loads hashed module; `CNAME` preserved; classic loader no longer lists `course.js` |
+
+Environmental note: `npm run test:browser` (puppeteer) can't pass in this sandbox
+— TLS interception blocks external CDNs — but it runs normally in GitHub Actions
+CI. CI on the head commit confirmed **Test / ESLint / CodeQL / codecov all green**;
+Pages build/deploy correctly **skipped** on the PR.
+
+---
+
+## 5. Codex feedback (PR #87)
+
+Codex left one substantive finding (P2):
+
+> **Preserve direct-file avalanche loading** — In `file://` mode, the module
+> entry can't populate `window.Avalanche` (Chrome blocks ES-module + import-map
+> loading from a null origin), and avalanche.js was removed from the classic
+> loader, so `snowglider.js` silently disables the avalanche system.
+
+**Assessment:** valid, and it applies equally to `course.js`. A true non-module
+fallback isn't a simple `<script src>` — the converted files contain
+`import`/`export`, so loading them as classic scripts throws a SyntaxError; a real
+fallback would need a separate UMD build that gets deleted at PR 2.10 anyway.
+
+**Resolution (user-chosen):** *document as a known, intended Phase-2 tradeoff.*
+Added the caveat to `CLAUDE.md` + `docs/TYPESCRIPT_MIGRATION.md`, and posted a
+threaded reply to the Codex review comment on PR #87 explaining the rationale.
+
+---
+
+## 6. PRs and the duplicate cleanup
+
+| PR | Title | Head → Base | Role |
+|----|-------|-------------|------|
+| **#87** | PR 2.1 — avalanche → ES module | `…phase-2-1-xv5i3g` → `main` | avalanche, **first** |
+| **#89** | PR 2.2 — course → ES module | `…avalanche-es-module-j6cc3o` → `…phase-2-1-xv5i3g` | course, **stacked after #87** |
+| ~~#88~~ | ~~PR 2.1 (duplicate)~~ | `…avalanche-es-module-j6cc3o` → `main` | **closed** |
+
+**Duplicate root cause:** the repo has automation that auto-opens a PR-to-`main`
+for every pushed `claude/*` branch. When this branch was pushed, that automation
+created **#88** (my branch → `main`), which mixed the inherited avalanche commit
+with the course work and inherited an avalanche-style title — duplicating #87.
+
+**Action:** closed #88 with an explanatory comment pointing to #87 (avalanche,
+first) and #89 (course, stacked). #89 is based on the avalanche branch so its diff
+is **course-only**; it auto-retargets to `main` once #87 merges.
+
+> ⚠️ The auto-PR will re-create a `…→ main` PR on every push to this branch. While
+> the explicit stacked PR #89 also exists, expect a duplicate per push unless the
+> auto-PR is disabled or used as the canonical course PR.
+
+---
+
+## 7. Commits on `claude/avalanche-es-module-j6cc3o`
+
+```
+5e2fd9f  docs: note file:// run-mode caveat for converted ES modules (Codex PR 2.1 feedback)
+3626b15  refactor(ts): PR 2.2 — convert course.js to an ES module (issue #84)
+ae266e1  refactor(ts): PR 2.1 — convert avalanche.js to an ES module (issue #84)   ← inherited (stack base)
+```
+
+---
+
+## 8. Files touched (PR 2.2 only, vs `ae266e1`)
+
+```
+ CLAUDE.md                            (+ file:// caveat; AGENTS.md symlink follows)
+ docs/TYPESCRIPT_MIGRATION.md         (+ status + file:// caveat)
+ eslint.config.js                     (+ course.js module entry; kept CourseModule global)
+ src/boot/script-loader.js            (- course.js from classic order)
+ src/course.js                        (import three + export CourseModule)
+ src/main.js                          (+ import './course.js')
+ tests/verification/dom_smoke_test.js (real module + real three; async main)
+ types/globals.d.ts                   (+ const CourseModule: any)
+```
+
+---
+
+## 9. Status & next steps
+
+- **PR 2.2 complete, pushed, all gates green.** Open as PR #89, stacked on #87.
+- Merge order: **#87 first, then #89** (which auto-retargets to `main`).
+- **Next in sequence:** PR 2.3 — `camera.js`.
+- Optional: subscribe to PR activity on #87/#89 to autofix CI / respond to review.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,10 @@ module.exports = [
         AuthModule: "readonly",
         Camera: "readonly",
         Controls: "readonly",
+        // course.js is now an ES module (PR 2.2), but the still-classic
+        // snowglider.js reads `CourseModule` by bare name, so keep it declared
+        // here until snowglider.js is converted (PR 2.9). (Contrast avalanche.js,
+        // which is only read as `window.Avalanche`, so its global was dropped.)
         CourseModule: "readonly",
         EffectsModule: "readonly",
         Howl: "readonly",
@@ -71,7 +75,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/main.js", "src/scores.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/course.js", "src/main.js", "src/scores.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -11,7 +11,8 @@
     // avalanche.js converted to an ES module (issue #84, PR 2.1); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
     'src/effects.js',
-    'src/course.js',
+    // course.js converted to an ES module (issue #84, PR 2.2); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/snowglider.js'
   ];
 

--- a/src/course.js
+++ b/src/course.js
@@ -15,8 +15,17 @@
 //     system; they exist to mark the line and the split points.
 //   - Best splits and the best-run trajectory are persisted in localStorage and only
 //     committed when a run sets a new personal best, so the ghost is always your best.
+//
+// Phase 2.2 (issue #84): second module converted off the classic global model.
+// `THREE` now comes from the npm package via a real ES-module import instead of
+// the CDN global, and `CourseModule` is `export`ed. The window.CourseModule
+// assignment below is kept so the still-classic consumer (snowglider.js, which
+// reads it by bare name and as window.CourseModule, converted last in PR 2.9)
+// keeps working during the staged migration; it is loaded into the page through
+// the bundle entry (src/main.js) rather than the classic script-loader.
+import * as THREE from 'three';
 
-const CourseModule = (function () {
+export const CourseModule = (function () {
   'use strict';
 
   // --- Course geometry (world units; 1 unit == 1 metre for the HUD) ---
@@ -584,6 +593,9 @@ const CourseModule = (function () {
   };
 })();
 
+// Backward-compat global export for the still-classic consumer (snowglider.js
+// reads `CourseModule`/`window.CourseModule`). Drop this once snowglider.js is
+// converted to import CourseModule directly (PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
   window.CourseModule = CourseModule;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,9 @@ import * as THREE from 'three';
 // finding the avalanche system. As more modules convert, add them here too
 // until the classic loader is retired (PR 2.10).
 import './avalanche.js';
+// Phase 2.2: course.js, imported for its `window.CourseModule = …` bridge so the
+// still-classic snowglider.js keeps finding the course system.
+import './course.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -1,7 +1,15 @@
 // dom_smoke_test.js
-// Load course.js + effects.js under jsdom with a mocked THREE, then exercise
-// init/reset/update/onFinish/avalanche/camera and assert sane behavior — headless
-// coverage for the two new modules without a browser. Requires jsdom (devDependency).
+// Headless coverage for course.js + effects.js under jsdom, without a browser.
+// Requires jsdom (devDependency).
+//
+// Phase 2.2 (issue #84): course.js is now an ES module that does
+// `import * as THREE from 'three'`, so it can no longer be evaluated with the
+// `new Function(src)` + mock-THREE injection used here — that pattern can't load
+// `import`/`export`. The CourseModule section now `import()`s the REAL module and
+// REAL three (three's geometry/material/texture constructors need no WebGL, so
+// they build fine headless under Node), exercising shipped code directly. The
+// still-classic effects.js keeps the mock-THREE `new Function` loader until it is
+// converted; switch it over the same way then.
 const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
@@ -57,102 +65,120 @@ class ColorMock { constructor() {} lerp() { return this; } }
 THREE.Color = ColorMock;
 global.THREE = THREE; window.THREE = THREE;
 
-// Load the modules into the jsdom global scope.
+// Load a still-classic module (effects.js) into the jsdom global scope with the
+// mock THREE. course.js is no longer loadable this way (it's an ES module) — it
+// is import()ed against real three in the CourseModule section below.
 function loadInWindow(file) {
   const code = fs.readFileSync(path.join(REPO, file), 'utf8');
   // Evaluate with access to our globals (THREE, document, window, localStorage).
-  const fn = new Function('THREE', 'document', 'window', 'localStorage', 'console', code + '\n;return (typeof CourseModule!=="undefined"?CourseModule:(typeof EffectsModule!=="undefined"?EffectsModule:null));');
+  const fn = new Function('THREE', 'document', 'window', 'localStorage', 'console', code + '\n;return (typeof EffectsModule!=="undefined"?EffectsModule:null);');
   return fn(THREE, window.document, window, global.localStorage, console);
 }
 
 let pass = 0, fail = 0;
 function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
 
-// ---- EffectsModule ----
-console.log('--- EffectsModule ---');
-const Effects = loadInWindow('src/effects.js');
-check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
-Effects.init();
-const banner = window.document.body.querySelector('div');
-check('init builds DOM overlays without throwing', !!banner);
-// Inactive avalanche hides things, active shows + sets danger
-Effects.updateAvalanche(false, Infinity);
-Effects.updateAvalanche(true, 40);
-Effects.updateAvalanche(true, 8); // very close
-check('updateAvalanche(active, near) runs', true);
-// Camera FOV widens with speed and shake offset returned
-const cam = { fov: 75, position: { x: 0, y: 0, z: 0 }, updateProjectionMatrix() { this._u = (this._u || 0) + 1; } };
-Effects.addShake(1.0);
-let off = Effects.tickCamera(cam, 1 / 60, 30);
-check('tickCamera returns an offset object', off && typeof off.x === 'number');
-check('high speed widens FOV above base 75', cam.fov > 75.0);
-Effects.reset();
-check('reset() runs without throwing', true);
+async function main() {
+  // ---- EffectsModule (still classic: mock THREE + new Function loader) ----
+  console.log('--- EffectsModule ---');
+  const Effects = loadInWindow('src/effects.js');
+  check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
+  Effects.init();
+  const banner = window.document.body.querySelector('div');
+  check('init builds DOM overlays without throwing', !!banner);
+  // Inactive avalanche hides things, active shows + sets danger
+  Effects.updateAvalanche(false, Infinity);
+  Effects.updateAvalanche(true, 40);
+  Effects.updateAvalanche(true, 8); // very close
+  check('updateAvalanche(active, near) runs', true);
+  // Camera FOV widens with speed and shake offset returned
+  const cam = { fov: 75, position: { x: 0, y: 0, z: 0 }, updateProjectionMatrix() { this._u = (this._u || 0) + 1; } };
+  Effects.addShake(1.0);
+  let off = Effects.tickCamera(cam, 1 / 60, 30);
+  check('tickCamera returns an offset object', off && typeof off.x === 'number');
+  check('high speed widens FOV above base 75', cam.fov > 75.0);
+  Effects.reset();
+  check('reset() runs without throwing', true);
 
-// ---- CourseModule ----
-console.log('\n--- CourseModule ---');
-const fakeCreateSnowman = () => { const g = new THREE.Group(); g.add(new THREE.Mesh()); return g; };
-const Course = loadInWindow('src/course.js');
-check('module exports init/update/onFinish', !!Course && typeof Course.update === 'function' && typeof Course.onFinish === 'function');
+  // ---- CourseModule (real ES module + real three, PR 2.2) ----
+  console.log('\n--- CourseModule ---');
+  // course.js now `import`s three from npm, so we import the REAL module + REAL
+  // three rather than evaluating the source with a mock. The fake snowman is a
+  // real three Group whose mesh carries a MeshStandardMaterial so buildGhost's
+  // material.clone()/color.lerp()/emissive path exercises shipped code.
+  const RealTHREE = await import('three');
+  const { CourseModule: Course } = await import('../../src/course.js');
+  const fakeCreateSnowman = () => {
+    const g = new RealTHREE.Group();
+    g.add(new RealTHREE.Mesh(new RealTHREE.BoxGeometry(1, 1, 1), new RealTHREE.MeshStandardMaterial()));
+    return g;
+  };
+  check('module exports init/update/onFinish', !!Course && typeof Course.update === 'function' && typeof Course.onFinish === 'function');
 
-const terrain = (x, z) => 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40) + (z < -30 ? (z + 30) * 0.12 : 0);
-Course.init({ scene: new THREE.Group(), getTerrainHeight: terrain, createSnowman: fakeCreateSnowman });
-check('init builds gates + HUD', true);
+  const terrain = (x, z) => 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40) + (z < -30 ? (z + 30) * 0.12 : 0);
+  Course.init({ scene: new RealTHREE.Scene(), getTerrainHeight: terrain, createSnowman: fakeCreateSnowman });
+  check('init builds gates + HUD', true);
 
-// Simulate a clean run reaching every split.
-global.localStorage.clear();
-Course.reset();
-const cfg = Course._config;
-const splitZ = cfg.splitPoints.map(s => s.z);
-let crossed = 0;
-const snowmanMock = { rotation: { y: Math.PI } };
-let t = 0;
-for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
-  t += 0.12; // ~ seconds; arbitrary monotonic clock
-  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t, snowmanMock);
-  // count how many split thresholds we've now passed
-  crossed = splitZ.filter(sz => z <= sz).length;
+  // Simulate a clean run reaching every split.
+  global.localStorage.clear();
+  Course.reset();
+  const cfg = Course._config;
+  const splitZ = cfg.splitPoints.map(s => s.z);
+  let crossed = 0;
+  const snowmanMock = { rotation: { y: Math.PI } };
+  let t = 0;
+  for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+    t += 0.12; // ~ seconds; arbitrary monotonic clock
+    Course.update({ x: 1.5, y: terrain(1.5, z), z }, t, snowmanMock);
+    // count how many split thresholds we've now passed
+    crossed = splitZ.filter(sz => z <= sz).length;
+  }
+  check('all checkpoints + finish are reachable', crossed === splitZ.length);
+
+  // First finish: should be a "first descent" (no previous best) and persist a ghost.
+  const panel1 = Course.onFinish(t, Infinity);
+  check('onFinish returns a result panel node', !!panel1 && panel1.id === 'courseResult');
+  check('ghost trajectory persisted to localStorage', !!global.localStorage.getItem('snowgliderGhost'));
+  check('best splits persisted to localStorage', !!global.localStorage.getItem('snowgliderBestSplits'));
+  const panelText1 = panel1.textContent || '';
+  check('first finish shows a medal/result text', /descent|record|Finish/i.test(panelText1));
+
+  // Gap 3 regression: the persisted ghost's final sample keeps the player's real x
+  // (not a hardcoded 0) so it doesn't snap to center at the line.
+  const ghostSaved = JSON.parse(global.localStorage.getItem('snowgliderGhost'));
+  const ghostLast = ghostSaved[ghostSaved.length - 1];
+  check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
+
+  // Second run, faster: should read as a new record and a ghost should now exist + interpolate.
+  Course.reset(); // loads the stored ghost AND best splits (Gap 2 fix)
+  let t2 = 0;
+  for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
+    t2 += 0.09; // faster pace than run 1 (0.12)
+    Course.update({ x: 1.5, y: terrain(1.5, z), z }, t2, snowmanMock);
+  }
+  const previousBest = t; // run 1 total
+  const panel2 = Course.onFinish(t2, previousBest);
+  const panelText2 = panel2.textContent || '';
+  check('faster second run reports a new record', /record/i.test(panelText2));
+  check('result panel contains a split table (Δ Best)', /Δ Best/.test(panelText2));
+
+  // Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
+  // second run's result table shows real per-split deltas instead of the "—" placeholder.
+  // (Scope the check to the split table — the "X — new personal best!" line legitimately
+  // uses an em dash as a separator, so checking the whole panel would false-positive.)
+  const EM_DASH = String.fromCharCode(0x2014);
+  const deltaTable = panel2.lastElementChild; // split table is appended last in the panel
+  check('best-split deltas not stale after PB (Gap 2)',
+    !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
+
+  Course.hideHud();
+  check('hideHud() runs without throwing', true);
+
+  console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
 }
-check('all checkpoints + finish are reachable', crossed === splitZ.length);
 
-// First finish: should be a "first descent" (no previous best) and persist a ghost.
-const panel1 = Course.onFinish(t, Infinity);
-check('onFinish returns a result panel node', !!panel1 && panel1.id === 'courseResult');
-check('ghost trajectory persisted to localStorage', !!global.localStorage.getItem('snowgliderGhost'));
-check('best splits persisted to localStorage', !!global.localStorage.getItem('snowgliderBestSplits'));
-const panelText1 = panel1.textContent || '';
-check('first finish shows a medal/result text', /descent|record|Finish/i.test(panelText1));
-
-// Gap 3 regression: the persisted ghost's final sample keeps the player's real x
-// (not a hardcoded 0) so it doesn't snap to center at the line.
-const ghostSaved = JSON.parse(global.localStorage.getItem('snowgliderGhost'));
-const ghostLast = ghostSaved[ghostSaved.length - 1];
-check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
-
-// Second run, faster: should read as a new record and a ghost should now exist + interpolate.
-Course.reset(); // loads the stored ghost AND best splits (Gap 2 fix)
-let t2 = 0;
-for (let z = cfg.START_Z; z >= cfg.FINISH_Z; z -= 1.0) {
-  t2 += 0.09; // faster pace than run 1 (0.12)
-  Course.update({ x: 1.5, y: terrain(1.5, z), z }, t2, snowmanMock);
-}
-const previousBest = t; // run 1 total
-const panel2 = Course.onFinish(t2, previousBest);
-const panelText2 = panel2.textContent || '';
-check('faster second run reports a new record', /record/i.test(panelText2));
-check('result panel contains a split table (Δ Best)', /Δ Best/.test(panelText2));
-
-// Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
-// second run's result table shows real per-split deltas instead of the "—" placeholder.
-// (Scope the check to the split table — the "X — new personal best!" line legitimately
-// uses an em dash as a separator, so checking the whole panel would false-positive.)
-const EM_DASH = String.fromCharCode(0x2014);
-const deltaTable = panel2.lastElementChild; // split table is appended last in the panel
-check('best-split deltas not stale after PB (Gap 2)',
-  !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
-
-Course.hideHud();
-check('hideHud() runs without throwing', true);
-
-console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
-process.exit(fail ? 1 : 0);
+main().catch((err) => {
+  console.error('Smoke test harness crashed:', err);
+  process.exit(1);
+});

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,7 +22,6 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
-  //   - course.js:    @ts-checked -> `CourseModule` lives in src/course.js, not here.
   //   - camera.js:    @ts-checked -> `Camera` (class) lives in src/camera.js, not here.
   //   - trees.js:     @ts-checked -> `Trees` + `getTerrainHeight`/`getTerrainGradient`
   //                   (top-level fns) live in src/trees.js, not here.
@@ -33,11 +32,14 @@ declare global {
   //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
   //                   (top-level fns) live in src/snowman.js, not here.
   //   - audio.js:     @ts-checked -> `AudioModule` lives in src/audio.js, not here.
-  // AuthModule/ScoresModule stay: auth.js/scores.js are ES modules (not script
-  // globals), so they don't define these as bare globals — kept loose for any
-  // consumer that reads them by bare name.
+  // AuthModule/ScoresModule/CourseModule stay: auth.js/scores.js (and, as of
+  // PR 2.2, course.js) are ES modules — their `CourseModule`/etc. are module-
+  // scoped, not script globals — yet the still-classic snowglider.js reads them
+  // by bare name. Keep them declared loose here until snowglider.js is converted
+  // (PR 2.9). (Once a module's bare consumer is gone, drop its entry.)
   const AuthModule: any;
   const ScoresModule: any;
+  const CourseModule: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;


### PR DESCRIPTION
Second per-module step of Phase 2, **stacked on #87 (PR 2.1, avalanche)** — base it on the avalanche branch so this PR's diff is course-only and merges *after* avalanche. (GitHub auto-retargets to `main` once #87 merges.)

## What
`course.js` now `import * as THREE from 'three'` (npm) and `export`s `CourseModule` instead of reading the CDN global. It still publishes the `window.CourseModule` bridge so the still-classic `snowglider.js` consumer keeps working until it is converted (PR 2.9).

- **Loading:** removed `course.js` from the classic `GAME_SCRIPT_ORDER`; it now loads via the bundle entry (`src/main.js`), imported for its side-effect bridge. The module script is deferred, so the bridge runs before the script-loader pulls in `snowglider.js`. Vite discovers it through `main.js`, emitting one hashed chunk (now ~478 kB: three + avalanche + course); `CNAME` preserved.
- **Globals:** unlike avalanche.js (only read as `window.Avalanche`), `snowglider.js` reads `CourseModule` by **bare** name, so its eslint readonly global and `types/globals.d.ts` declaration are **kept** (now declared loose like `AuthModule`/`ScoresModule`) until `snowglider.js` is converted. `course.js` added to the eslint module sourceType list.
- **Tests:** the CourseModule section of `tests/verification/dom_smoke_test.js` dropped the `new Function(src)` + mock-THREE loader (which can't load an `import`/`export` module) and now `import()`s the real module + real three, exercising shipped code (18/18). The still-classic `effects.js` keeps the mock-THREE loader there.

## Codex PR 2.1 follow-up
Codex flagged on #87 that converted modules don't load over `file://` (Chrome blocks module + import-map loading from a null origin), silently disabling the feature on direct `open index.html`. Per the chosen resolution (document, not add throwaway non-module scaffolding), this PR records the caveat in `CLAUDE.md` and `docs/TYPESCRIPT_MIGRATION.md`: use `npm start` or a build to run the full game. It applies equally to course.js.

## Verification
`npm test` (full suite, smoke 18/18, avalanche 12/12), `npm run lint`, `tsc --noEmit`, and `npm run build` + Pages-artifact checks all green. (`npm run test:browser` can't run in the sandbox — TLS interception blocks the CDNs — but is environmental; runs normally in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bqn8gdST11zHhiPQM71r3G)_