### PR TITLE
refactor(ts): PR 2.10 — single-source three.js, drop the CDN UMD global (issue #84)

### DIFF
--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -9,27 +9,31 @@
   CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
   `auth.js` / `scores.js` were already ES modules for Firebase; `src/main.js` (the bundle entry),
   **`src/avalanche.js`**, **`src/course.js`**, **`src/camera.js`**, **`src/controls.js`**,
-  **`src/effects.js`**, **`src/trees.js`**, **`src/mountains.js`**, **`src/snow.js`** and
-  **`src/snowman.js`** are now ES modules too. The remaining game modules (`audio.js`, `snowglider.js`)
-  are still classic `<script>` globals loaded via `src/boot/script-loader.js`, with three.js **r160**
-  as a CDN global.
+  **`src/effects.js`**, **`src/trees.js`**, **`src/mountains.js`**, **`src/snow.js`**,
+  **`src/snowman.js`** and (PR 2.9) the orchestrator **`src/snowglider.js`** are now ES modules too —
+  every game module except **`audio.js`**, which is still a classic `<script>` global loaded via
+  `src/boot/script-loader.js`. As of PR 2.10 three.js is **r160 imported from npm** (no CDN global);
+  the `window.*` bridges now serve only the still-classic consumers (the browser-test scripts and
+  `audio.js`).
 - **Build today:** `vite build` produces a **real ES-module bundle** (PR 2.0): `index.html` loads
   `src/main.js` as `<script type="module">`, and Vite resolves its import graph (three from npm +
   each converted module) into a hashed chunk referenced by `dist/index.html`. `copyStaticAppFiles`
-  still copies the static tree so the **classic CDN + script-loader path keeps booting the game**
-  during the staged conversion. Until the loader is retired (PR 2.10), converted modules also load
-  through the bundle and re-publish their `window.*` namespace so the still-classic `snowglider.js`
-  keeps finding them — which means three.js is loaded twice transitionally (CDN UMD for classic
-  scripts, npm/ESM for the bundle; browsers log a benign "Multiple instances of Three.js" warning).
-  An import map in `index.html` resolves the bundle's bare `three` specifier when the page is served
-  as raw source (puppeteer suite, `npm start`); it is inert in the Vite build, where three is bundled.
+  still copies the static tree so the **script-loader path keeps booting the game** during the staged
+  conversion. Converted modules load through the bundle (`src/main.js`) and re-publish their `window.*`
+  namespace so the still-classic consumers — the browser-test scripts and `audio.js` — keep finding
+  them. **PR 2.10** removed the redundant CDN UMD `<script>` global (a *second* copy of r160): three is
+  now single-sourced from npm, so the "Multiple instances of Three.js" warning is gone. An import map in
+  `index.html` resolves the bundle's bare `three` specifier when the page is served as raw source
+  (puppeteer suite, `npm start`) — now pointed at the local `node_modules` copy, so the raw-source path
+  no longer needs the CDN; it is inert in the Vite build, where three is bundled. `main.js` bridges
+  `window.THREE` for the still-classic browser-test scripts that read three by bare name.
   - **`file://` caveat:** because converted modules load via `<script type="module">`, opening
     `index.html` directly (`file://`) no longer loads them — Chrome blocks module + import-map loading
     from a null origin (CORS). The classic-script part of the game still boots, but converted features
     (avalanche, course, camera) are silently disabled by `snowglider.js`'s "module not loaded" fallback. Use
     `npm start` or a build to run the full game. This is an intended consequence of the bundler/server
-    run model (`file://` direct-open is retired by PR 2.10), not a regression; it was raised in Codex
-    review of PR 2.1 and applies equally to every later conversion.
+    run model (direct `file://` open is no longer a supported run mode), not a regression; it was raised
+    in Codex review of PR 2.1 and applies equally to every later conversion.
 - **Converted so far:**
   - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
     Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead
@@ -85,8 +89,25 @@
     "current" side (the frozen classic baseline still loads via `vm.runInContext`) and stubs
     `global.window` for updateSnowman's test-hook/debug paths; the load-bearing coasting invariant
     stays **bit-identical** to the baseline. `physics-tests`/`tree-collision-tests` are self-contained
-    mocks and needed no change. (`snowglider.js` — the orchestrator that unwinds every `window.*`
-    bridge and loose global — and the classic-loader retirement remain as their own later PRs.)
+    mocks and needed no change.
+  - **PR 2.9 — `src/snowglider.js`** (the orchestrator, converted last): `import * as THREE from 'three'`
+    plus direct imports of every converted module instead of CDN-global `THREE` + the `window.*` bridges.
+    It still loads **last + deferred**, so it can't be a classic `<script>`: `src/main.js` exposes
+    `window.__loadSnowGliderOrchestrator = () => import('./snowglider.js')`, which the classic
+    `script-loader.js` calls after audio.js + Auth (snowglider dropped from `GAME_SCRIPT_ORDER`). The
+    dynamic import keeps it in Vite's shared module graph (one Snow/Snowman/… instance) while raw-serve
+    still resolves it to `/src/snowglider.js` (the request the puppeteer start-menu regression
+    intercepts). Browser suites drive the game by bare name, so snowglider re-publishes its mutable
+    state on `window` via get/set accessors; `AudioModule`/`AuthModule`/`ScoresModule`/`firebaseModules`
+    stay `window.*` reads until their own conversion.
+  - **PR 2.10 — three.js de-dup + `window.THREE` bridge:** with every game module now importing three
+    from npm, the redundant CDN UMD `<script>` global in `index.html` (a *second* copy of r160) was
+    removed — three is single-sourced (bundled by Vite, or import-mapped from `node_modules` on the
+    raw-source path, which no longer needs the CDN). `src/main.js` bridges `window.THREE` for the
+    still-classic browser-test scripts (`camera-tests.js`) that read three by bare name. The
+    `script-loader`, the import map, and the per-module `window.*` bridges **remain** — still consumed by
+    the classic browser-test suite and the still-classic `audio.js` — so retiring them is deferred to
+    later PRs (alongside converting `audio.js` and migrating the browser tests to ES modules).
 - **Target:** ES-module TypeScript with full type-checking in CI, `@types/three`, and a thin build step that still ships static files to GitHub Pages.
 - **Guardrail:** the existing test suite (`npm test`) and ESLint must stay green after every phase. No phase is allowed to leave `main` un-deployable.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,9 @@ module.exports = [
         // here until those bare reads are removed.
         Mountains: "readonly",
         ScoresModule: "readonly",
+        // As of PR 2.10 three.js is single-sourced from npm: the CDN UMD global
+        // is gone and main.js bridges `window.THREE`. Kept declared here for the
+        // still-classic browser-test scripts (camera-tests.js) that read it bare.
         THREE: "readonly",
         // trees.js is now an ES module (PR 2.4), but the still-classic snow.js
         // reads `Trees` by bare name (at eval, to build the `Snow` namespace), so

--- a/index.html
+++ b/index.html
@@ -11,14 +11,19 @@
     effect when index.html is served as raw source (the puppeteer suite and
     `npm start`), where converted modules' bare `import * as THREE from 'three'`
     needs a resolvable URL. In the Vite build that ships to snowglider.ai, three
-    is bundled into the hashed chunk, so this map is inert there. Pinned to the
-    same r160 as the classic CDN <script> below to avoid version skew while both
-    load paths coexist (the classic loader is retired in PR 2.10).
+    is bundled into the hashed chunk, so this map is inert there.
+
+    PR 2.10 (issue #84): three.js is now single-sourced from the npm package.
+    The redundant CDN UMD <script> global (a *second* copy of r160) is gone, so
+    this map resolves bare `three` to the same npm build the bundler uses, served
+    locally from node_modules. That removes the version-skew hazard of two
+    coexisting three copies and drops the CDN dependency from the raw-source path
+    (so the puppeteer suite no longer needs network access to a CDN to load three).
   -->
   <script type="importmap">
   {
     "imports": {
-      "three": "https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.module.min.js"
+      "three": "/node_modules/three/build/three.module.min.js"
     }
   }
   </script>
@@ -162,13 +167,14 @@
   <!-- Leaderboard Container (will be added to game over overlay) -->
   <div id="leaderboard" style="display:none;"></div>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.0/three.min.js" integrity="sha512-vnmn/Qqn6aG0POAc9mIGzjq0IybrvxJXYDafNvp9JSnDGxeF3pbkSqLvf+YGd5ku63pT7sa/jxHn7/d0mU8+tA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!--
     ES-module bundle entry (issue #84, Phase 2). Deferred like every module
-    script, so it runs after the classic CDN three.js above is in place but
-    before DOMContentLoaded — i.e. before script-loader.js pulls in the classic
-    game modules. Converted modules (avalanche.js so far) publish their
-    window.* bridge here so the still-classic snowglider.js keeps finding them.
+    script, so it runs before DOMContentLoaded — i.e. before script-loader.js
+    pulls in audio.js + the classic browser-test scripts. main.js imports three
+    from npm and publishes the `window.THREE` + per-module `window.*` bridges that
+    the still-classic browser tests (and audio.js) read. PR 2.10 removed the
+    redundant CDN UMD <script> global that used to sit here; three is now bundled
+    (Vite build) or import-mapped from node_modules (raw source) — a single copy.
   -->
   <script type="module" src="src/main.js"></script>
   <!-- Audio: Simplified implementation using native HTML5 Audio (no library dependencies) -->

--- a/src/main.js
+++ b/src/main.js
@@ -8,9 +8,8 @@ import * as THREE from 'three';
 //
 // Phase 2.1: avalanche.js is the first converted module. Importing it here for
 // its side effect runs its `window.Avalanche = …` bridge before the classic
-// script-loader pulls in snowglider.js, so the still-classic consumer keeps
-// finding the avalanche system. As more modules convert, add them here too
-// until the classic loader is retired (PR 2.10).
+// script-loader pulls in the game/test scripts, so the still-classic consumers
+// (the browser-test suite) keep finding the avalanche system.
 import './avalanche.js';
 // Phase 2.2: course.js, imported for its `window.CourseModule = …` bridge so the
 // still-classic snowglider.js keeps finding the course system.
@@ -47,6 +46,14 @@ if (typeof window !== 'undefined') {
   /** @type {any} */ (window).__SNOWGLIDER_BUNDLE__ = {
     threeRevision: THREE.REVISION
   };
+
+  // PR 2.10 (issue #84): the CDN UMD <script> that used to define the global
+  // `THREE` is gone — three is now single-sourced from npm (bundled by Vite, or
+  // import-mapped from node_modules when index.html is served as raw source).
+  // The still-classic browser-test scripts (camera-tests.js) read three as a
+  // bare global, so bridge it here, exactly like the per-module bridges above.
+  // Drop this once those test scripts are converted to ES modules.
+  /** @type {any} */ (window).THREE = THREE;
 
   // Phase 2.9: snowglider.js (the orchestrator) is now an ES module too, but it
   // must still run LAST — after the classic loader has loaded audio.js + Auth —

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -7,7 +7,11 @@
 import type * as THREE_NS from 'three';
 
 declare global {
-  // three.js r160, loaded as a CDN global (not an ES-module import yet).
+  // three.js r160. As of PR 2.10 the CDN UMD <script> global is gone — three is
+  // single-sourced from npm (every src module `import`s it; main.js bridges
+  // `window.THREE`). Kept declared as an ambient global in lockstep with
+  // eslint.config.js for the still-classic browser-test scripts (camera-tests.js)
+  // that read it bare; drop once those tests become ES modules.
   const THREE: typeof THREE_NS;
 
   /** Terrain height sampler injected via setTerrainFunction (see docs/ARCHITECTURE.md §4). */
@@ -77,6 +81,9 @@ declare global {
   // (snowglider.js) are converted (PR 2.9). mountains.js (PR 2.7) likewise
   // republishes the terrain samplers onto window.
   interface Window {
+    // three.js bridged onto window by main.js (PR 2.10) for the still-classic
+    // browser-test scripts, replacing the removed CDN UMD global.
+    THREE: typeof THREE_NS;
     AudioModule: any;
     AuthModule: any;
     Avalanche: any;


### PR DESCRIPTION
Next step of Phase 2, **stacked on #92 (PR 2.9, snowglider.js)** → #91 → #90 → #89 → #87; GitHub auto-retargets to `main` as those merge. With every game module now importing three from npm (through 2.9), the CDN UMD `<script>` global in `index.html` was a redundant **second copy of r160** — the version-skew hazard the import-map comment itself flagged. This PR single-sources three.js and removes that CDN global.

## Scope — why this isn't the full "loader/import-map/bridge retirement" yet

After 2.9, the classic **browser-test scripts** (loaded by `script-loader.js`) still read the `window.*` module bridges heavily (Camera 46×, Controls 56×, Avalanche 56×, Snowman 37×, Utils 22×, `getTerrainHeight` 21×, `gameActive` 40×…) and `camera-tests.js` still reads **global `THREE`**. `audio.js` is also still a classic `<script>`. So the import map (raw-source needs it to resolve bare `three`), the script-loader (loads audio + the classic test scripts), and the per-module `window.*` bridges are **all still load-bearing**. Retiring them requires converting `audio.js` (flagged HIGH RISK in `CLAUDE.md`) and migrating the whole classic browser-test suite to ES modules — separate, riskier concerns left to later PRs.

What *is* cleanly achievable now is killing the **duplicate three.js**.

## What

- **`index.html`:** delete the CDN UMD `<script>` global; repoint the import map's bare `three` specifier from the CDN module to the local `node_modules` build (`/node_modules/three/build/three.module.min.js`). The raw-source path (puppeteer suite, `npm start`) no longer needs CDN access to load three. Inert in the Vite build, where three is bundled into the hashed chunk.
- **`src/main.js`:** bridge `window.THREE = THREE` for the still-classic browser-test scripts (`camera-tests.js`) that read three by bare name, replacing the removed CDN global. main.js runs deferred, before the script-loader pulls in the test scripts, so the bridge is in place in time. Refresh the now-stale loader/orchestrator comments.
- **`eslint.config.js` / `types/globals.d.ts`:** keep the `THREE` ambient global (classic test scripts still read it) but document it's now window-bridged, not CDN; add the `window.THREE` field to the `Window` interface.
- **`docs/TYPESCRIPT_MIGRATION.md`:** record PR 2.9 (snowglider.js) + PR 2.10, and correct the stale "three loaded twice / CDN global" status now that three is single-sourced (the "Multiple instances of Three.js" warning is gone).

The script-loader, import map, and per-module `window.*` bridges **remain** — still consumed by the classic browser-test suite and the still-classic `audio.js`.

## Verification

`npm test` (full suite — terrain 7/7, tree-collision 6/6, regression 10/10, avalanche 12/12, physics, auth 23/23, scores 20/20, invariant harness **OK incl. IDENTICAL coasting**, smoke 18/18), `npm run lint` (0 warnings), `tsc --noEmit`, and `npm run build` + Pages-artifact checks (CNAME preserved; three bundled with **no bare `three` left in the emitted chunks**; `window.THREE` bridge present) all green.

`npm run test:browser` now **boots the page locally** (three loads from `node_modules` — previously blocked entirely by the CDN), but still can't complete in the sandbox because `auth.js` imports Firebase from `gstatic` (CDN, TLS-intercepted) — environmental, same as the rest of the stack; runs in CI. This PR removed the *three.js* CDN dependency from that path, leaving Firebase as the only remaining one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnjRYK6xenZuae79yG2Zte)_