### PR TITLE
refactor(ts): Phase 2 — audio.js → ESM, migrate browser tests to modules, drop window.* bridges (issue #84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
           test -f dist/LICENSE
           test -f dist/README.md
           test ! -d dist/tests/verification
+          # The verbatim-copied browser tests import bare `three`; Pages has no
+          # node_modules, so the page import map's three build must be published.
+          test -f dist/node_modules/three/build/three.module.min.js
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,15 +33,9 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 ## Commands
 - Install dependencies: `npm ci`
 - Run development server: `npm start` (uses http-server on port 8080)
-- Open locally: `open index.html` or use URL parameters for tests
-  - **Caveat (Phase 2 migration):** modules already converted to ES modules
-    (`avalanche.js`, `course.js`, loaded via `src/main.js` as `<script type="module">`)
-    do **not** load over `file://` in Chrome — module + import-map loading is blocked
-    by CORS (null origin). Opening `index.html` directly still boots the rest of the
-    game, but those converted features are silently disabled (`snowglider.js` falls
-    into its "module not loaded" path). Use `npm start` (or `npm run build` + serve
-    `dist/`) to exercise the full game. This is an intended consequence of the move to
-    a bundler/server run model; `file://` direct-open is being retired by PR 2.10.
+- Open locally through a server (`npm run dev`, `npm start`, or serve `dist/` after `npm run build`).
+  Direct `file://` opens are not supported after the ES-module migration because browser module graphs
+  and the import map do not load reliably from a null origin.
 - Run lint: `npm run lint` (eslint)
 - Run all Node tests: `npm test`
 - Run Node tests with coverage: `npm run test:coverage`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Run the Node suite with `npm test`; in-browser suites load via `?test=…` URL p
 3. Run locally using one of these options:
    - **Option 1:** Run with Vite: `npm run dev` (full features)
    - **Option 2:** Run the legacy static server: `npm start` (full features)
-   - **Option 3:** Open `index.html` directly in your browser (limited features)
+   - Direct `file://` opens are not supported after the ES-module migration.
 
 #### Local Development Notes
 - **Server mode (`npm run dev` or `npm start`):**
@@ -111,12 +111,8 @@ Run the Node suite with `npm test`; in-browser suites load via `?test=…` URL p
   - Best times are stored in localStorage and can be synced to Firebase when online
 
 - **Direct browser mode (opening `index.html` directly):**
-  - Uses the `file://` protocol 
-  - All Firebase services (Authentication and Firestore) are automatically disabled
-  - A "Local File Mode: Firebase disabled" indicator will be displayed
-  - Login UI is hidden and replaced with a "Local Mode" message
-  - Best times are only stored in localStorage
-  - Perfect for quick testing without server setup
+  - Not supported. Browser module graphs and the import map do not load reliably from a `file://` origin.
+  - Use `npm run dev`, `npm start`, or `npm run build` plus a static server.
 
 ### Firebase Setup and Deployment
 
@@ -172,10 +168,8 @@ The application uses the following Firestore collections:
 - Mobile devices now use popup-based authentication for better compatibility with Chrome and other mobile browsers
 
 ### CORS Errors When Opening Directly
-- If you previously saw CORS errors when opening the game directly with `file://` protocol, this has been fixed
-- The game now automatically detects the file:// protocol and provides a fallback implementation
-- Authentication UI is hidden in this mode and replaced with a "Local Mode" indicator
-- All core gameplay features will work without authentication
+- Direct `file://` opens are no longer a supported run mode.
+- Use `npm run dev`, `npm start`, or serve the `dist/` output from `npm run build`.
 
 ### GitHub Pages Deployment
 - The GitHub Pages deployment will continue to work normally with the full set of features

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -27,13 +27,9 @@
   (puppeteer suite, `npm start`) — now pointed at the local `node_modules` copy, so the raw-source path
   no longer needs the CDN; it is inert in the Vite build, where three is bundled. `main.js` bridges
   `window.THREE` for the still-classic browser-test scripts that read three by bare name.
-  - **`file://` caveat:** because converted modules load via `<script type="module">`, opening
-    `index.html` directly (`file://`) no longer loads them — Chrome blocks module + import-map loading
-    from a null origin (CORS). The classic-script part of the game still boots, but converted features
-    (avalanche, course, camera) are silently disabled by `snowglider.js`'s "module not loaded" fallback. Use
-    `npm start` or a build to run the full game. This is an intended consequence of the bundler/server
-    run model (direct `file://` open is no longer a supported run mode), not a regression; it was raised
-    in Codex review of PR 2.1 and applies equally to every later conversion.
+  - **`file://` caveat:** direct `open index.html` is no longer a supported run mode. Browser module
+    graphs and the import map do not load reliably from a null origin (CORS), so use `npm run dev`,
+    `npm start`, or serve the built `dist/` output.
 - **Converted so far:**
   - **PR 2.1 — `src/avalanche.js`:** `import * as THREE from 'three'` + `export class AvalancheSystem`.
     Its Node test (`tests/avalanche-tests.js`) now `import()`s the real module and real three instead

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,7 +98,7 @@ module.exports = [
   {
     // Test suites converted to ES modules (issue #84) — they `import` the real
     // src modules. Grows as each browser-test file is migrated off the window.* bridges.
-    files: ["tests/audio-tests.js"],
+    files: ["tests/audio-tests.js", "tests/controls-tests.js", "tests/camera-tests.js", "tests/browser-avalanche-tests.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,15 +42,13 @@ module.exports = [
         // here until those bare reads are removed.
         Mountains: "readonly",
         ScoresModule: "readonly",
-        // As of PR 2.10 three.js is single-sourced from npm: the CDN UMD global
-        // is gone and main.js bridges `window.THREE`. Kept declared here for the
-        // still-classic browser-test scripts (camera-tests.js) that read it bare.
-        THREE: "readonly",
-        // trees.js is now an ES module (PR 2.4), but the still-classic snow.js
-        // reads `Trees` by bare name (at eval, to build the `Snow` namespace), so
-        // keep it declared here until snow.js is converted (this same cluster).
+        // three.js is single-sourced from npm; every module `import`s it and the
+        // browser tests do too, so the bare `THREE` global (and its window.THREE
+        // bridge) were removed (issue #84).
+        // trees.js is an ES module, but snow.js + mountains.js still read `Trees`
+        // by bare name (via the window bridge) at eval, so keep it declared until
+        // those modules import it directly.
         Trees: "readonly",
-        Utils: "readonly",
         // Terrain samplers republished onto window by mountains.js (PR 2.7). Kept
         // for the window bridge; the converted modules take them as parameters.
         getTerrainHeight: "readonly",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,9 +96,18 @@ module.exports = [
     }
   },
   {
-    // Test suites converted to ES modules (issue #84) — they `import` the real
-    // src modules. Grows as each browser-test file is migrated off the window.* bridges.
-    files: ["tests/audio-tests.js", "tests/controls-tests.js", "tests/camera-tests.js", "tests/browser-avalanche-tests.js"],
+    // Browser-test suites converted to ES modules (issue #84) — they `import` the
+    // real src modules instead of the window.* bridges. (unified-test-runner.js is
+    // still a classic script; the node-only test files stay sourceType: script.)
+    files: [
+      "tests/audio-tests.js",
+      "tests/controls-tests.js",
+      "tests/camera-tests.js",
+      "tests/browser-avalanche-tests.js",
+      "tests/browser-tests.js",
+      "tests/browser-tree-tests.js",
+      "tests/browser-regression-tests.js"
+    ],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,7 +78,7 @@ module.exports = [
     }
   },
   {
-    files: ["src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/trees.js"],
+    files: ["src/audio.js", "src/auth.js", "src/avalanche.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/trees.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,18 +37,10 @@ module.exports = [
         // 2.10). avalanche.js is likewise only read as window.Avalanche.
         Howl: "readonly",
         Howler: "readonly",
-        // mountains.js is now an ES module (PR 2.7), but trees.js + snow.js read
-        // `Mountains` by bare name (the window bridge) at eval, so keep it declared
-        // here until those bare reads are removed.
-        Mountains: "readonly",
         ScoresModule: "readonly",
-        // three.js is single-sourced from npm; every module `import`s it and the
-        // browser tests do too, so the bare `THREE` global (and its window.THREE
-        // bridge) were removed (issue #84).
-        // trees.js is an ES module, but snow.js + mountains.js still read `Trees`
-        // by bare name (via the window bridge) at eval, so keep it declared until
-        // those modules import it directly.
-        Trees: "readonly",
+        // three.js + Mountains + Trees are single-sourced from npm and imported by
+        // every consumer (the terrain trio import each other), so their bare
+        // globals + window bridges were removed (issue #84).
         // Terrain samplers republished onto window by mountains.js (PR 2.7). Kept
         // for the window bridge; the converted modules take them as parameters.
         getTerrainHeight: "readonly",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,14 +38,11 @@ module.exports = [
         Howl: "readonly",
         Howler: "readonly",
         ScoresModule: "readonly",
-        // three.js + Mountains + Trees are single-sourced from npm and imported by
-        // every consumer (the terrain trio import each other), so their bare
-        // globals + window bridges were removed (issue #84).
-        // Terrain samplers republished onto window by mountains.js (PR 2.7). Kept
-        // for the window bridge; the converted modules take them as parameters.
-        getTerrainHeight: "readonly",
-        getTerrainGradient: "readonly",
-        getDownhillDirection: "readonly",
+        // three.js + Mountains + Trees + the terrain samplers (getTerrainHeight/
+        // getTerrainGradient/getDownhillDirection) are single-sourced from npm and
+        // reached via imports (terrain trio + camera.js) or injected parameters
+        // (snowman.js, course.js), so their bare globals + window bridges were all
+        // removed (issue #84).
         // snowman.js's checkTreeCollision test hook reads these two as bare globals
         // (not its parameters), and the browser test suites reassign them to drive
         // the live game; snowglider.js re-publishes them on window via accessors

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,5 +94,13 @@ module.exports = [
     rules: {
       "no-undef": "off"
     }
+  },
+  {
+    // Test suites converted to ES modules (issue #84) — they `import` the real
+    // src modules. Grows as each browser-test file is migrated off the window.* bridges.
+    files: ["tests/audio-tests.js"],
+    languageOptions: {
+      sourceType: "module"
+    }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:regression": "node tests/regression-tests.js",
     "test:tree-collision": "node tests/tree-collision-tests.js",
     "test:avalanche": "node tests/avalanche-tests.js",
-    "test:auth": "node tests/auth-tests.js",
+    "test:auth": "node tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",
     "test:scores": "node tests/scores-tests.js",
     "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node tests/verification/dom_smoke_test.js",

--- a/src/audio.js
+++ b/src/audio.js
@@ -2,6 +2,13 @@
 // audio.js - Radically simplified audio using native HTML5 Audio
 // ~100 lines max, single track, minimal state management
 //
+// Phase 2 (issue #84): converted off the classic global model. `AudioModule` is
+// now `export`ed and loaded through the bundle entry (src/main.js) rather than
+// the classic script-loader. This module uses no three.js, so there is no
+// `import * as THREE`. The `window.AudioModule` assignment below is kept so the
+// still-window consumers (snowglider.js bare reads, start-menu.js, and the
+// classic audio-tests browser suite) keep working until they import it directly.
+//
 // Design principles:
 // 1. Native HTML5 Audio element - no library dependencies
 // 2. Single track only (drum_loop) - no track switching complexity
@@ -31,7 +38,7 @@ const AUDIO_ENABLED = true;
  * @property {string} [contextState]
  */
 
-const AudioModule = (function() {
+export const AudioModule = (function() {
   let audio = null;
   let muted = false;
   let initialized = false;
@@ -201,4 +208,8 @@ const AudioModule = (function() {
   };
 })();
 
-window.AudioModule = AudioModule;
+// Backward-compat global export for the still-window consumers (snowglider.js
+// reads `AudioModule` by bare name; start-menu.js + audio-tests use window.AudioModule).
+if (typeof window !== 'undefined') {
+  /** @type {any} */ (window).AudioModule = AudioModule;
+}

--- a/src/avalanche.js
+++ b/src/avalanche.js
@@ -224,13 +224,5 @@ export class AvalancheSystem {
   }
 }
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `window.Avalanche.AvalancheSystem`). Drop this once snowglider.js is
-// converted to import AvalancheSystem directly (PR 2.9, issue #84).
-const Avalanche = {
-  AvalancheSystem
-};
-
-if (typeof window !== 'undefined') {
-  window.Avalanche = Avalanche;
-}
+// The window.Avalanche bridge was removed (issue #84): snowglider.js imports
+// AvalancheSystem and the avalanche browser tests import it too.

--- a/src/boot/firebase-bootstrap.js
+++ b/src/boot/firebase-bootstrap.js
@@ -59,8 +59,29 @@
     authScript.type = 'module';
     authScript.id = 'authScript';
     authScript.src = 'src/auth.js';
+    // If Firebase was merely slow, waitForAuthModule may have already timed out
+    // and booted the local fallback. src/auth.js then finishes here and overwrites
+    // window.AuthModule with the real, uninitialized module. Re-initialize it so
+    // the real Google login handlers / auth listener get installed instead of
+    // leaving the page stuck in local mode. No-op on the happy path (the fallback
+    // never ran) and when waitForAuthModule already initialized the real module.
+    authScript.addEventListener('load', () => {
+      if (localFallbackActivated &&
+          window.AuthModule &&
+          typeof window.AuthModule.initializeAuth === 'function') {
+        console.log("src/auth.js loaded after local fallback - re-initializing the real AuthModule.");
+        initializeAuthModule();
+      }
+    });
     head.appendChild(authScript);
   }
+
+  // Set when we degrade to the localStorage fallback because the Firebase auth
+  // module did not load in time (slow CDN/network, not a hard failure). src/auth.js
+  // assigns window.AuthModule unconditionally, so if it finishes *after* the
+  // fallback it silently replaces the initialized stub with the real, but
+  // *uninitialized*, module — see the authScript 'load' handler below.
+  let localFallbackActivated = false;
 
   // Install the localStorage-backed Auth/Scores stubs from local-auth.js. Used
   // both for file:// (no Firebase by design) and as a graceful-degradation
@@ -108,6 +129,7 @@
             // mode and resolve so the game still boots, instead of rejecting
             // and aborting the entire startup chain.
             console.warn("AuthModule failed to load after timeout - falling back to local mode.");
+            localFallbackActivated = true;
             installLocalAuthFallback();
             resolve();
           }

--- a/src/boot/firebase-bootstrap.js
+++ b/src/boot/firebase-bootstrap.js
@@ -70,6 +70,7 @@
           window.AuthModule &&
           typeof window.AuthModule.initializeAuth === 'function') {
         console.log("src/auth.js loaded after local fallback - re-initializing the real AuthModule.");
+        clearLocalAuthFallbackUi();
         initializeAuthModule();
       }
     });
@@ -101,6 +102,21 @@
     if (!window.AuthModule && typeof localAuth.installAuthModule === 'function') {
       localAuth.installAuthModule();
     }
+  }
+
+  function clearLocalAuthFallbackUi() {
+    const authContainer = document.getElementById('authContainer');
+    const localModeNotice = authContainer
+      ? authContainer.querySelector('.local-mode-notice')
+      : null;
+    if (localModeNotice) {
+      localModeNotice.remove();
+    }
+
+    const authUI = document.getElementById('authUI');
+    const profileUI = document.getElementById('profileUI');
+    if (authUI) authUI.style.display = 'flex';
+    if (profileUI) profileUI.style.display = 'none';
   }
 
   function waitForAuthModule() {

--- a/src/boot/firebase-bootstrap.js
+++ b/src/boot/firebase-bootstrap.js
@@ -62,6 +62,26 @@
     head.appendChild(authScript);
   }
 
+  // Install the localStorage-backed Auth/Scores stubs from local-auth.js. Used
+  // both for file:// (no Firebase by design) and as a graceful-degradation
+  // fallback over http when the Firebase modules fail to load (offline, a CDN
+  // outage, or a blocked gstatic request). Without this fallback a single
+  // failed gstatic fetch would reject waitForAuthModule and take the whole game
+  // down with it; instead we boot in local mode (CLAUDE.md: "graceful
+  // degradation to localStorage when Firebase is unavailable").
+  function installLocalAuthFallback() {
+    const localAuth = window.SnowGliderLocalAuth;
+    if (!localAuth) {
+      return;
+    }
+    if (!window.ScoresModule && typeof localAuth.installScoresModule === 'function') {
+      localAuth.installScoresModule();
+    }
+    if (!window.AuthModule && typeof localAuth.installAuthModule === 'function') {
+      localAuth.installAuthModule();
+    }
+  }
+
   function waitForAuthModule() {
     if (isFileProtocol) {
       if (window.SnowGliderLocalAuth &&
@@ -72,7 +92,7 @@
       return Promise.resolve();
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       let checkCount = 0;
       const maxChecks = 25;
       const checkInterval = setInterval(() => {
@@ -84,8 +104,12 @@
           checkCount++;
           if (checkCount >= maxChecks) {
             clearInterval(checkInterval);
-            console.error("AuthModule failed to load after timeout.");
-            reject(new Error("AuthModule failed to load"));
+            // Firebase did not come up in time — degrade gracefully to local
+            // mode and resolve so the game still boots, instead of rejecting
+            // and aborting the entire startup chain.
+            console.warn("AuthModule failed to load after timeout - falling back to local mode.");
+            installLocalAuthFallback();
+            resolve();
           }
         }
       }, 200);

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -56,13 +56,26 @@
     avalanche: ['browser-avalanche-tests']
   };
 
-  function loadScript(src) {
+  function appendScript(src, configureScript) {
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
+      if (typeof configureScript === 'function') {
+        configureScript(script);
+      }
       script.src = src;
-      script.onload = resolve;
+      script.onload = () => resolve();
       script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
       document.body.appendChild(script);
+    });
+  }
+
+  function loadScript(src) {
+    return appendScript(src);
+  }
+
+  function loadModuleScript(src) {
+    return appendScript(src, (script) => {
+      script.type = 'module';
     });
   }
 
@@ -82,21 +95,35 @@
 
     console.log(`Loading test scripts for test parameter: ${testParam}`);
 
-    const testUtils = document.createElement('script');
-    testUtils.src = 'tests/unified-test-runner.js';
-    document.body.appendChild(testUtils);
-
     // Every browser-test suite is now an ES module (issue #84): loaded as
     // `<script type="module">` so they `import` the real src modules instead of
     // reading window.* bridges. (unified-test-runner.js stays a classic script —
     // it imports nothing and only reads window.run*Tests, which the modules set.)
     const selectedScripts = TEST_SCRIPTS[testParam] || [];
-    selectedScripts.forEach((scriptName) => {
-      const testScript = document.createElement('script');
-      testScript.type = 'module';
-      testScript.src = `tests/${scriptName}.js`;
-      document.body.appendChild(testScript);
+
+    if (testParam === 'unified') {
+      // Set this before module test suites evaluate so they publish their
+      // window.run*Tests hooks without also self-starting.
+      /** @type {any} */ (window)._unifiedTestRunnerActive = true;
+    }
+
+    const testModuleLoads = selectedScripts.map((scriptName) => {
+      return loadModuleScript(`tests/${scriptName}.js`);
     });
+
+    Promise.allSettled(testModuleLoads)
+      .then((results) => {
+        results.forEach((result, index) => {
+          if (result.status === 'rejected') {
+            console.error(`Failed to load test module ${selectedScripts[index]}:`, result.reason);
+          }
+        });
+
+        return loadScript('tests/unified-test-runner.js');
+      })
+      .catch((error) => {
+        console.error("Failed to load unified test runner:", error);
+      });
   }
 
   function preloadAudio() {

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -86,22 +86,14 @@
     testUtils.src = 'tests/unified-test-runner.js';
     document.body.appendChild(testUtils);
 
-    // Test suites converted to ES modules (issue #84): loaded as
-    // `<script type="module">` so they can `import` the real src modules instead
-    // of reading window.* bridges. The rest remain classic until converted.
-    const MODULE_TESTS = new Set([
-      'audio-tests',
-      'controls-tests',
-      'camera-tests',
-      'browser-avalanche-tests'
-    ]);
-
+    // Every browser-test suite is now an ES module (issue #84): loaded as
+    // `<script type="module">` so they `import` the real src modules instead of
+    // reading window.* bridges. (unified-test-runner.js stays a classic script —
+    // it imports nothing and only reads window.run*Tests, which the modules set.)
     const selectedScripts = TEST_SCRIPTS[testParam] || [];
     selectedScripts.forEach((scriptName) => {
       const testScript = document.createElement('script');
-      if (MODULE_TESTS.has(scriptName)) {
-        testScript.type = 'module';
-      }
+      testScript.type = 'module';
       testScript.src = `tests/${scriptName}.js`;
       document.body.appendChild(testScript);
     });

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -86,9 +86,19 @@
     testUtils.src = 'tests/unified-test-runner.js';
     document.body.appendChild(testUtils);
 
+    // Test suites converted to ES modules (issue #84): loaded as
+    // `<script type="module">` so they can `import` the real src modules instead
+    // of reading window.* bridges. The rest remain classic until converted.
+    const MODULE_TESTS = new Set([
+      'audio-tests'
+    ]);
+
     const selectedScripts = TEST_SCRIPTS[testParam] || [];
     selectedScripts.forEach((scriptName) => {
       const testScript = document.createElement('script');
+      if (MODULE_TESTS.has(scriptName)) {
+        testScript.type = 'module';
+      }
       testScript.src = `tests/${scriptName}.js`;
       document.body.appendChild(testScript);
     });

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -11,7 +11,9 @@
     // via the bundle entry (src/main.js), not this classic loader.
     // snowman.js converted to an ES module (issue #84, PR 2.8); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
-    'src/audio.js'
+    // audio.js converted to an ES module (issue #84); it now loads via the
+    // bundle entry (src/main.js), not this classic loader. GAME_SCRIPT_ORDER is
+    // now empty — every game module loads through src/main.js.
     // controls.js converted to an ES module (issue #84, PR 2.5); it now loads
     // via the bundle entry (src/main.js), not this classic loader.
     // avalanche.js converted to an ES module (issue #84, PR 2.1); it now loads

--- a/src/boot/script-loader.js
+++ b/src/boot/script-loader.js
@@ -90,7 +90,10 @@
     // `<script type="module">` so they can `import` the real src modules instead
     // of reading window.* bridges. The rest remain classic until converted.
     const MODULE_TESTS = new Set([
-      'audio-tests'
+      'audio-tests',
+      'controls-tests',
+      'camera-tests',
+      'browser-avalanche-tests'
     ]);
 
     const selectedScripts = TEST_SCRIPTS[testParam] || [];

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,14 +1,12 @@
 // @ts-check
 // camera.js - Camera management for SnowGlider
 //
-// Phase 2.3 (issue #84): third module converted off the classic global model.
-// `THREE` now comes from the npm package via a real ES-module import instead of
-// the CDN global, and the class is `export`ed. The window.Camera assignment
-// below is kept so the still-classic consumer (snowglider.js, which reads
-// `Camera` by bare name and is converted last in PR 2.9) keeps working during
-// the staged migration; it is loaded into the page through the bundle entry
-// (src/main.js) rather than the classic script-loader.
+// Phase 2.3 (issue #84): converted off the classic global model. `THREE` and the
+// terrain sampler (`Mountains.getTerrainHeight`) now come from real ES-module
+// imports instead of the CDN global / window bridge, and the class is `export`ed.
+// Loaded via the bundle entry (src/main.js).
 import * as THREE from 'three';
+import { Mountains } from './mountains.js';
 
 export class Camera {
   constructor(scene) {
@@ -168,7 +166,7 @@ export class Camera {
     this.camera.position.lerp(this.smoothingVectors.targetPosition, effectiveSmoothingFactor);
     
     // Maintain minimum height above terrain to prevent camera from going below ground
-    const terrainHeightAtCamera = getTerrainHeight(this.camera.position.x, this.camera.position.z);
+    const terrainHeightAtCamera = Mountains.getTerrainHeight(this.camera.position.x, this.camera.position.z);
     if (this.camera.position.y < terrainHeightAtCamera + 5) {
       this.camera.position.y = terrainHeightAtCamera + 5;
     }

--- a/src/camera.js
+++ b/src/camera.js
@@ -239,9 +239,4 @@ export class Camera {
   }
 }
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `Camera` by bare name as `new Camera(scene)`). Drop this once
-// snowglider.js is converted to import Camera directly (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.Camera = Camera;
-}
+// The window.Camera bridge was removed (issue #84): snowglider.js imports Camera.

--- a/src/controls.js
+++ b/src/controls.js
@@ -510,9 +510,5 @@ function setupButtonTouchHandlers() {
   }
 }
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `Controls` by bare name, e.g. `Controls.setupControls()`). Drop this
-// once snowglider.js is converted to import Controls directly (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.Controls = Controls;
-}
+// The window.Controls bridge was removed (issue #84): snowglider.js and the
+// controls browser tests import Controls.

--- a/src/course.js
+++ b/src/course.js
@@ -593,9 +593,4 @@ export const CourseModule = (function () {
   };
 })();
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `CourseModule`/`window.CourseModule`). Drop this once snowglider.js is
-// converted to import CourseModule directly (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.CourseModule = CourseModule;
-}
+// The window.CourseModule bridge was removed (issue #84): snowglider.js imports it.

--- a/src/effects.js
+++ b/src/effects.js
@@ -189,10 +189,4 @@ export const EffectsModule = (function () {
   return { init, updateAvalanche, addShake, tickCamera, reset };
 })();
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `EffectsModule` by bare name, e.g. `EffectsModule.tickCamera(...)`). Drop
-// this once snowglider.js is converted to import EffectsModule directly
-// (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.EffectsModule = EffectsModule;
-}
+// The window.EffectsModule bridge was removed (issue #84): snowglider.js imports it.

--- a/src/main.js
+++ b/src/main.js
@@ -3,45 +3,29 @@ import * as THREE from 'three';
 
 // Phase 2.0 (issue #84): a real ES-module entry that Vite bundles into a
 // hashed asset, importing three.js from the npm package instead of the CDN
-// global. Per-module conversions (PR 2.1 onward) move each game module onto
-// this bundle, which index.html now loads as `<script type="module">`.
+// global. index.html loads this as `<script type="module">`.
 //
-// Phase 2.1: avalanche.js is the first converted module. Importing it here for
-// its side effect runs its `window.Avalanche = …` bridge before the classic
-// script-loader pulls in the game/test scripts, so the still-classic consumers
-// (the browser-test suite) keep finding the avalanche system.
+// Most game modules are imported here only so they're part of the eagerly-loaded
+// bundle graph; snowglider.js (the deferred orchestrator) imports them too, and
+// the browser tests import the ones they need directly. Their per-module
+// `window.*` namespace bridges have been removed (issue #84). Two side effects
+// here are still load-bearing:
+//   1. The terrain trio (trees.js, mountains.js, snow.js) must run in THIS order:
+//      snow.js reads `Mountains`/`Trees` by bare name at module-eval (via the
+//      window.Mountains / window.Trees bridges those two still publish), so both
+//      must execute before snow.js. mountains.js also publishes the
+//      window.getTerrainHeight/getTerrainGradient/getDownhillDirection samplers.
+//   2. audio.js publishes the still-needed window.AudioModule bridge (read by the
+//      classic start-menu.js + the audio browser tests).
 import './avalanche.js';
-// Phase 2.2: course.js, imported for its `window.CourseModule = …` bridge so the
-// still-classic snowglider.js keeps finding the course system.
 import './course.js';
-// Phase 2.3: camera.js, imported for its `window.Camera = …` bridge so the
-// still-classic snowglider.js keeps finding the Camera class (`new Camera(...)`).
 import './camera.js';
-// Phase 2.5: controls.js, imported for its `window.Controls = …` bridge so the
-// still-classic snowglider.js keeps finding the input controls.
 import './controls.js';
-// Phase 2.6: effects.js, imported for its `window.EffectsModule = …` bridge so the
-// still-classic snowglider.js keeps finding the avalanche/camera-juice effects.
 import './effects.js';
-// Phase 2.4: trees.js, imported for its `window.Trees = …` bridge. Imported before
-// snow.js (below) because snow.js reads `Trees` at module-eval time when it builds
-// the `Snow` namespace.
 import './trees.js';
-// Phase 2.7: mountains.js, imported for its `window.Mountains = …` +
-// `window.getTerrainHeight/getTerrainGradient/getDownhillDirection` bridges. Also
-// imported before snow.js, which reads `Mountains` at module-eval time.
 import './mountains.js';
-// Phase 2.6/cluster: snow.js, imported LAST of the terrain trio for its
-// `window.Snow`/`window.Utils` bridges — it reads `Mountains`/`Trees` at eval, so
-// both must already be bridged above.
 import './snow.js';
-// Phase 2.8: snowman.js, imported for its `window.Snowman = …` bridge so the
-// still-classic snowglider.js keeps finding the snowman model + physics.
 import './snowman.js';
-// Phase 2 (audio): audio.js, imported for its `window.AudioModule = …` bridge so
-// snowglider.js (bare `AudioModule` reads), start-menu.js, and the audio-tests
-// browser suite keep finding it. It was the last game module loaded by the
-// classic script-loader; with this import GAME_SCRIPT_ORDER is empty.
 import './audio.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
@@ -52,13 +36,10 @@ if (typeof window !== 'undefined') {
     threeRevision: THREE.REVISION
   };
 
-  // PR 2.10 (issue #84): the CDN UMD <script> that used to define the global
-  // `THREE` is gone — three is now single-sourced from npm (bundled by Vite, or
-  // import-mapped from node_modules when index.html is served as raw source).
-  // The still-classic browser-test scripts (camera-tests.js) read three as a
-  // bare global, so bridge it here, exactly like the per-module bridges above.
-  // Drop this once those test scripts are converted to ES modules.
-  /** @type {any} */ (window).THREE = THREE;
+  // The window.THREE bridge was removed (issue #84): three is single-sourced
+  // from npm (bundled by Vite, or import-mapped from node_modules in raw source),
+  // and the browser-test scripts that used to read it bare (camera-tests.js) now
+  // `import * as THREE from 'three'` directly.
 
   // Phase 2.9: snowglider.js (the orchestrator) is now an ES module too, but it
   // must still run LAST — after the classic loader has loaded audio.js + Auth —

--- a/src/main.js
+++ b/src/main.js
@@ -38,6 +38,11 @@ import './snow.js';
 // Phase 2.8: snowman.js, imported for its `window.Snowman = …` bridge so the
 // still-classic snowglider.js keeps finding the snowman model + physics.
 import './snowman.js';
+// Phase 2 (audio): audio.js, imported for its `window.AudioModule = …` bridge so
+// snowglider.js (bare `AudioModule` reads), start-menu.js, and the audio-tests
+// browser suite keep finding it. It was the last game module loaded by the
+// classic script-loader; with this import GAME_SCRIPT_ORDER is empty.
+import './audio.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/mountains.js
+++ b/src/mountains.js
@@ -439,13 +439,6 @@ export const Mountains = {
   heightMap // Expose the heightmap for debugging
 };
 
-// The window.Mountains bridge was removed (issue #84): trees.js and snow.js
-// import Mountains directly now. The bare terrain samplers are still republished
-// onto `window` because snowman.js / camera.js / course.js read them by bare name
-// (resolving via this bridge) — drop these once those modules take the samplers
-// as imports/parameters.
-if (typeof window !== 'undefined') {
-  window.getTerrainHeight = getTerrainHeight;
-  window.getTerrainGradient = getTerrainGradient;
-  window.getDownhillDirection = getDownhillDirection;
-}
+// All window.* bridges from mountains.js are gone (issue #84). Consumers get the
+// terrain samplers via imports (camera.js, trees.js, snow.js import Mountains) or
+// as injected parameters (snowman.js, course.js receive them from snowglider.js).

--- a/src/mountains.js
+++ b/src/mountains.js
@@ -1,16 +1,18 @@
 // @ts-check
 // mountains.js - Terrain and mountain features for snowglider
 //
-// Phase 2.7 (issue #84): converted off the classic global model. `THREE` now
-// comes from the npm package via a real ES-module import instead of the CDN
-// global, and `Mountains` is `export`ed. Because mountains.js used to define the
-// terrain sampler functions (`getTerrainHeight`/`getTerrainGradient`/
-// `getDownhillDirection`) as bare script globals, the bottom of this file now
-// republishes them onto `window` so the still-classic/converted consumers that
-// read them by bare name (snowman.js, plus the already-converted camera.js and
-// course.js) keep resolving them during the staged migration. It is loaded into
-// the page through the bundle entry (src/main.js) rather than the classic loader.
+// Phase 2.7 (issue #84): converted off the classic global model. `THREE` and the
+// `Trees` module now come from real ES-module imports, and `Mountains` is
+// `export`ed. mountains.js and trees.js import each other (the cross-references
+// run only at call time, so the circular import resolves cleanly).
+//
+// The bottom of this file still republishes the terrain sampler functions
+// (`getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) onto `window`,
+// because snowman.js, camera.js and course.js still read them by bare name
+// (resolving via the window bridge). Those bridges stay until those modules take
+// the samplers as imports/parameters.
 import * as THREE from 'three';
+import { Trees } from './trees.js';
 
 // --- SimplexNoise implementation ---
 class SimplexNoise {
@@ -288,8 +290,8 @@ function createTerrain(scene) {
   
   // Add trees to make the slope more visible using the separate Trees module
   let treePositions = [];
-  if (typeof window !== 'undefined' && window.Trees && window.Trees.addTrees) {
-    treePositions = window.Trees.addTrees(scene);
+  if (Trees && typeof Trees.addTrees === 'function') {
+    treePositions = Trees.addTrees(scene);
   } else {
     console.warn("Trees module not found, skipping tree creation");
   }
@@ -437,15 +439,12 @@ export const Mountains = {
   heightMap // Expose the heightmap for debugging
 };
 
-// Backward-compat global exports for the still-classic / staged consumers.
-// `window.Mountains` is read by trees.js and snow.js (as a bridge) and indirectly
-// by snowglider.js via `Snow`. The bare terrain samplers below used to be script
-// globals defined by this (classic) file; now that it is an ES module they are
-// republished onto `window` so bare reads in snowman.js / camera.js / course.js
-// keep resolving. Drop these once all consumers import the functions directly
-// (snowman.js in this cluster, snowglider.js in PR 2.9, issue #84).
+// The window.Mountains bridge was removed (issue #84): trees.js and snow.js
+// import Mountains directly now. The bare terrain samplers are still republished
+// onto `window` because snowman.js / camera.js / course.js read them by bare name
+// (resolving via this bridge) — drop these once those modules take the samplers
+// as imports/parameters.
 if (typeof window !== 'undefined') {
-  window.Mountains = Mountains;
   window.getTerrainHeight = getTerrainHeight;
   window.getTerrainGradient = getTerrainGradient;
   window.getDownhillDirection = getDownhillDirection;

--- a/src/snow.js
+++ b/src/snow.js
@@ -408,14 +408,7 @@ export const Snow = {
 // For backward compatibility, alias Utils to Snow
 const Utils = Snow;
 
-// Backward-compat global exports. snowglider.js reads `Snow` by bare name
-// (`Snow.getTerrainHeight`, `Snow.addTrees`, …); as a classic script it used to
-// see snow.js's top-level `const Snow` via the shared script scope, but now that
-// snow.js is an ES module that binding is module-scoped, so we republish it onto
-// `window` (bare `Snow` in the classic snowglider.js resolves via window). The
-// legacy `window.Utils` alias is preserved. Drop both once snowglider.js imports
-// Snow directly (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.Snow = Snow;
-  window.Utils = Snow;
-}
+// The window.Snow / window.Utils bridges were removed (issue #84): snowglider.js
+// imports Snow, and the browser tests import it as `Snow as Utils`. (snow.js still
+// reads Mountains/Trees via their window bridges at eval — those remain until
+// mountains.js/trees.js are imported here.)

--- a/src/snow.js
+++ b/src/snow.js
@@ -1,16 +1,15 @@
 // @ts-check
 // Snow.js - Utility functions for the snowman skiing game
 //
-// Phase 2.6/cluster (issue #84): converted off the classic global model. `THREE`
-// now comes from the npm package via a real ES-module import instead of the CDN
-// global, and `Snow` is `export`ed. snow.js builds its `Snow` namespace from
-// `Mountains.*` and `Trees.*` at module-eval time, reading them as bare globals,
-// so it must load AFTER mountains.js and trees.js — src/main.js imports it last
-// of the three for exactly that reason. The window.Snow / window.Utils bridges
-// below keep the still-classic snowglider.js (which reads `Snow` by bare name)
-// working until it is converted (PR 2.9). Loaded via the bundle entry, not the
-// classic script-loader.
+// Phase 2.6/cluster (issue #84): converted off the classic global model. `THREE`,
+// `Mountains` and `Trees` now come from real ES-module imports, and `Snow` is
+// `export`ed. snow.js builds its `Snow` namespace from `Mountains.*` and `Trees.*`
+// at module-eval time; the imports guarantee both are evaluated first, so the
+// previous bare-global reads (via window bridges) are gone. Loaded via the bundle
+// entry, not the classic script-loader.
 import * as THREE from 'three';
+import { Mountains } from './mountains.js';
+import { Trees } from './trees.js';
 
 // Mountains features are now in mountains.js
 // This file now delegates terrain/mountain calls to mountains.js

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -1262,6 +1262,12 @@ window.initializeGameWithAudio = function() {
     gameActive:         { get: () => gameActive,         set: (v) => { gameActive = v; } },
     isInAir:            { get: () => isInAir,            set: (v) => { isInAir = v; } },
     verticalVelocity:   { get: () => verticalVelocity,   set: (v) => { verticalVelocity = v; } },
+    // jumpCooldown is reassigned by the gameplay suite (testJumpMechanics). It must
+    // be republished like the others: now that browser-tests.js is an ES module
+    // (strict mode), a bare `jumpCooldown = 0` assignment to an unpublished name
+    // throws a ReferenceError instead of silently creating a sloppy-mode global
+    // (issue #84).
+    jumpCooldown:       { get: () => jumpCooldown,       set: (v) => { jumpCooldown = v; } },
     bestTime:           { get: () => bestTime,           set: (v) => { bestTime = v; } },
     startTime:          { get: () => startTime,          set: (v) => { startTime = v; } },
     avalancheTriggered: { get: () => avalancheTriggered, set: (v) => { avalancheTriggered = v; } },

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -1282,6 +1282,15 @@ window.initializeGameWithAudio = function() {
     avalanche:          { get: () => avalanche },
     snowSplash:         { get: () => snowSplash },
     terrain:            { get: () => terrain },
+    // Live terrain sampler for the browser tests. camera.js imports the sampler
+    // directly (window.getTerrainHeight* was dropped from production in 0781822),
+    // but the deployed GitHub Pages artifact runs dist/index.html from Vite's
+    // bundle while the verbatim-copied dist/tests/*.js import a *second* copy of
+    // snow.js — whose heightMap is never populated by createTerrain and whose
+    // per-vertex Math.random() noise differs anyway. testCameraAboveTerrain must
+    // sample the same terrain instance the live camera clamps to, so republish the
+    // bundled sampler here (test seam only) instead of importing a fork (issue #84).
+    getTerrainHeight:   { get: () => Snow.getTerrainHeight },
     updateCamera:       { get: () => updateCamera },
     updateSnowman:      { get: () => updateSnowman }
   };

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -1294,6 +1294,12 @@ window.initializeGameWithAudio = function() {
     // sample the same terrain instance the live camera clamps to, so republish the
     // bundled sampler here (test seam only) instead of importing a fork (issue #84).
     getTerrainHeight:   { get: () => Snow.getTerrainHeight },
+    // Live Controls accessor for the gameplay suite. On the deployed Pages
+    // artifact the verbatim-copied dist/tests/*.js import a *second* Controls
+    // module instance, so `Controls.getControls().jump = true` in the test would
+    // mutate a fork while the bundled updateSnowman reads this singleton. Publish
+    // the live getControls so the test drives the same instance (issue #84).
+    getControls:        { get: () => Controls.getControls },
     updateCamera:       { get: () => updateCamera },
     updateSnowman:      { get: () => updateSnowman }
   };

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -447,6 +447,9 @@ document.body.appendChild(cameraToggleBtn);
 function updateSnowman(delta) {
   // We no longer need to add test hooks every frame as they're set up at initialization
   // and after resets. This improves performance.
+  const activeShowGameOver = typeof window.showGameOver === 'function'
+    ? window.showGameOver
+    : showGameOver;
   
   // Update snowman using the Snowman module function
   const result = Snowman.updateSnowman(
@@ -454,7 +457,7 @@ function updateSnowman(delta) {
     lastTerrainHeight, airTime, jumpCooldown, Controls.getControls(), 
     turnPhase, currentTurnDirection, turnChangeCooldown, turnAmplitude,
     Snow.getTerrainHeight, Snow.getTerrainGradient, Snow.getDownhillDirection, 
-    treePositions, gameActive, showGameOver
+    treePositions, gameActive, activeShowGameOver
   );
   
   // Update state variables from the result

--- a/src/snowglider.js
+++ b/src/snowglider.js
@@ -12,9 +12,9 @@
 // Snow/Snowman/Mountains/etc. instances as main.js instead of forking a second
 // copy from the verbatim dist/src tree.
 //
-// Still read as globals (not yet ES modules): AudioModule (audio.js is classic);
-// AuthModule/ScoresModule/firebaseModules (published onto window by the Firebase
-// bootstrap). Those stay window.* reads until their own conversion.
+// Still read as globals (not yet ES modules): AuthModule/ScoresModule/
+// firebaseModules (published onto window by the Firebase bootstrap). Those stay
+// window.* reads until their own conversion.
 import * as THREE from 'three';
 import { Camera } from './camera.js';
 import { Controls } from './controls.js';
@@ -23,6 +23,7 @@ import { Snowman } from './snowman.js';
 import { CourseModule } from './course.js';
 import { EffectsModule } from './effects.js';
 import { AvalancheSystem } from './avalanche.js';
+import { AudioModule } from './audio.js';
 
 // Get keyboard controls from the Controls module
 Controls.setupControls();

--- a/src/snowman.js
+++ b/src/snowman.js
@@ -861,9 +861,5 @@ export const Snowman = {
   addTestHooks
 };
 
-// Backward-compat global export for the still-classic consumer (snowglider.js
-// reads `Snowman` by bare name, e.g. `Snowman.createSnowman(scene)`). Drop this
-// once snowglider.js is converted to import Snowman directly (PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.Snowman = Snowman;
-}
+// The window.Snowman bridge was removed (issue #84): snowglider.js and the
+// gameplay browser tests import Snowman.

--- a/src/trees.js
+++ b/src/trees.js
@@ -1,16 +1,13 @@
 // @ts-check
 // trees.js - Tree creation and management for snowglider
 //
-// Phase 2.4 (issue #84): converted off the classic global model. `THREE` now
-// comes from the npm package via a real ES-module import instead of the CDN
-// global, and `Trees` is `export`ed. The window.Trees assignment below is kept so
-// the still-classic consumers (snow.js reads `Trees` by bare name at eval time;
-// snowglider.js is converted last in PR 2.9) keep working during the staged
-// migration; it is loaded into the page through the bundle entry (src/main.js)
-// rather than the classic script-loader. The internal getTerrainHeight/
-// getTerrainGradient wrappers below delegate to window.Mountains at call time, so
-// they keep working whether Mountains is classic or an ES-module bridge.
+// Phase 2.4 (issue #84): converted off the classic global model. `THREE` and the
+// terrain samplers (`Mountains`) now come from real ES-module imports instead of
+// the CDN global / window bridges, and `Trees` is `export`ed. mountains.js and
+// trees.js import each other (the cross-references are only used at call time, so
+// the circular import resolves cleanly).
 import * as THREE from 'three';
+import { Mountains } from './mountains.js';
 
 // Create a more realistic tree with visible branches and variability
 function createTree(scale = 1.0) {
@@ -356,35 +353,23 @@ function addTrees(scene) {
   return treePositions;
 }
 
-// Helper function to use Mountains utility to get terrain height
+// Helper function to use the Mountains module to get terrain height.
 function getTerrainHeight(x, z) {
-  // First try to use global function
-  if (window && window.Mountains && window.Mountains.getTerrainHeight) {
-    return window.Mountains.getTerrainHeight(x, z);
-  }
-  
-  // Fallback to accessing via the Mountains global
-  if (typeof Mountains !== 'undefined' && Mountains.getTerrainHeight) {
+  if (Mountains && Mountains.getTerrainHeight) {
     return Mountains.getTerrainHeight(x, z);
   }
-  
+
   // Last resort - approximate with zero height
   console.warn('Trees: getTerrainHeight function not found');
   return 0;
 }
 
-// Helper function to use Mountains utility to get terrain gradient
+// Helper function to use the Mountains module to get terrain gradient.
 function getTerrainGradient(x, z) {
-  // First try to use global function
-  if (window && window.Mountains && window.Mountains.getTerrainGradient) {
-    return window.Mountains.getTerrainGradient(x, z);
-  }
-  
-  // Fallback to accessing via the Mountains global
-  if (typeof Mountains !== 'undefined' && Mountains.getTerrainGradient) {
+  if (Mountains && Mountains.getTerrainGradient) {
     return Mountains.getTerrainGradient(x, z);
   }
-  
+
   // Last resort - approximate with flat gradient
   console.warn('Trees: getTerrainGradient function not found');
   return { x: 0, z: 0 };
@@ -400,10 +385,5 @@ export const Trees = {
   getTerrainGradient
 };
 
-// Backward-compat global export for the still-classic consumers (snow.js reads
-// `Trees` by bare name when it builds the `Snow` namespace; snowglider.js reads
-// it indirectly via `Snow`). Drop this once those consumers import Trees directly
-// (snow.js in PR 2.6/this cluster, snowglider.js in PR 2.9, issue #84).
-if (typeof window !== 'undefined') {
-  window.Trees = Trees;
-}
+// The window.Trees bridge was removed (issue #84): snow.js and mountains.js
+// import Trees directly now.

--- a/tests/audio-tests.js
+++ b/tests/audio-tests.js
@@ -1,6 +1,12 @@
 // Audio Test Suite for SnowGlider
 // Tests for simplified native HTML5 Audio implementation
 // Run with: open index.html?test=unified or index.html?test=audio
+//
+// Phase 2 (issue #84): converted to an ES module. It imports AudioModule from
+// the real src module instead of reading the window.AudioModule bridge, and is
+// loaded via `<script type="module">` by the boot script-loader. It still
+// publishes window.runAudioTests so the unified runner can invoke it.
+import { AudioModule } from '../src/audio.js';
 
 (function() {
   if (window.location.search.includes('test=') && !window._unifiedTestRunnerActive) {

--- a/tests/browser-avalanche-tests.js
+++ b/tests/browser-avalanche-tests.js
@@ -22,12 +22,16 @@ import { AvalancheSystem } from '../src/avalanche.js';
       (window.location.search.includes('test=true') && window.location.search.includes('avalanche=true'))) && 
       !window.location.search.includes('test=unified') && 
       !window._unifiedTestRunnerActive) {
-    // Wait for game to initialize
-    window.addEventListener('load', function() {
+    if (document.readyState === 'complete') {
       console.log("Avalanche tests initializing from direct URL parameter");
-      // Give the game a moment to fully initialize
       setTimeout(runAvalancheTests, 500);
-    });
+    } else {
+      window.addEventListener('load', function() {
+        console.log("Avalanche tests initializing from direct URL parameter");
+        // Give the game a moment to fully initialize
+        setTimeout(runAvalancheTests, 500);
+      });
+    }
   }
   
   // Expose the test runner for the unified test system

--- a/tests/browser-avalanche-tests.js
+++ b/tests/browser-avalanche-tests.js
@@ -10,6 +10,11 @@
 // 6. Avalanche Reset - tests avalanche resets with game reset
 //
 // The tests can be run individually or as part of the unified test suite (index.html?test=unified)
+//
+// Phase 2 (issue #84): converted to an ES module — imports AvalancheSystem from the
+// real src module instead of probing the window.Avalanche bridge; loaded via
+// `<script type="module">`. Still publishes window.runAvalancheTests for the runner.
+import { AvalancheSystem } from '../src/avalanche.js';
 
 (function() {
   // Only run tests if ?test=avalanche is in the URL and not running through the unified test runner
@@ -136,12 +141,11 @@
 
     // Test 1: Avalanche System Initialization
     function testAvalancheInitialization() {
-      // Check that Avalanche module is loaded
-      const moduleLoaded = typeof window.Avalanche !== 'undefined' && 
-                          window.Avalanche.AvalancheSystem !== undefined;
-      
-      assert(moduleLoaded, 'Avalanche Module Loaded', 
-        moduleLoaded ? 'Avalanche module is properly loaded' : 
+      // Check that the Avalanche module is loaded (imported from src/avalanche.js)
+      const moduleLoaded = typeof AvalancheSystem === 'function';
+
+      assert(moduleLoaded, 'Avalanche Module Loaded',
+        moduleLoaded ? 'Avalanche module is properly loaded' :
         'Avalanche module failed to load');
       
       // Check that avalanche system is initialized in the game

--- a/tests/browser-regression-tests.js
+++ b/tests/browser-regression-tests.js
@@ -3,7 +3,12 @@
  * 
  * Add to index.html with: ?test=regression
  * These tests focus on gameplay regressions identified from git history
+ *
+ * Phase 2 (issue #84): converted to an ES module — imports the Snow (`Utils`)
+ * namespace from src/snow.js instead of the window.Utils bridge; loaded via
+ * `<script type="module">`. Still publishes window.runRegressionTests for the runner.
  */
+import { Snow as Utils } from '../src/snow.js';
 
 (function() {
   // Only run if ?test=regression is in the URL and not running through the unified test runner

--- a/tests/browser-regression-tests.js
+++ b/tests/browser-regression-tests.js
@@ -13,11 +13,14 @@ import { Snow as Utils } from '../src/snow.js';
 (function() {
   // Only run if ?test=regression is in the URL and not running through the unified test runner
   if (window.location.search.includes('test=regression') && !window.location.search.includes('unified=true') && !window._unifiedTestRunnerActive) {
-    // Wait for game to initialize
-    window.addEventListener('load', function() {
-      // Give the game a moment to fully initialize
+    if (document.readyState === 'complete') {
       setTimeout(runRegressionTests, 500);
-    });
+    } else {
+      window.addEventListener('load', function() {
+        // Give the game a moment to fully initialize
+        setTimeout(runRegressionTests, 500);
+      });
+    }
   }
 
   // Expose the test runner for the unified test system

--- a/tests/browser-tests.js
+++ b/tests/browser-tests.js
@@ -1,5 +1,14 @@
 // SnowGlider Test Suite
 // Run with: open index.html?test=true in browser
+//
+// Phase 2 (issue #84): converted to an ES module — imports the Snow (`Utils`),
+// Controls, and Snowman namespaces from the real src modules instead of reading
+// the window.* bridges; loaded via `<script type="module">`. Runtime game state
+// (pos/velocity/scene/snowman/…) is still read via the window seam snowglider.js
+// publishes. Still publishes window.runGameTests for the unified runner.
+import { Snow as Utils } from '../src/snow.js';
+import { Controls } from '../src/controls.js';
+import { Snowman } from '../src/snowman.js';
 
 (function() {
   // Only run tests if ?test=true is in the URL and not running through the unified test runner
@@ -142,9 +151,9 @@
       // If test hooks don't exist, call the Snowman module to set them up
       if (!window.testHooks || !window.testHooks.forceTreeCollision) {
         console.log("COLLISION TEST: Test hooks missing, requesting setup from Snowman module");
-        if (window.Snowman && typeof window.Snowman.addTestHooks === 'function') {
+        if (Snowman && typeof Snowman.addTestHooks === 'function') {
           console.log("COLLISION TEST: Using Snowman.addTestHooks to set up hooks");
-          window.Snowman.addTestHooks(pos, window.showGameOver, Utils.getTerrainHeight);
+          Snowman.addTestHooks(pos, window.showGameOver, Utils.getTerrainHeight);
         } else {
           console.error("COLLISION TEST: Snowman module or addTestHooks function not available!");
         }
@@ -339,9 +348,9 @@
       // If test hooks don't exist, call the Snowman module to set them up
       if (!window.testHooks || !window.testHooks.forceTreeCollision) {
         console.log("GAME OVER TEST: Test hooks missing, requesting setup from Snowman module");
-        if (window.Snowman && typeof window.Snowman.addTestHooks === 'function') {
+        if (Snowman && typeof Snowman.addTestHooks === 'function') {
           console.log("GAME OVER TEST: Using Snowman.addTestHooks to set up hooks");
-          window.Snowman.addTestHooks(pos, originalShowGameOver, Utils.getTerrainHeight);
+          Snowman.addTestHooks(pos, originalShowGameOver, Utils.getTerrainHeight);
         } else {
           console.error("GAME OVER TEST: Snowman module or addTestHooks function not available!");
         }
@@ -584,9 +593,9 @@
       // If test hooks don't exist, call the Snowman module to set them up
       if (!window.testHooks || !window.testHooks.forceTreeCollision) {
         console.log("BEST TIME TEST: Test hooks missing, requesting setup from Snowman module");
-        if (window.Snowman && typeof window.Snowman.addTestHooks === 'function') {
+        if (Snowman && typeof Snowman.addTestHooks === 'function') {
           console.log("BEST TIME TEST: Using Snowman.addTestHooks to set up hooks");
-          window.Snowman.addTestHooks(pos, window.showGameOver, gameActive, Utils.getTerrainHeight);
+          Snowman.addTestHooks(pos, window.showGameOver, gameActive, Utils.getTerrainHeight);
         } else {
           console.error("BEST TIME TEST: Snowman module or addTestHooks function not available!");
         }

--- a/tests/browser-tests.js
+++ b/tests/browser-tests.js
@@ -1,13 +1,18 @@
 // SnowGlider Test Suite
 // Run with: open index.html?test=true in browser
 //
-// Phase 2 (issue #84): converted to an ES module — imports the Snow (`Utils`),
-// Controls, and Snowman namespaces from the real src modules instead of reading
-// the window.* bridges; loaded via `<script type="module">`. Runtime game state
-// (pos/velocity/scene/snowman/…) is still read via the window seam snowglider.js
-// publishes. Still publishes window.runGameTests for the unified runner.
+// Phase 2 (issue #84): converted to an ES module — imports the Snow (`Utils`)
+// and Snowman namespaces from the real src modules; loaded via
+// `<script type="module">`. Runtime game state (pos/velocity/scene/snowman/…) is
+// still read via the window seam snowglider.js publishes. Still publishes
+// window.runGameTests for the unified runner.
+//
+// Controls is NOT imported: testJumpMechanics mutates the live controls object
+// (jump = true) that the bundled updateSnowman reads, so it must use the same
+// singleton. On the deployed Pages artifact a local `import` would resolve to a
+// second Controls instance, so we read the live one via window.getControls()
+// (published on the test seam by snowglider.js).
 import { Snow as Utils } from '../src/snow.js';
-import { Controls } from '../src/controls.js';
 import { Snowman } from '../src/snowman.js';
 
 (function() {
@@ -389,8 +394,8 @@ import { Snowman } from '../src/snowman.js';
       
       // Trigger a jump
       jumpCooldown = 0;
-      // Get the controls object and set jump to true
-      const controls = Controls.getControls();
+      // Get the LIVE controls object (same instance updateSnowman reads) and set jump
+      const controls = window.getControls();
       controls.jump = true;
       updateSnowman(0.1);
       

--- a/tests/browser-tests.js
+++ b/tests/browser-tests.js
@@ -18,11 +18,16 @@ import { Snowman } from '../src/snowman.js';
 (function() {
   // Only run tests if ?test=true is in the URL and not running through the unified test runner
   if (window.location.search.includes('test=true') && !window.location.search.includes('unified=true') && !window._unifiedTestRunnerActive) {
-    // Wait for game to initialize
-    window.addEventListener('load', function() {
-      // Give the game a moment to fully initialize
+    // These module tests are injected after auth/game startup, which can happen
+    // after window load when Firebase falls back slowly.
+    if (document.readyState === 'complete') {
       setTimeout(runTests, 500);
-    });
+    } else {
+      window.addEventListener('load', function() {
+        // Give the game a moment to fully initialize
+        setTimeout(runTests, 500);
+      });
+    }
   }
 
   // Expose the test runner for the unified test system

--- a/tests/browser-tree-tests.js
+++ b/tests/browser-tree-tests.js
@@ -15,11 +15,14 @@ import { Snow as Utils } from '../src/snow.js';
 (function() {
   // Only run if ?test=trees is in the URL and not running through the unified test runner
   if (window.location.search.includes('test=trees') && !window.location.search.includes('unified=true') && !window._unifiedTestRunnerActive) {
-    // Wait for game to initialize
-    window.addEventListener('load', function() {
-      // Give the game a moment to fully initialize
+    if (document.readyState === 'complete') {
       setTimeout(runTreeTests, 500);
-    });
+    } else {
+      window.addEventListener('load', function() {
+        // Give the game a moment to fully initialize
+        setTimeout(runTreeTests, 500);
+      });
+    }
   }
   
   // Expose the test runner for the unified test system

--- a/tests/browser-tree-tests.js
+++ b/tests/browser-tree-tests.js
@@ -5,7 +5,12 @@
  * that have been identified in the git history.
  * 
  * Run with: open index.html?test=trees
+ *
+ * Phase 2 (issue #84): converted to an ES module — imports the Snow (`Utils`)
+ * namespace from src/snow.js instead of the window.Utils bridge; loaded via
+ * `<script type="module">`. Still publishes window.runTreeTests for the runner.
  */
+import { Snow as Utils } from '../src/snow.js';
 
 (function() {
   // Only run if ?test=trees is in the URL and not running through the unified test runner

--- a/tests/camera-tests.js
+++ b/tests/camera-tests.js
@@ -9,6 +9,13 @@
 // 5. Camera Smoothing - tests smooth camera movement and following behavior
 //
 // The tests can be run individually or as part of the unified test suite (index.html?test=unified)
+//
+// Phase 2 (issue #84): converted to an ES module — imports three from npm and the
+// terrain sampler from src/snow.js (the `Snow`/`Utils` namespace) instead of reading
+// the window.THREE / window.Utils bridges; loaded via `<script type="module">`.
+// Still publishes window.runCameraTests for the unified runner.
+import * as THREE from 'three';
+import { Snow as Utils } from '../src/snow.js';
 
 (function() {
   // Only run tests if ?test=camera is in the URL and not running through the unified test runner

--- a/tests/camera-tests.js
+++ b/tests/camera-tests.js
@@ -27,12 +27,16 @@ import * as THREE from 'three';
       (window.location.search.includes('test=true') && window.location.search.includes('camera=true'))) && 
       !window.location.search.includes('test=unified') && 
       !window._unifiedTestRunnerActive) {
-    // Wait for game to initialize
-    window.addEventListener('load', function() {
+    if (document.readyState === 'complete') {
       console.log("Camera tests initializing from direct URL parameter");
-      // Give the game a moment to fully initialize
       setTimeout(runCameraTests, 500);
-    });
+    } else {
+      window.addEventListener('load', function() {
+        console.log("Camera tests initializing from direct URL parameter");
+        // Give the game a moment to fully initialize
+        setTimeout(runCameraTests, 500);
+      });
+    }
   }
   
   // Expose the test runner for the unified test system

--- a/tests/camera-tests.js
+++ b/tests/camera-tests.js
@@ -445,12 +445,18 @@ import { Snow as Utils } from '../src/snow.js';
       // Force reset of game
       resetSnowman();
       
-      // Camera smoothing vectors should all be initialized (not undefined)
+      // Camera smoothing vectors should all be initialized (not undefined).
+      // Use three's `.isVector3` duck-type flag rather than `instanceof THREE.Vector3`:
+      // on the deployed Pages artifact the game runs from the Vite-bundled three while
+      // this copied test imports the standalone import-map three, so the two are
+      // different module instances and `instanceof` would be false even when the live
+      // camera is correct. `.isVector3` is three's canonical cross-instance check (issue #84).
+      const isVector3 = (v) => Boolean(v && v.isVector3 === true);
       const vectorsExist = (
         cameraManager.smoothingVectors &&
-        cameraManager.smoothingVectors.lastPosition instanceof THREE.Vector3 &&
-        cameraManager.smoothingVectors.targetPosition instanceof THREE.Vector3 &&
-        cameraManager.smoothingVectors.lookAtPosition instanceof THREE.Vector3
+        isVector3(cameraManager.smoothingVectors.lastPosition) &&
+        isVector3(cameraManager.smoothingVectors.targetPosition) &&
+        isVector3(cameraManager.smoothingVectors.lookAtPosition)
       );
       
       assert(vectorsExist, 'Camera Vector Initialization', 

--- a/tests/camera-tests.js
+++ b/tests/camera-tests.js
@@ -10,12 +10,16 @@
 //
 // The tests can be run individually or as part of the unified test suite (index.html?test=unified)
 //
-// Phase 2 (issue #84): converted to an ES module — imports three from npm and the
-// terrain sampler from src/snow.js (the `Snow`/`Utils` namespace) instead of reading
-// the window.THREE / window.Utils bridges; loaded via `<script type="module">`.
-// Still publishes window.runCameraTests for the unified runner.
+// Phase 2 (issue #84): converted to an ES module — imports three from npm; loaded
+// via `<script type="module">`. Still publishes window.runCameraTests for the
+// unified runner.
+//
+// Terrain height is read from the LIVE game via window.getTerrainHeight (published
+// on the test seam by snowglider.js) rather than importing src/snow.js here. On the
+// deployed GitHub Pages artifact a local `import` would resolve to a second copy of
+// snow.js whose terrain heightMap is unpopulated and randomly noised, so it would
+// disagree with the bundled terrain the live camera actually clamps to.
 import * as THREE from 'three';
-import { Snow as Utils } from '../src/snow.js';
 
 (function() {
   // Only run tests if ?test=camera is in the URL and not running through the unified test runner
@@ -408,14 +412,14 @@ import { Snow as Utils } from '../src/snow.js';
         // Move snowman to test location
         pos.x = location.x;
         pos.z = location.z;
-        pos.y = Utils.getTerrainHeight(location.x, location.z);
+        pos.y = window.getTerrainHeight(location.x, location.z);
         snowman.position.set(pos.x, pos.y, pos.z);
-        
+
         // Update camera
         updateCamera();
-        
-        // Get terrain height at camera position
-        const terrainHeightAtCamera = Utils.getTerrainHeight(camera.position.x, camera.position.z);
+
+        // Get terrain height at camera position (live game's terrain instance)
+        const terrainHeightAtCamera = window.getTerrainHeight(camera.position.x, camera.position.z);
         
         // Camera should be at least 5 units above terrain
         const minHeightAboveTerrain = 5;

--- a/tests/controls-tests.js
+++ b/tests/controls-tests.js
@@ -384,11 +384,14 @@ function runControlsTests() {
 
 // Auto-run tests if not in Node.js environment and test param is set
 if (typeof window !== 'undefined' && window.location.search.includes('test=controls')) {
-  // Wait for game to initialize
-  window.addEventListener('load', function() {
-    // Give the game a moment to fully initialize
+  if (document.readyState === 'complete') {
     setTimeout(runControlsTests, 500);
-  });
+  } else {
+    window.addEventListener('load', function() {
+      // Give the game a moment to fully initialize
+      setTimeout(runControlsTests, 500);
+    });
+  }
 }
 
 // Export for Node.js environment and unified test runner

--- a/tests/controls-tests.js
+++ b/tests/controls-tests.js
@@ -1,6 +1,11 @@
 /**
  * Controls module tests for SnowGlider
+ *
+ * Phase 2 (issue #84): converted to an ES module — imports Controls from the real
+ * src module instead of reading the window.Controls bridge; loaded via
+ * `<script type="module">`. Still publishes window.runControlsTests for the runner.
  */
+import { Controls } from '../src/controls.js';
 
 // Helper function to simulate keyboard events
 function simulateKeyEvent(type, key) {

--- a/tests/firebase-bootstrap-tests.js
+++ b/tests/firebase-bootstrap-tests.js
@@ -1,0 +1,74 @@
+// firebase-bootstrap-tests.js
+// Headless coverage for the auth bootstrap fallback/recovery path.
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const REPO = path.join(__dirname, '..');
+
+let pass = 0;
+let fail = 0;
+
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  condition ? pass++ : fail++;
+}
+
+function loadBrowserScript(window, relativePath) {
+  const code = fs.readFileSync(path.join(REPO, relativePath), 'utf8');
+  window.eval(code);
+}
+
+async function main() {
+  console.log('--- Firebase bootstrap late-auth recovery ---');
+
+  const dom = new JSDOM(`<!doctype html><html><head></head><body>
+    <div id="authContainer">
+      <div id="authUI" style="display:flex"><button id="loginBtn">Login with Google</button></div>
+      <div id="profileUI" style="display:none"></div>
+    </div>
+  </body></html>`, {
+    url: 'https://snowglider.ai/',
+    runScripts: 'outside-only'
+  });
+  const { window } = dom;
+  window.console = console;
+
+  loadBrowserScript(window, 'src/boot/local-auth.js');
+  loadBrowserScript(window, 'src/boot/firebase-bootstrap.js');
+
+  await window.SnowGliderFirebase.waitForAuthModule();
+  window.SnowGliderFirebase.initializeAuthModule();
+
+  const authContainer = window.document.getElementById('authContainer');
+  const authUI = window.document.getElementById('authUI');
+  const profileUI = window.document.getElementById('profileUI');
+  check('local fallback appends a local-mode notice',
+    !!authContainer.querySelector('.local-mode-notice'));
+  check('local fallback hides real auth UI',
+    authUI.style.display === 'none' && profileUI.style.display === 'none');
+
+  let realInitCalls = 0;
+  window.AuthModule = {
+    initializeAuth: () => { realInitCalls++; },
+    isFirebaseAvailable: () => ({ auth: true, firestore: true, analytics: true })
+  };
+
+  const authScript = window.document.getElementById('authScript');
+  authScript.dispatchEvent(new window.Event('load'));
+
+  check('late real auth load removes stale local-mode notice',
+    !authContainer.querySelector('.local-mode-notice'));
+  check('late real auth load resets signed-out auth UI',
+    authUI.style.display === 'flex' && profileUI.style.display === 'none');
+  check('late real auth module is initialized',
+    realInitCalls === 1);
+
+  console.log(`\nFIREBASE BOOTSTRAP TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch(error => {
+  console.error('Firebase bootstrap test crashed:', error);
+  process.exit(1);
+});

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -261,9 +261,12 @@ async function runBrowserTests() {
             return true;
           }
           
-          // Also check if tests completed but summary text isn't updated
+          // Also check if tests completed but summary text isn't updated. This
+          // must use the runner's expected count; resolving at a hard-coded lower
+          // count can silently skip later suites.
           const counts = window._unifiedTestCounts;
-          if (counts && counts.completed && counts.completed.length >= 6) {
+          const expectedSuiteCount = window._unifiedExpectedSuiteCount || 7;
+          if (counts && counts.completed && counts.completed.length >= expectedSuiteCount) {
             resolve({
               passed: counts.passed,
               failed: counts.failed,

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -220,8 +220,15 @@ async function runBrowserTests() {
     await page.waitForSelector('canvas', { timeout: 10000 });
     console.log('Canvas loaded');
     
-    // Simulate user interaction to trigger audio tests and unlock audio context
-    await page.click('body');
+    // Simulate user interaction to trigger audio tests and unlock audio context.
+    // The unified results overlay (zIndex 99999) can cover the body's center, so
+    // click a fixed top-left corner outside it; tolerate failure since autoplay is
+    // already permitted via the --autoplay-policy launch flag.
+    try {
+      await page.mouse.click(5, 5);
+    } catch (clickErr) {
+      console.warn('Audio-unlock click skipped:', clickErr.message);
+    }
     await new Promise(r => setTimeout(r, 1000));
     
     // Wait for tests to complete

--- a/tests/unified-test-runner.js
+++ b/tests/unified-test-runner.js
@@ -86,6 +86,7 @@
       { name: 'avalanche', runner: window.runAvalancheTests, started: false, completed: false },
       { name: 'regression', runner: window.runRegressionTests, started: false, completed: false }
     ];
+    window._unifiedExpectedSuiteCount = testSuites.length;
     
     // Callback for tests to signal completion
     window._testCompleteCallback = function(testName, error) {

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -31,15 +31,11 @@ declare global {
   // they're still referenced loosely.
   const AuthModule: any;
   const ScoresModule: any;
-  // trees.js / mountains.js (and snow.js) now import each other directly, so the
-  // bare `Trees` / `Mountains` globals + their window bridges were removed (#84).
-  // Terrain samplers republished onto window by mountains.js (PR 2.7). Kept as a
-  // loose ambient global for the window bridge; the converted modules take them as
-  // parameters rather than reading these names. (Distinct from the per-run
-  // `setTerrainFunction` seam.)
-  const getTerrainHeight: TerrainHeightFn;
-  const getTerrainGradient: (x: number, z: number) => { x: number; z: number };
-  const getDownhillDirection: (x: number, z: number) => { x: number; z: number };
+  // trees.js / mountains.js / snow.js import each other directly, camera.js imports
+  // Mountains, and snowman.js / course.js receive the terrain samplers as injected
+  // parameters — so the bare `Trees` / `Mountains` / `getTerrainHeight` /
+  // `getTerrainGradient` / `getDownhillDirection` globals + their window bridges
+  // were all removed (issue #84). `TerrainHeightFn` is still used below.
 
   // snowman.js's checkTreeCollision test hook reads these two as bare globals
   // (they are not its parameters, unlike `pos`/`getTerrainHeight`). snowglider.js
@@ -70,17 +66,13 @@ declare global {
   // (snowglider.js) are converted (PR 2.9). mountains.js (PR 2.7) likewise
   // republishes the terrain samplers onto window.
   interface Window {
-    // AudioModule still bridged (start-menu.js + the audio browser tests read
-    // window.AudioModule); the terrain samplers (getTerrainHeight*) are still
-    // bridged (snowman.js/camera.js/course.js read them by bare name). The
-    // THREE/Avalanche/Camera/Controls/CourseModule/EffectsModule/Snow/Snowman/
-    // Utils/Mountains/Trees bridges were removed (issue #84) — every consumer
-    // imports those directly now.
+    // AudioModule is the last module-namespace bridge (start-menu.js + the audio
+    // browser tests read window.AudioModule). The THREE/Avalanche/Camera/Controls/
+    // CourseModule/EffectsModule/Snow/Snowman/Utils/Mountains/Trees bridges and the
+    // getTerrainHeight* terrain samplers were all removed (issue #84) — every
+    // consumer imports those directly or receives them as injected parameters.
     AudioModule: any;
     AuthModule: any;
-    getTerrainHeight?: (x: number, z: number) => number;
-    getTerrainGradient?: (x: number, z: number) => { x: number; z: number };
-    getDownhillDirection?: (x: number, z: number) => { x: number; z: number };
     ScoresModule: any;
     SnowGliderFirebase?: any;
     SnowGliderLocalAuth?: any;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -31,14 +31,8 @@ declare global {
   // they're still referenced loosely.
   const AuthModule: any;
   const ScoresModule: any;
-  // trees.js (PR 2.4) is an ES module; `Trees` is module-scoped there, but
-  // snow.js reads it by bare name at eval (via the window bridge). Kept until
-  // snow.js stops reading it bare.
-  const Trees: any;
-  // mountains.js (PR 2.7) is an ES module; `Mountains` is module-scoped there,
-  // but snow.js (and trees.js) read it by bare name at eval via the window bridge.
-  // Kept until those bare reads are removed.
-  const Mountains: any;
+  // trees.js / mountains.js (and snow.js) now import each other directly, so the
+  // bare `Trees` / `Mountains` globals + their window bridges were removed (#84).
   // Terrain samplers republished onto window by mountains.js (PR 2.7). Kept as a
   // loose ambient global for the window bridge; the converted modules take them as
   // parameters rather than reading these names. (Distinct from the per-run
@@ -77,13 +71,13 @@ declare global {
   // republishes the terrain samplers onto window.
   interface Window {
     // AudioModule still bridged (start-menu.js + the audio browser tests read
-    // window.AudioModule); Mountains/Trees still bridged (snow.js/mountains.js
-    // read them by bare name at eval). The THREE/Avalanche/Camera/Controls/
-    // CourseModule/EffectsModule/Snow/Snowman/Utils bridges were removed (issue
-    // #84) — every consumer imports those directly now.
+    // window.AudioModule); the terrain samplers (getTerrainHeight*) are still
+    // bridged (snowman.js/camera.js/course.js read them by bare name). The
+    // THREE/Avalanche/Camera/Controls/CourseModule/EffectsModule/Snow/Snowman/
+    // Utils/Mountains/Trees bridges were removed (issue #84) — every consumer
+    // imports those directly now.
     AudioModule: any;
     AuthModule: any;
-    Mountains: any;
     getTerrainHeight?: (x: number, z: number) => number;
     getTerrainGradient?: (x: number, z: number) => { x: number; z: number };
     getDownhillDirection?: (x: number, z: number) => { x: number; z: number };
@@ -95,7 +89,6 @@ declare global {
     // Deferred dynamic-import hook for the orchestrator (src/main.js -> snowglider.js),
     // invoked by the classic script-loader after audio.js + Auth are ready (PR 2.9).
     __loadSnowGliderOrchestrator?: () => Promise<unknown>;
-    Trees: any;
     FIREBASE_MANUAL_INIT?: boolean;
     __FIREBASE_DEFAULTS__?: any; // set by auth.js to stop Firebase auto-init 404s
     // Cross-module/test handles published by snowglider.js (docs/ARCHITECTURE.md §3).

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -4,15 +4,10 @@
 //
 // Phase 1 strategy: start loose (`any` for not-yet-typed module namespaces),
 // give the well-understood primitives real three.js types, and tighten per module.
-import type * as THREE_NS from 'three';
-
 declare global {
-  // three.js r160. As of PR 2.10 the CDN UMD <script> global is gone — three is
-  // single-sourced from npm (every src module `import`s it; main.js bridges
-  // `window.THREE`). Kept declared as an ambient global in lockstep with
-  // eslint.config.js for the still-classic browser-test scripts (camera-tests.js)
-  // that read it bare; drop once those tests become ES modules.
-  const THREE: typeof THREE_NS;
+  // three.js r160 is single-sourced from npm. Every src module and every browser
+  // test now `import * as THREE from 'three'`, so the ambient `THREE` global and
+  // its window.THREE bridge were removed (issue #84).
 
   /** Terrain height sampler injected via setTerrainFunction (see docs/ARCHITECTURE.md §4). */
   type TerrainHeightFn = (x: number, z: number) => number;
@@ -81,18 +76,14 @@ declare global {
   // (snowglider.js) are converted (PR 2.9). mountains.js (PR 2.7) likewise
   // republishes the terrain samplers onto window.
   interface Window {
-    // three.js bridged onto window by main.js (PR 2.10) for the still-classic
-    // browser-test scripts, replacing the removed CDN UMD global.
-    THREE: typeof THREE_NS;
+    // AudioModule still bridged (start-menu.js + the audio browser tests read
+    // window.AudioModule); Mountains/Trees still bridged (snow.js/mountains.js
+    // read them by bare name at eval). The THREE/Avalanche/Camera/Controls/
+    // CourseModule/EffectsModule/Snow/Snowman/Utils bridges were removed (issue
+    // #84) — every consumer imports those directly now.
     AudioModule: any;
     AuthModule: any;
-    Avalanche: any;
-    Camera: any;
-    Controls: any;
-    CourseModule: any;
-    EffectsModule: any;
     Mountains: any;
-    Snow: any;
     getTerrainHeight?: (x: number, z: number) => number;
     getTerrainGradient?: (x: number, z: number) => { x: number; z: number };
     getDownhillDirection?: (x: number, z: number) => { x: number; z: number };
@@ -104,9 +95,7 @@ declare global {
     // Deferred dynamic-import hook for the orchestrator (src/main.js -> snowglider.js),
     // invoked by the classic script-loader after audio.js + Auth are ready (PR 2.9).
     __loadSnowGliderOrchestrator?: () => Promise<unknown>;
-    Snowman: any;
     Trees: any;
-    Utils: any;
     FIREBASE_MANUAL_INIT?: boolean;
     __FIREBASE_DEFAULTS__?: any; // set by auth.js to stop Firebase auto-init 404s
     // Cross-module/test handles published by snowglider.js (docs/ARCHITECTURE.md §3).

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,18 @@ function copyStaticAppFiles() {
         recursive: true,
         force: true
       });
+
+      // Publish the single three.js ESM build the page import map points at
+      // (`/node_modules/three/build/three.module.min.js`). The bundled game never
+      // hits the import map (Vite inlines three into the hashed chunk), but the
+      // verbatim-copied browser tests in dist/tests load as `<script type="module">`
+      // and import bare `three`, so on Pages — where node_modules is NOT published —
+      // they'd 404 and the `?test=…` entry points would fail before registering
+      // their window.run*Tests hooks. Copying just this one file (not all of
+      // node_modules) keeps those deployed test pages resolving three (issue #84).
+      const threeRel = path.join('node_modules', 'three', 'build', 'three.module.min.js');
+      await mkdir(path.join(distDir, path.dirname(threeRel)), { recursive: true });
+      await cp(path.join(rootDir, threeRel), path.join(distDir, threeRel), { force: true });
     }
   };
 }


### PR DESCRIPTION
Continues Phase 2 of the TypeScript migration, **stacked on #93**. This PR moves the remaining lower-stack runtime/test pieces onto the ES-module path while keeping the final `window.AudioModule` bridge for #95.

## What changed

- Converted `src/audio.js` to an ES module and kept its compatibility stubs for existing callers.
- Migrated all seven browser-test suites to `<script type="module">` loading so they import real source modules directly.
- Preserved direct browser-test URLs when test modules are injected after the page `load` event: non-audio direct suites now use the same `document.readyState === 'complete'` guard as `audio-tests.js`.
- Made the boot loader wait for selected module test suites to settle before starting the classic unified runner, so cold-cache or post-load module evaluation cannot race `window.run*Tests` registration.
- Removed the redundant three.js CDN global and retired the per-module namespace bridges already no longer needed by this layer (`THREE`, `Avalanche`, `Camera`, `Controls`, `CourseModule`, `EffectsModule`, `Snow`, `Snowman`, `Utils`, `Mountains`, `Trees`, and the terrain sampler bridges).
- Kept the deferred snowglider orchestrator hook so Auth/audio/start-menu ordering and the start-menu race regression remain covered.
- Fixed the browser runner so it waits for the unified runner's actual suite count instead of stopping at a stale hard-coded count.
- Restored the tree-collision test seam in module mode by letting `snowglider.js` honor a test-installed `window.showGameOver` override when calling `Snowman.updateSnowman`.
- Handled slow Firebase/auth recovery by removing the stale `.local-mode-notice` and restoring signed-out auth UI state when the real `AuthModule` loads after local fallback.
- Updated docs to reflect that direct `file://` opens are no longer a supported run mode after the ES-module migration.

## Verification

Verified on head `5998c69`:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:browser` — **87 passed / 0 failed**, completed suites: controls, camera, audio, gameplay, tree, avalanche, regression
- targeted post-load unified test smoke: loaded the app with no test param, waited for `document.readyState === 'complete'`, changed the URL to `?test=unified`, invoked `loadTests()`, and verified all seven suites registered and completed **87 passed / 0 failed** with no page exceptions
- `npm run build`

Earlier, the full restacked top-of-stack #96 head (`c1df661`) was verified with lint, typecheck, Node tests, Vite browser tests, production build, copied artifact checks, and static `dist/` smoke. Downstream stacked branches should be restacked again if they need to include `5998c69`.

## Deferred to #95

- Convert `src/boot/script-loader.js` and `src/ui/start-menu.js` to modules that import `AudioModule` directly.
- Remove the final `window.AudioModule` bridge and mark Phase 2 complete.