### PR TITLE
test(browser): serve the puppeteer suite through Vite so .ts modules load (Phase 3 prerequisite, issue #84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,10 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 
 ## Commands
 - Install dependencies: `npm ci`
-- Run development server: `npm start` (uses http-server on port 8080)
+- Run development server: `npm start` (Vite dev server on port 8080) or `npm run dev`
 - Open locally through a server (`npm run dev`, `npm start`, or serve `dist/` after `npm run build`).
+  These go through Vite, which transpiles the TypeScript modules (Phase 3); a plain static
+  file server can no longer serve raw `src/` once any module is `.ts`.
   Direct `file://` opens are not supported after the ES-module migration because browser module graphs
   and the import map do not load reliably from a null origin.
 - Run lint: `npm run lint` (eslint)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0",
-    "start": "http-server -p 8080 -c-1"
+    "start": "vite --host 0.0.0.0 --port 8080"
   },
   "dependencies": {
     "firebase": "^11.5.0",

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -7,6 +7,7 @@
 
 const puppeteer = require('puppeteer');
 const { spawn } = require('child_process');
+const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
@@ -19,43 +20,68 @@ if (!fs.existsSync(RESULTS_DIR)) {
   fs.mkdirSync(RESULTS_DIR, { recursive: true });
 }
 
+// Probe the server root until it answers, so we don't race the server's own
+// readiness banner. Resolves true once an HTTP response (any status) comes back.
+function probeOnce(url) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(1000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
 async function startServer() {
-  return new Promise((resolve, reject) => {
-    console.log('Starting http-server...');
-    
-    const server = spawn('npx', ['http-server', '-p', PORT, '-c-1'], {
+  // Serve through Vite's dev server rather than http-server: game modules are
+  // now ES modules and (as of Phase 3) some are TypeScript, which a browser can't
+  // execute raw. Vite transpiles `.ts` on the fly and resolves the `./x.js`
+  // import specifiers to their `.ts` sources, so the suite exercises the real
+  // shipped modules over the same module graph the production build ships. (It
+  // also single-sources three through Vite's dep optimizer, removing the
+  // dual-instance hazard the raw import-map path had.)
+  console.log('Starting vite dev server...');
+
+  const server = spawn(
+    'npx',
+    ['vite', '--port', String(PORT), '--strictPort', '--host', '127.0.0.1'],
+    {
       cwd: path.join(__dirname, '..'),
       stdio: ['ignore', 'pipe', 'pipe']
-    });
-    
-    let started = false;
-    
-    server.stdout.on('data', (data) => {
-      const output = data.toString();
-      if (!started && output.includes('Available on')) {
-        started = true;
-        console.log(`Server started on port ${PORT}`);
-        // Give server a moment to be fully ready
-        setTimeout(() => resolve(server), 1000);
-      }
-    });
-    
-    server.stderr.on('data', (data) => {
-      console.error('Server stderr:', data.toString());
-    });
-    
-    server.on('error', (err) => {
-      reject(new Error(`Failed to start server: ${err.message}`));
-    });
-    
-    // Timeout for server startup
-    setTimeout(() => {
-      if (!started) {
-        server.kill();
-        reject(new Error('Server startup timeout'));
-      }
-    }, 15000);
+    }
+  );
+
+  server.stdout.on('data', (data) => {
+    const output = data.toString().trim();
+    if (output) console.log(`[vite] ${output}`);
   });
+  server.stderr.on('data', (data) => {
+    console.error('Server stderr:', data.toString());
+  });
+
+  const startupError = new Promise((_resolve, reject) => {
+    server.on('error', (err) => reject(new Error(`Failed to start server: ${err.message}`)));
+  });
+
+  // Poll the port for up to ~30s (Vite's first cold dep-optimize can be slow).
+  const ready = (async () => {
+    const url = `http://127.0.0.1:${PORT}/`;
+    for (let i = 0; i < 60; i++) {
+      if (await probeOnce(url)) {
+        console.log(`Server started on port ${PORT}`);
+        return server;
+      }
+      await wait(500);
+    }
+    server.kill();
+    throw new Error('Server startup timeout');
+  })();
+
+  return Promise.race([ready, startupError]);
 }
 
 function wait(ms) {
@@ -83,7 +109,15 @@ async function runStartMenuRaceRegression(browser) {
 
   await page.setRequestInterception(true);
   page.on('request', async (request) => {
-    if (request.url().endsWith('/src/snowglider.js')) {
+    // Match the orchestrator's dynamic import regardless of any Vite-appended
+    // query (e.g. `?t=…`/`?import`) — `pathname` strips the query string.
+    let pathname;
+    try {
+      pathname = new URL(request.url()).pathname;
+    } catch {
+      pathname = request.url();
+    }
+    if (pathname.endsWith('/src/snowglider.js')) {
       snowgliderRequestSeen();
       await releaseSnowgliderScriptPromise;
     }
@@ -91,7 +125,7 @@ async function runStartMenuRaceRegression(browser) {
   });
 
   try {
-    await page.goto(`http://localhost:${PORT}/index.html`, {
+    await page.goto(`http://127.0.0.1:${PORT}/index.html`, {
       waitUntil: 'domcontentloaded',
       timeout: 30000
     });
@@ -211,7 +245,7 @@ async function runBrowserTests() {
     
     // Navigate to test page
     console.log('Loading test page...');
-    await page.goto(`http://localhost:${PORT}/index.html?test=unified`, {
+    await page.goto(`http://127.0.0.1:${PORT}/index.html?test=unified`, {
       waitUntil: 'networkidle2',
       timeout: 30000
     });

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -8,6 +8,7 @@
 const puppeteer = require('puppeteer');
 const { spawn } = require('child_process');
 const http = require('http');
+const net = require('net');
 const fs = require('fs');
 const path = require('path');
 
@@ -38,6 +39,30 @@ function probeViteReady(port) {
   });
 }
 
+function assertPortAvailable(port) {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+
+    probe.once('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        reject(new Error(`Port ${port} is already in use; refusing to run browser tests against a pre-existing server`));
+        return;
+      }
+      reject(err);
+    });
+
+    probe.once('listening', () => {
+      probe.close(resolve);
+    });
+
+    probe.listen({
+      host: '127.0.0.1',
+      port: Number(port),
+      exclusive: true
+    });
+  });
+}
+
 async function startServer() {
   // Serve through Vite's dev server rather than http-server: game modules are
   // now ES modules and (as of Phase 3) some are TypeScript, which a browser can't
@@ -47,6 +72,7 @@ async function startServer() {
   // also single-sources three through Vite's dep optimizer, removing the
   // dual-instance hazard the raw import-map path had.)
   console.log('Starting vite dev server...');
+  await assertPortAvailable(PORT);
 
   const server = spawn(
     'npx',
@@ -84,6 +110,10 @@ async function startServer() {
         throw new Error(`Vite exited before becoming ready (code ${exitInfo.code}, signal ${exitInfo.signal})`);
       }
       if (await probeViteReady(PORT)) {
+        await wait(100);
+        if (exitInfo) {
+          throw new Error(`Vite exited during readiness probe (code ${exitInfo.code}, signal ${exitInfo.signal})`);
+        }
         console.log(`Server started on port ${PORT}`);
         return server;
       }

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -20,13 +20,15 @@ if (!fs.existsSync(RESULTS_DIR)) {
   fs.mkdirSync(RESULTS_DIR, { recursive: true });
 }
 
-// Probe the server root until it answers, so we don't race the server's own
-// readiness banner. Resolves true once an HTTP response (any status) comes back.
-function probeOnce(url) {
+// Probe a Vite-specific endpoint so a stale or unrelated listener already on the
+// port can't masquerade as a ready dev server (`--strictPort` makes our own Vite
+// exit rather than reuse it). Vite serves `/@vite/client` with status 200; only
+// that counts as ready.
+function probeViteReady(port) {
   return new Promise((resolve) => {
-    const req = http.get(url, (res) => {
+    const req = http.get(`http://127.0.0.1:${port}/@vite/client`, (res) => {
       res.resume();
-      resolve(true);
+      resolve(res.statusCode === 200);
     });
     req.on('error', () => resolve(false));
     req.setTimeout(1000, () => {
@@ -63,15 +65,25 @@ async function startServer() {
     console.error('Server stderr:', data.toString());
   });
 
+  // Record an early exit (e.g. `--strictPort` and the port was already taken, so
+  // Vite refuses to start) so we can fail loudly instead of probing whatever else
+  // is on the port.
+  let exitInfo = null;
+  server.on('exit', (code, signal) => {
+    exitInfo = { code, signal };
+  });
+
   const startupError = new Promise((_resolve, reject) => {
     server.on('error', (err) => reject(new Error(`Failed to start server: ${err.message}`)));
   });
 
-  // Poll the port for up to ~30s (Vite's first cold dep-optimize can be slow).
+  // Poll Vite's own endpoint for up to ~30s (its first cold dep-optimize is slow).
   const ready = (async () => {
-    const url = `http://127.0.0.1:${PORT}/`;
     for (let i = 0; i < 60; i++) {
-      if (await probeOnce(url)) {
+      if (exitInfo) {
+        throw new Error(`Vite exited before becoming ready (code ${exitInfo.code}, signal ${exitInfo.signal})`);
+      }
+      if (await probeViteReady(PORT)) {
         console.log(`Server started on port ${PORT}`);
         return server;
       }


### PR DESCRIPTION
**Phase 3 prerequisite**, stacked on #95 (Phase 2 conversion complete). Must land before any `.ts` module reaches `main`, where CI runs `npm run test:browser`.

## Why
The browser suite previously served raw `src/` over `http-server` with no transpile step. The moment a game module becomes TypeScript (Phase 3, starting with #96 / `avalanche.ts`), a browser can't execute it. This PR switches the CI browser harness to Vite so `.js` import specifiers resolve to `.ts` sources and the suite exercises the same module graph shape as the production build.

## What

- Switches `tests/puppeteer-runner.js` from `http-server` to Vite's dev server.
- Uses `127.0.0.1` and path-based request matching so Vite query strings do not break the start-menu race regression hook.
- Probes Vite's `/@vite/client` endpoint for readiness.
- Rejects a pre-existing listener on `TEST_PORT` before spawning Vite, then rechecks that the spawned process is still alive after readiness; this prevents stale Vite servers from being accepted as the test server.
- Points `npm start` at Vite so local development uses the transpiling server path too.

## Restack / Verification

Restacked on head `11aed1d` onto updated #95 (`b5f6772`).

Full local verification after restack was run on the top-of-stack #96 head (`efd01f6`), which includes this PR:

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:browser` — Vite-served harness, **87 passed / 0 failed**, completed suites: controls, camera, audio, gameplay, tree, avalanche, regression
- `rm -rf dist` then `npm run build`
- artifact checks: `dist/src/avalanche.js` exists, `dist/src/avalanche.ts` does not, and copied source/test bare `three` imports are rewritten away
- static `dist/` smoke through `http-server`: `index.html?test=unified` completed **87 passed / 0 failed** across all seven suites

## Scope note
This fixes `npm run test:browser` and the local `npm start` development path. The deployed static `index.html?test=…` path is addressed in #96 for the first `.ts` source by emitting browser-loadable copied JS from copied TypeScript sources.