### PR TITLE
refactor(ts): PR 2.4/2.7/2.8 — convert the terrain cluster (trees, mountains, snow, snowman) to ES modules (issue #84)

### DIFF
--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -8,10 +8,10 @@
   per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking in
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
   `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
-  **`src/avalanche.js`**, **`src/course.js`**, **`src/camera.js`**, **`src/controls.js`** and
-  **`src/effects.js`** are now ES modules too. The remaining game modules (`mountains.js`, `trees.js`,
-  `snow.js`, `snowman.js`, `audio.js`, `snowglider.js`) are still classic `<script>` globals loaded
-  via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+  **`src/avalanche.js`**, **`src/course.js`**, **`src/camera.js`**, **`src/controls.js`**,
+  **`src/effects.js`** and **`src/trees.js`** are now ES modules too. The remaining game modules
+  (`mountains.js`, `snow.js`, `snowman.js`, `audio.js`, `snowglider.js`) are still classic `<script>`
+  globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
@@ -57,6 +57,13 @@
     coverage (`tests/verification/dom_smoke_test.js`) now `import()`s the real module; with effects.js
     converted, that file's last `new Function` + mock-THREE scaffolding is gone (both its sections now
     import real modules).
+  - **PR 2.4 — `src/trees.js`:** `import * as THREE from 'three'` + `export const Trees`, plus a
+    `window.Trees` bridge. `Trees` is read by **bare** name at eval time by the still-classic `snow.js`
+    (which builds its `Snow` namespace from `Trees.*`/`Mountains.*`), so its eslint global +
+    `types/globals.d.ts` declaration are kept until `snow.js` is converted (same cluster). trees.js's
+    internal `getTerrainHeight`/`getTerrainGradient` wrappers delegate to `window.Mountains` at call
+    time, so they keep working across the migration. No test migration: `terrain-tests`/`regression-tests`
+    inject a *Trees mock* (they don't load real trees.js), and `tree-collision-tests` is self-contained.
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -9,9 +9,10 @@
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
   `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
   **`src/avalanche.js`**, **`src/course.js`**, **`src/camera.js`**, **`src/controls.js`**,
-  **`src/effects.js`**, **`src/trees.js`**, **`src/mountains.js`** and **`src/snow.js`** are now ES
-  modules too. The remaining game modules (`snowman.js`, `audio.js`, `snowglider.js`) are still classic
-  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+  **`src/effects.js`**, **`src/trees.js`**, **`src/mountains.js`**, **`src/snow.js`** and
+  **`src/snowman.js`** are now ES modules too. The remaining game modules (`audio.js`, `snowglider.js`)
+  are still classic `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160**
+  as a CDN global.
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
@@ -76,6 +77,16 @@
     run inside an async IIFE; `tree-collision-tests` and `physics-tests` are self-contained mocks and
     needed no change. Ambient `getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection` +
     `Mountains`/`Snow` declarations move into `types/globals.d.ts`, kept until snowglider.js (PR 2.9).
+  - **PR 2.8 — `src/snowman.js`:** `import * as THREE from 'three'` + `export const Snowman`, plus a
+    `window.Snowman` bridge (snowglider.js reads `Snowman` by bare name, e.g.
+    `Snowman.createSnowman(scene)`). snowman.js receives the terrain samplers as *function arguments*
+    (not globals), so it needed no terrain bridge of its own. The physics-invariant harness
+    (`tests/verification/physics_invariant_harness.js`) now `import()`s the real snowman.js for the
+    "current" side (the frozen classic baseline still loads via `vm.runInContext`) and stubs
+    `global.window` for updateSnowman's test-hook/debug paths; the load-bearing coasting invariant
+    stays **bit-identical** to the baseline. `physics-tests`/`tree-collision-tests` are self-contained
+    mocks and needed no change. (`snowglider.js` — the orchestrator that unwinds every `window.*`
+    bridge and loose global — and the classic-loader retirement remain as their own later PRs.)
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -9,9 +9,9 @@
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
   `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
   **`src/avalanche.js`**, **`src/course.js`**, **`src/camera.js`**, **`src/controls.js`**,
-  **`src/effects.js`** and **`src/trees.js`** are now ES modules too. The remaining game modules
-  (`mountains.js`, `snow.js`, `snowman.js`, `audio.js`, `snowglider.js`) are still classic `<script>`
-  globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
+  **`src/effects.js`**, **`src/trees.js`**, **`src/mountains.js`** and **`src/snow.js`** are now ES
+  modules too. The remaining game modules (`snowman.js`, `audio.js`, `snowglider.js`) are still classic
+  `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160** as a CDN global.
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
@@ -64,6 +64,18 @@
     internal `getTerrainHeight`/`getTerrainGradient` wrappers delegate to `window.Mountains` at call
     time, so they keep working across the migration. No test migration: `terrain-tests`/`regression-tests`
     inject a *Trees mock* (they don't load real trees.js), and `tree-collision-tests` is self-contained.
+  - **PR 2.7 + snow — `src/mountains.js` + `src/snow.js`** (converted together): `import * as THREE
+    from 'three'` + `export const Mountains` / `export const Snow`. mountains.js republishes the bare
+    terrain samplers (`window.getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) it used to
+    define as script globals; snow.js republishes `window.Snow` (the still-classic snowglider.js reads
+    `Snow` by bare name) alongside the legacy `window.Utils` alias. They convert in one step because
+    `terrain-tests` and `regression-tests` load *both* via the shared `with(sandbox)` + `new Function`
+    loader, which can't evaluate an ES module, and because snow.js reads `Mountains`/`Trees` at
+    module-eval (so main.js imports mountains+trees before snow). Both Node tests now `import()` the
+    real modules (setting `global.Mountains` + a lightweight `Trees` mock before importing snow.js) and
+    run inside an async IIFE; `tree-collision-tests` and `physics-tests` are self-contained mocks and
+    needed no change. Ambient `getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection` +
+    `Mountains`/`Snow` declarations move into `types/globals.d.ts`, kept until snowglider.js (PR 2.9).
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,9 @@ module.exports = [
         Snow: "readonly",
         Snowman: "readonly",
         THREE: "readonly",
+        // trees.js is now an ES module (PR 2.4), but the still-classic snow.js
+        // reads `Trees` by bare name (at eval, to build the `Snow` namespace), so
+        // keep it declared here until snow.js is converted (this same cluster).
         Trees: "readonly",
         Utils: "readonly",
         avalanche: "writable",
@@ -85,7 +88,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/scores.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/scores.js", "src/trees.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,6 +59,9 @@ module.exports = [
         // snowglider.js reads `Snow` by bare name (`Snow.getTerrainHeight`, …),
         // so keep it declared here until snowglider.js is converted (PR 2.9).
         Snow: "readonly",
+        // snowman.js is now an ES module (PR 2.8), but the still-classic
+        // snowglider.js reads `Snowman` by bare name (`Snowman.createSnowman`),
+        // so keep it declared here until snowglider.js is converted (PR 2.9).
         Snowman: "readonly",
         THREE: "readonly",
         // trees.js is now an ES module (PR 2.4), but the still-classic snow.js
@@ -99,7 +102,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/trees.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowman.js", "src/trees.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,8 +50,14 @@ module.exports = [
         EffectsModule: "readonly",
         Howl: "readonly",
         Howler: "readonly",
+        // mountains.js is now an ES module (PR 2.7), but trees.js + snow.js read
+        // `Mountains` by bare name (as the window bridge), so keep it declared
+        // here until those + snowglider.js are converted (PR 2.9).
         Mountains: "readonly",
         ScoresModule: "readonly",
+        // snow.js is now an ES module (cluster), but the still-classic
+        // snowglider.js reads `Snow` by bare name (`Snow.getTerrainHeight`, …),
+        // so keep it declared here until snowglider.js is converted (PR 2.9).
         Snow: "readonly",
         Snowman: "readonly",
         THREE: "readonly",
@@ -66,7 +72,12 @@ module.exports = [
         camera: "writable",
         cameraManager: "writable",
         gameActive: "writable",
+        // Terrain samplers: mountains.js (now an ES module, PR 2.7) republishes
+        // these onto window; snowman.js / camera.js / course.js read them by bare
+        // name. Kept until snowglider.js is converted (PR 2.9).
         getTerrainHeight: "readonly",
+        getTerrainGradient: "readonly",
+        getDownhillDirection: "readonly",
         isInAir: "writable",
         lastAvalancheZ: "writable",
         pos: "writable",
@@ -88,7 +99,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/scores.js", "src/trees.js"],
+    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/trees.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -2,7 +2,8 @@
 (function () {
   const GAME_SCRIPT_ORDER = [
     'src/mountains.js',
-    'src/trees.js',
+    // trees.js converted to an ES module (issue #84, PR 2.4); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/snow.js',
     // camera.js converted to an ES module (issue #84, PR 2.3); it now loads
     // via the bundle entry (src/main.js), not this classic loader.

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -1,10 +1,12 @@
 // @ts-check
 (function () {
   const GAME_SCRIPT_ORDER = [
-    'src/mountains.js',
+    // mountains.js converted to an ES module (issue #84, PR 2.7); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     // trees.js converted to an ES module (issue #84, PR 2.4); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
-    'src/snow.js',
+    // snow.js converted to an ES module (issue #84, cluster); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     // camera.js converted to an ES module (issue #84, PR 2.3); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
     'src/snowman.js',

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -9,7 +9,8 @@
     // via the bundle entry (src/main.js), not this classic loader.
     // camera.js converted to an ES module (issue #84, PR 2.3); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
-    'src/snowman.js',
+    // snowman.js converted to an ES module (issue #84, PR 2.8); it now loads
+    // via the bundle entry (src/main.js), not this classic loader.
     'src/audio.js',
     // controls.js converted to an ES module (issue #84, PR 2.5); it now loads
     // via the bundle entry (src/main.js), not this classic loader.

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,10 @@ import './controls.js';
 // Phase 2.6: effects.js, imported for its `window.EffectsModule = …` bridge so the
 // still-classic snowglider.js keeps finding the avalanche/camera-juice effects.
 import './effects.js';
+// Phase 2.4: trees.js, imported for its `window.Trees = …` bridge. Imported before
+// snow.js (below) because snow.js reads `Trees` at module-eval time when it builds
+// the `Snow` namespace.
+import './trees.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,14 @@ import './effects.js';
 // snow.js (below) because snow.js reads `Trees` at module-eval time when it builds
 // the `Snow` namespace.
 import './trees.js';
+// Phase 2.7: mountains.js, imported for its `window.Mountains = …` +
+// `window.getTerrainHeight/getTerrainGradient/getDownhillDirection` bridges. Also
+// imported before snow.js, which reads `Mountains` at module-eval time.
+import './mountains.js';
+// Phase 2.6/cluster: snow.js, imported LAST of the terrain trio for its
+// `window.Snow`/`window.Utils` bridges — it reads `Mountains`/`Trees` at eval, so
+// both must already be bridged above.
+import './snow.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,9 @@ import './mountains.js';
 // `window.Snow`/`window.Utils` bridges — it reads `Mountains`/`Trees` at eval, so
 // both must already be bridged above.
 import './snow.js';
+// Phase 2.8: snowman.js, imported for its `window.Snowman = …` bridge so the
+// still-classic snowglider.js keeps finding the snowman model + physics.
+import './snowman.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/mountains.js
+++ b/src/mountains.js
@@ -1,5 +1,16 @@
 // @ts-check
 // mountains.js - Terrain and mountain features for snowglider
+//
+// Phase 2.7 (issue #84): converted off the classic global model. `THREE` now
+// comes from the npm package via a real ES-module import instead of the CDN
+// global, and `Mountains` is `export`ed. Because mountains.js used to define the
+// terrain sampler functions (`getTerrainHeight`/`getTerrainGradient`/
+// `getDownhillDirection`) as bare script globals, the bottom of this file now
+// republishes them onto `window` so the still-classic/converted consumers that
+// read them by bare name (snowman.js, plus the already-converted camera.js and
+// course.js) keep resolving them during the staged migration. It is loaded into
+// the page through the bundle entry (src/main.js) rather than the classic loader.
+import * as THREE from 'three';
 
 // --- SimplexNoise implementation ---
 class SimplexNoise {
@@ -414,7 +425,7 @@ function debugHeightMap(x, z) {
 }
 
 // Export all mountain-related functions and classes
-const Mountains = {
+export const Mountains = {
   SimplexNoise,
   getTerrainHeight,
   getTerrainGradient,
@@ -426,7 +437,16 @@ const Mountains = {
   heightMap // Expose the heightmap for debugging
 };
 
-// Make Mountains available globally
+// Backward-compat global exports for the still-classic / staged consumers.
+// `window.Mountains` is read by trees.js and snow.js (as a bridge) and indirectly
+// by snowglider.js via `Snow`. The bare terrain samplers below used to be script
+// globals defined by this (classic) file; now that it is an ES module they are
+// republished onto `window` so bare reads in snowman.js / camera.js / course.js
+// keep resolving. Drop these once all consumers import the functions directly
+// (snowman.js in this cluster, snowglider.js in PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
   window.Mountains = Mountains;
+  window.getTerrainHeight = getTerrainHeight;
+  window.getTerrainGradient = getTerrainGradient;
+  window.getDownhillDirection = getDownhillDirection;
 }

--- a/src/snow.js
+++ b/src/snow.js
@@ -1,5 +1,16 @@
 // @ts-check
 // Snow.js - Utility functions for the snowman skiing game
+//
+// Phase 2.6/cluster (issue #84): converted off the classic global model. `THREE`
+// now comes from the npm package via a real ES-module import instead of the CDN
+// global, and `Snow` is `export`ed. snow.js builds its `Snow` namespace from
+// `Mountains.*` and `Trees.*` at module-eval time, reading them as bare globals,
+// so it must load AFTER mountains.js and trees.js — src/main.js imports it last
+// of the three for exactly that reason. The window.Snow / window.Utils bridges
+// below keep the still-classic snowglider.js (which reads `Snow` by bare name)
+// working until it is converted (PR 2.9). Loaded via the bundle entry, not the
+// classic script-loader.
+import * as THREE from 'three';
 
 // Mountains features are now in mountains.js
 // This file now delegates terrain/mountain calls to mountains.js
@@ -365,8 +376,12 @@ function updateSnowSplash(splash, delta, snowman, velocity, isInAir, scene) {
 }
 
 // Export utility functions and classes
-// We leverage the Mountains export from mountains.js and add our own
-const Snow = {
+// We leverage the Mountains export from mountains.js and add our own.
+// `Mountains` and `Trees` are read here as bare globals (the window.* bridges
+// published by the already-imported mountains.js / trees.js modules), so this
+// object literal must evaluate after those modules — guaranteed by main.js's
+// import order.
+export const Snow = {
   // Mountain features are now imported from mountains.js
   // For backward compatibility, provide the same API via delegation
   SimplexNoise: Mountains.SimplexNoise,
@@ -393,15 +408,14 @@ const Snow = {
 // For backward compatibility, alias Utils to Snow
 const Utils = Snow;
 
-// Make Utils available in the global scope for backward compatibility
+// Backward-compat global exports. snowglider.js reads `Snow` by bare name
+// (`Snow.getTerrainHeight`, `Snow.addTrees`, …); as a classic script it used to
+// see snow.js's top-level `const Snow` via the shared script scope, but now that
+// snow.js is an ES module that binding is module-scoped, so we republish it onto
+// `window` (bare `Snow` in the classic snowglider.js resolves via window). The
+// legacy `window.Utils` alias is preserved. Drop both once snowglider.js imports
+// Snow directly (PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
+  window.Snow = Snow;
   window.Utils = Snow;
 }
-
-// In a module environment, you would use:
-// export { 
-//   SimplexNoise, getTerrainHeight, getTerrainGradient,
-//   getDownhillDirection, createTerrain, createSnowman, 
-//   createSnowflakes, updateSnowflakes, createTree, createRock,
-//   addTrees, addRocks, addBranchesAtLayer, addSnowCaps
-// };

--- a/src/snowman.js
+++ b/src/snowman.js
@@ -1,5 +1,17 @@
 // @ts-check
 // snowman.js - Snowman model and functions for SnowGlider game
+//
+// Phase 2.8 (issue #84): final terrain-cluster module converted off the classic
+// global model. `THREE` now comes from the npm package via a real ES-module
+// import instead of the CDN global, and `Snowman` is `export`ed. The
+// window.Snowman assignment below is kept so the still-classic consumer
+// (snowglider.js, which reads `Snowman` by bare name, e.g.
+// `Snowman.createSnowman(scene)`, converted last in PR 2.9) keeps working during
+// the staged migration. snowman.js reads the terrain samplers (getTerrainHeight/
+// getTerrainGradient/getDownhillDirection) by bare name at call time; those
+// resolve to the window bridges published by mountains.js (PR 2.7). It is loaded
+// into the page through the bundle entry (src/main.js), not the classic loader.
+import * as THREE from 'three';
 
 // Create Snowman (Three Spheres)
 function createSnowman(scene) {
@@ -842,14 +854,16 @@ function addTestHooks(pos, showGameOver, getTerrainHeight) {
 }
 
 // Export snowman functions
-const Snowman = {
+export const Snowman = {
   createSnowman,
   resetSnowman,
   updateSnowman,
   addTestHooks
 };
 
-// Make Snowman available globally
+// Backward-compat global export for the still-classic consumer (snowglider.js
+// reads `Snowman` by bare name, e.g. `Snowman.createSnowman(scene)`). Drop this
+// once snowglider.js is converted to import Snowman directly (PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
   window.Snowman = Snowman;
 }

--- a/src/trees.js
+++ b/src/trees.js
@@ -1,5 +1,16 @@
 // @ts-check
 // trees.js - Tree creation and management for snowglider
+//
+// Phase 2.4 (issue #84): converted off the classic global model. `THREE` now
+// comes from the npm package via a real ES-module import instead of the CDN
+// global, and `Trees` is `export`ed. The window.Trees assignment below is kept so
+// the still-classic consumers (snow.js reads `Trees` by bare name at eval time;
+// snowglider.js is converted last in PR 2.9) keep working during the staged
+// migration; it is loaded into the page through the bundle entry (src/main.js)
+// rather than the classic script-loader. The internal getTerrainHeight/
+// getTerrainGradient wrappers below delegate to window.Mountains at call time, so
+// they keep working whether Mountains is classic or an ES-module bridge.
+import * as THREE from 'three';
 
 // Create a more realistic tree with visible branches and variability
 function createTree(scale = 1.0) {
@@ -380,7 +391,7 @@ function getTerrainGradient(x, z) {
 }
 
 // Export all tree-related functions
-const Trees = {
+export const Trees = {
   createTree,
   addBranchesAtLayer,
   addSnowCaps,
@@ -389,7 +400,10 @@ const Trees = {
   getTerrainGradient
 };
 
-// Make Trees available globally
+// Backward-compat global export for the still-classic consumers (snow.js reads
+// `Trees` by bare name when it builds the `Snow` namespace; snowglider.js reads
+// it indirectly via `Snow`). Drop this once those consumers import Trees directly
+// (snow.js in PR 2.6/this cluster, snowglider.js in PR 2.9, issue #84).
 if (typeof window !== 'undefined') {
   window.Trees = Trees;
 }

--- a/tests/regression-tests.js
+++ b/tests/regression-tests.js
@@ -5,84 +5,33 @@
  * based on the git history and codebase analysis.
  */
 
-// Require the utils and mountains modules plus THREE.js
-const fs = require('fs');
-const path = require('path');
-const THREE = require('three');
+// mountains.js and snow.js are now ES modules (issue #84), so they can no longer
+// be evaluated as source in a `new Function` + `with(sandbox)` scope. We import
+// the REAL modules and exercise their shipped terrain/snow-effect code directly.
 
-// Mock THREE.js features
-THREE.Color = function() {};
-THREE.CanvasTexture = function() {
-  return {
-    wrapS: 0,
-    wrapT: 0,
-    repeat: { set: () => {} }
+// snow.js builds its `Snow` namespace from `Mountains.*`/`Trees.*` at module-eval
+// time, reading them as bare globals, so we set `global.Mountains` (from the real
+// module) and a lightweight `Trees` mock — these tests only need the Trees
+// function surface, not real meshes — before importing snow.js.
+async function loadUtils() {
+  global.Trees = {
+    createTree: function() {},
+    addTrees: function() { return []; },
+    addBranchesAtLayer: function() {},
+    addSnowCaps: function() {}
   };
-};
-
-// Load Mountains.js content first (since it's not a module, we need to evaluate it)
-const mountainsContent = fs.readFileSync(path.join(__dirname, '..', 'src', 'mountains.js'), 'utf8');
-// Then load Snow.js content which depends on Mountains
-const utilsContent = fs.readFileSync(path.join(__dirname, '..', 'src', 'snow.js'), 'utf8');
-
-// Create a function to execute the content and return the Utils global
-function loadUtils() {
-  // Create a sandbox environment
-  const sandbox = {
-    window: {},
-    document: {
-      createElement: () => ({
-        getContext: () => ({
-          fillRect: () => {},
-          fillStyle: '',
-          createLinearGradient: () => ({
-            addColorStop: () => {}
-          }),
-          createRadialGradient: () => ({
-            addColorStop: () => {}
-          }),
-          beginPath: () => {},
-          moveTo: () => {},
-          lineTo: () => {},
-          stroke: () => {},
-          strokeStyle: ''
-        }),
-        width: 0,
-        height: 0
-      })
-    },
-    THREE: THREE
-  };
-  
-  // Create trees.js mock since tests only use Mountains directly
-  const treesMock = `
-    // Mock Trees for testing
-    const Trees = {
-      createTree: function() {},
-      addTrees: function() { return []; },
-      addBranchesAtLayer: function() {},
-      addSnowCaps: function() {}
-    };
-    if (typeof window !== 'undefined') {
-      window.Trees = Trees;
-    }
-  `;
-  
-  // Create a function to evaluate the mountainsContent first, trees mock, then utilsContent in the sandbox
-  const fn = new Function('sandbox', `
-    with (sandbox) {
-      ${mountainsContent}
-      ${treesMock}
-      ${utilsContent}
-      return Utils;
-    }
-  `);
-  
-  return fn(sandbox);
+  const { Mountains } = await import('../src/mountains.js');
+  global.Mountains = Mountains;
+  const { Snow } = await import('../src/snow.js');
+  return Snow;
 }
 
-// Load the Utils object
-const Utils = loadUtils();
+// Load the Utils object, then run the suite. The import is async, so the whole
+// suite runs inside an async IIFE (closed at the end of the file). `Utils` is
+// declared here (not at module scope) so it shadows the read-only `Utils` global
+// instead of reassigning it.
+(async () => {
+const Utils = await loadUtils();
 
 // Custom assert functions
 function assert(condition, message) {
@@ -643,3 +592,4 @@ console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
 
 // Exit with appropriate code for CI integration
 process.exit(failCount > 0 ? 1 : 0);
+})();

--- a/tests/terrain-tests.js
+++ b/tests/terrain-tests.js
@@ -2,84 +2,33 @@
  * Basic tests for terrain functionality in SnowGlider
  */
 
-// Require the mountains and utils modules directly
-const fs = require('fs');
-const path = require('path');
-const THREE = require('three');
+// mountains.js and snow.js are now ES modules (issue #84), so they can no longer
+// be evaluated as source in a `new Function` + `with(sandbox)` scope. We import
+// the REAL modules and exercise their shipped terrain math directly.
 
-// Mock the necessary THREE functions
-THREE.Color = function() {};
-THREE.CanvasTexture = function() {
-  return {
-    wrapS: 0,
-    wrapT: 0,
-    repeat: { set: () => {} }
+// snow.js builds its `Snow` namespace from `Mountains.*`/`Trees.*` at module-eval
+// time, reading them as bare globals, so we set `global.Mountains` (from the real
+// module) and a lightweight `Trees` mock — these terrain tests only need the
+// Trees function surface, not real meshes — before importing snow.js.
+async function loadUtils() {
+  global.Trees = {
+    createTree: function() {},
+    addTrees: function() { return []; },
+    addBranchesAtLayer: function() {},
+    addSnowCaps: function() {}
   };
-};
-
-// Load Mountains.js content first (since it's not a module, we need to evaluate it)
-const mountainsContent = fs.readFileSync(path.join(__dirname, '..', 'src', 'mountains.js'), 'utf8');
-// Then load Snow.js content which depends on Mountains
-const utilsContent = fs.readFileSync(path.join(__dirname, '..', 'src', 'snow.js'), 'utf8');
-
-// Create a function to execute the content and return the Utils global
-function loadUtils() {
-  // Create a sandbox environment
-  const sandbox = {
-    window: {},
-    document: {
-      createElement: () => ({
-        getContext: () => ({
-          fillRect: () => {},
-          fillStyle: '',
-          createLinearGradient: () => ({
-            addColorStop: () => {}
-          }),
-          createRadialGradient: () => ({
-            addColorStop: () => {}
-          }),
-          beginPath: () => {},
-          moveTo: () => {},
-          lineTo: () => {},
-          stroke: () => {},
-          strokeStyle: ''
-        }),
-        width: 0,
-        height: 0
-      })
-    },
-    THREE: THREE
-  };
-  
-  // Create trees.js mock since tests only use Mountains directly
-  const treesMock = `
-    // Mock Trees for testing
-    const Trees = {
-      createTree: function() {},
-      addTrees: function() { return []; },
-      addBranchesAtLayer: function() {},
-      addSnowCaps: function() {}
-    };
-    if (typeof window !== 'undefined') {
-      window.Trees = Trees;
-    }
-  `;
-
-  // Create a function to evaluate the mountainsContent first, trees mock, then utilsContent in the sandbox
-  const fn = new Function('sandbox', `
-    with (sandbox) {
-      ${mountainsContent}
-      ${treesMock}
-      ${utilsContent}
-      return Utils;
-    }
-  `);
-  
-  return fn(sandbox);
+  const { Mountains } = await import('../src/mountains.js');
+  global.Mountains = Mountains;
+  const { Snow } = await import('../src/snow.js');
+  return Snow;
 }
 
-// Load the Utils object (which internally delegates to Mountains)
-const Utils = loadUtils();
+// Load the Utils object (which internally delegates to Mountains), then run the
+// suite. The import is async, so the whole suite runs inside an async IIFE
+// (closed at the end of the file). `Utils` is declared here (not at module scope)
+// so it shadows the read-only `Utils` global instead of reassigning it.
+(async () => {
+const Utils = await loadUtils();
 
 // Custom assert functions
 function assert(condition, message) {
@@ -336,3 +285,4 @@ console.log(`Tests completed: ${passCount} passed, ${failCount} failed`);
 
 // Exit with appropriate code for CI integration
 process.exit(failCount > 0 ? 1 : 0);
+})();

--- a/tests/verification/physics_invariant_harness.js
+++ b/tests/verification/physics_invariant_harness.js
@@ -84,8 +84,19 @@ function simulate(updateFn, controls, seed, steps = 220, dt = 1 / 60) {
            distance: -15 - pos.z, steps: traj.length, technique: st.technique };
 }
 
+// The frozen baseline is still a classic script, so it loads via vm.runInContext.
+// src/snowman.js is now an ES module (issue #84, PR 2.8) and can't be evaluated
+// that way, so import the REAL module and read its updateSnowman directly. The
+// comparison is unchanged: both return the same updateSnowman(...) contract, and
+// the harness injects terrain + controls as arguments (snowman.js reads no terrain
+// globals). The async import means the checks run inside an async IIFE.
+(async () => {
 const orig = loadUpdate(path.join(__dirname, 'snowman_baseline.js'));
-const mod = loadUpdate(path.join(__dirname, '..', '..', 'src', 'snowman.js'));
+const mod = (await import('../../src/snowman.js')).Snowman.updateSnowman;
+// updateSnowman reads window.treeCollisionRadius / window.location.search for its
+// test-hook + debug-logging paths; the frozen baseline gets these from its vm
+// sandbox, so provide the same minimal stub on the global for the imported module.
+global.window = global.window || { location: { search: '' } };
 
 const NONE = { left: false, right: false, up: false, down: false, jump: false };
 const DOWN = { left: false, right: false, up: false, down: true, jump: false };
@@ -167,3 +178,4 @@ if (!scrubAtSpeed) hardFail = true;
 
 console.log(`\nINVARIANT HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (safety invariant + technique gating checks hold)'}`);
 process.exit(hardFail ? 1 : 0);
+})();

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,8 +22,6 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
-  //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
-  //                   (top-level fns) live in src/snowman.js, not here.
   //   - audio.js:     @ts-checked -> `AudioModule` lives in src/audio.js, not here.
   // AuthModule/ScoresModule/CourseModule/Camera/Controls/EffectsModule stay:
   // auth.js/scores.js (and, as of PR 2.2/2.3/2.5/2.6, course.js/camera.js/
@@ -49,10 +47,14 @@ declare global {
   // until snowglider.js is converted (PR 2.9).
   const Mountains: any;
   const Snow: any;
+  // snowman.js (PR 2.8) is an ES module; `Snowman` is module-scoped there, but
+  // the still-classic snowglider.js reads it by bare name (`Snowman.createSnowman`).
+  // Kept until snowglider.js is converted (PR 2.9).
+  const Snowman: any;
   // Terrain samplers republished onto window by mountains.js (PR 2.7); read by
-  // bare name in the still-classic snowman.js and the converted camera.js/
-  // course.js. (Distinct from the per-run `setTerrainFunction` seam.) Kept until
-  // snowglider.js is converted (PR 2.9).
+  // bare name in the converted snowman.js / camera.js / course.js. (Distinct from
+  // the per-run `setTerrainFunction` seam.) Kept until snowglider.js is converted
+  // (PR 2.9).
   const getTerrainHeight: TerrainHeightFn;
   const getTerrainGradient: (x: number, z: number) => { x: number; z: number };
   const getDownhillDirection: (x: number, z: number) => { x: number; z: number };
@@ -67,9 +69,11 @@ declare global {
   // `avalanche`, `gameActive`, `isInAir`, `startTime`, `bestTime`, …) are real
   // top-level `const`/`let` script-globals in src/snowglider.js — declaring any of
   // them here would be a TS2451 redeclare, so they are intentionally absent.
-  // `resetSnowman`/`updateSnowman` likewise live in snowman.js (still classic).
-  // The Phase 3 step is to replace these ad-hoc globals with a typed GameState
-  // object; `TerrainHeightFn` (above) is kept for that work.
+  // `resetSnowman`/`updateSnowman` are snowglider.js's OWN top-level wrapper
+  // functions (script globals) — distinct from snowman.js's `Snowman.resetSnowman`/
+  // `Snowman.updateSnowman`, which snowglider.js reaches via the namespace — so
+  // they stay absent here too. The Phase 3 step is to replace these ad-hoc globals
+  // with a typed GameState object; `TerrainHeightFn` (above) is kept for that work.
 
   // Classic scripts publish their namespaces onto window; allow those writes.
   // NOTE: `Snow` and `Camera` used to be *bare globals* (NOT window properties),

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,8 +22,6 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
-  //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
-  //   - mountains.js: @ts-checked -> `Mountains` lives in src/mountains.js, not here.
   //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
   //                   (top-level fns) live in src/snowman.js, not here.
   //   - audio.js:     @ts-checked -> `AudioModule` lives in src/audio.js, not here.
@@ -45,6 +43,19 @@ declare global {
   // still-classic snow.js reads it by bare name at eval. Kept until snow.js is
   // converted (same cluster).
   const Trees: any;
+  // mountains.js (PR 2.7) + snow.js (cluster) are ES modules; `Mountains`/`Snow`
+  // are module-scoped there, but bare consumers remain — trees.js/snow.js read
+  // `Mountains`, and snowglider.js reads `Snow` — via the window bridges. Kept
+  // until snowglider.js is converted (PR 2.9).
+  const Mountains: any;
+  const Snow: any;
+  // Terrain samplers republished onto window by mountains.js (PR 2.7); read by
+  // bare name in the still-classic snowman.js and the converted camera.js/
+  // course.js. (Distinct from the per-run `setTerrainFunction` seam.) Kept until
+  // snowglider.js is converted (PR 2.9).
+  const getTerrainHeight: TerrainHeightFn;
+  const getTerrainGradient: (x: number, z: number) => { x: number; z: number };
+  const getDownhillDirection: (x: number, z: number) => { x: number; z: number };
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;
@@ -56,16 +67,17 @@ declare global {
   // `avalanche`, `gameActive`, `isInAir`, `startTime`, `bestTime`, …) are real
   // top-level `const`/`let` script-globals in src/snowglider.js — declaring any of
   // them here would be a TS2451 redeclare, so they are intentionally absent.
-  // `getTerrainHeight`/`resetSnowman`/`updateSnowman` likewise live in trees.js /
-  // snowman.js. The Phase 3 step is to replace these ad-hoc globals with a typed
-  // GameState object; `TerrainHeightFn` (above) is kept for that work.
+  // `resetSnowman`/`updateSnowman` likewise live in snowman.js (still classic).
+  // The Phase 3 step is to replace these ad-hoc globals with a typed GameState
+  // object; `TerrainHeightFn` (above) is kept for that work.
 
   // Classic scripts publish their namespaces onto window; allow those writes.
-  // NOTE: per docs/ARCHITECTURE.md §3, `Snow` is a *bare global* and is NOT a
-  // window property (only `window.Utils` aliases `Snow`), so it is intentionally
-  // absent here. `Camera` used to be a bare global too, but as of PR 2.3 camera.js
-  // is an ES module that publishes a `window.Camera` migration bridge, so it is
-  // listed below until its bare consumer (snowglider.js) is converted (PR 2.9).
+  // NOTE: `Snow` and `Camera` used to be *bare globals* (NOT window properties),
+  // but as of the terrain cluster / PR 2.3 their defining files (snow.js,
+  // camera.js) are ES modules that publish `window.Snow` / `window.Camera`
+  // migration bridges, so they are listed below until their bare consumers
+  // (snowglider.js) are converted (PR 2.9). mountains.js (PR 2.7) likewise
+  // republishes the terrain samplers onto window.
   interface Window {
     AudioModule: any;
     AuthModule: any;
@@ -75,6 +87,10 @@ declare global {
     CourseModule: any;
     EffectsModule: any;
     Mountains: any;
+    Snow: any;
+    getTerrainHeight?: (x: number, z: number) => number;
+    getTerrainGradient?: (x: number, z: number) => { x: number; z: number };
+    getDownhillDirection?: (x: number, z: number) => { x: number; z: number };
     ScoresModule: any;
     SnowGliderFirebase?: any;
     SnowGliderLocalAuth?: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,8 +22,6 @@ declare global {
   // entry here causes "TS2451: Cannot redeclare". So: remove a module's entry
   // from this block in the same change that adds `// @ts-check` to that module.
   //   - avalanche.js: @ts-checked -> `Avalanche` lives in src/avalanche.js, not here.
-  //   - trees.js:     @ts-checked -> `Trees` + `getTerrainHeight`/`getTerrainGradient`
-  //                   (top-level fns) live in src/trees.js, not here.
   //   - snow.js:      @ts-checked -> `Snow` + `Utils` live in src/snow.js, not here.
   //   - mountains.js: @ts-checked -> `Mountains` lives in src/mountains.js, not here.
   //   - snowman.js:   @ts-checked -> `Snowman` + `resetSnowman`/`updateSnowman`
@@ -43,6 +41,10 @@ declare global {
   const Camera: any;
   const Controls: any;
   const EffectsModule: any;
+  // trees.js (PR 2.4) is an ES module; `Trees` is module-scoped there, but the
+  // still-classic snow.js reads it by bare name at eval. Kept until snow.js is
+  // converted (same cluster).
+  const Trees: any;
 
   // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
   const Howl: any;


### PR DESCRIPTION
The terrain cluster of Phase 2, split out from the mechanical-leaf batch (#90) because converting it drags migration of the core physics/terrain Node tests off the `new Function(src)` + mock-THREE loader. Stacked on #90 (PR 2.3/2.5/2.6) → #89 → #87; GitHub auto-retargets as those merge.

These four modules are coupled — they share the bare terrain globals (`getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) and `snow.js` reads `Mountains`/`Trees` at **module-eval time** — so they convert as a small unit, one logical commit per concern.

## Status — complete ✅

- [x] **PR 2.4 — `src/trees.js`:** `import three` + `export const Trees` + `window.Trees` bridge. No test migration (terrain/regression tests use a *Trees mock*; tree-collision-tests is self-contained).
- [x] **PR 2.7 + snow — `src/mountains.js` + `src/snow.js`** (converted **together**): `import three` + `export`. mountains.js republishes the bare terrain samplers (`window.getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) it used to define as script globals; snow.js republishes `window.Snow` (+ legacy `window.Utils`). Converted together because `terrain-tests` + `regression-tests` load *both* via the shared `with(sandbox)` loader, and snow.js reads `Mountains`/`Trees` at eval (so main.js imports mountains+trees before snow). Both Node tests now `import()` the real modules (real `Mountains` + a lightweight `Trees` mock) inside an async IIFE.
- [x] **PR 2.8 — `src/snowman.js`:** `import three` + `export const Snowman` + `window.Snowman` bridge. Receives terrain samplers as *arguments* (no terrain bridge needed). The **physics-invariant harness** now `import()`s the real snowman.js for the current side (frozen classic baseline still via `vm`); the load-bearing coasting invariant stays **bit-identical** to the baseline.

## Why these are riskier than the leaves

This is the terrain-height / tree-collision / skiing-physics core. The guardrail is the physics-invariant harness + `terrain-tests`/`regression-tests`/`tree-collision-tests`/`physics-tests`, all kept green per commit.

## Verification (every commit)

`npm test` (full suite — terrain 7/7, tree-collision 6/6, regression 10/10, physics 12/12, avalanche 12/12, auth 23/23, scores 20/20, invariant harness **OK incl. IDENTICAL coasting**, smoke 18/18), `npm run lint` (0 warnings), `tsc --noEmit`, and `npm run build` + Pages-artifact checks (CNAME + each module's `window.*` bridge in the emitted chunk) all green. (`npm run test:browser` can't run in the sandbox — TLS interception — but is environmental and runs in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)