### PR TITLE
refactor(ts): PR 3.1 — rename course.js + effects.js to .ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,9 +63,10 @@ module.exports = [
     }
   },
   {
-    // avalanche.js renamed to avalanche.ts (issue #84, Phase 3.0); `eslint .`
-    // does not lint .ts (no typescript-eslint configured), so it's dropped here.
-    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/camera.js", "src/controls.js", "src/course.js", "src/effects.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/trees.js", "src/ui/start-menu.js"],
+    // avalanche.js (Phase 3.0) and course.js/effects.js (Phase 3.1) were renamed
+    // to .ts (issue #84); `eslint .` does not lint .ts (no typescript-eslint
+    // configured), so those files are dropped from this module override.
+    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/camera.js", "src/controls.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/trees.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/course.ts
+++ b/src/course.ts
@@ -1,5 +1,4 @@
-// @ts-check
-// course.js - Course structure, split timing, ghost racing and result screen for SnowGlider
+// course.ts - Course structure, split timing, ghost racing and result screen for SnowGlider
 //
 // This module turns the open slope into a timed course:
 //   - Visible checkpoint gates and a finish arch placed down the fall line
@@ -18,12 +17,66 @@
 //
 // Phase 2.2 (issue #84): second module converted off the classic global model.
 // `THREE` now comes from the npm package via a real ES-module import instead of
-// the CDN global, and `CourseModule` is `export`ed. The window.CourseModule
-// assignment below is kept so the still-classic consumer (snowglider.js, which
-// reads it by bare name and as window.CourseModule, converted last in PR 2.9)
-// keeps working during the staged migration; it is loaded into the page through
-// the bundle entry (src/main.js) rather than the classic script-loader.
+// the CDN global, and `CourseModule` is `export`ed; it is loaded into the page
+// through the bundle entry (src/main.js) and imported directly by snowglider.js.
+//
+// Phase 3.1 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file) and the previously inferred course/ghost/HUD
+// shapes are now real `interface`/`type` declarations. Behaviour is unchanged —
+// every edit is type-only/erasable, so esbuild (Vite) and Node's native
+// type-stripping both run it exactly as before.
 import * as THREE from 'three';
+
+/** Terrain sampler injected via {@link CourseModule.init}. */
+export type TerrainHeightFn = (x: number, z: number) => number;
+
+/** Factory that builds a fresh snowman group, reused to spawn the ghost. */
+export type CreateSnowmanFn = (scene: THREE.Scene) => THREE.Object3D;
+
+/** One recorded point on a run's trajectory; the persisted ghost is an array of these. */
+export interface GhostSample {
+  t: number;   // seconds since run start
+  x: number;
+  y: number;
+  z: number;
+  rot: number; // snowman heading (radians)
+}
+
+/** A checkpoint or the finish line along the fall line. */
+export interface SplitPoint {
+  z: number;
+  label: string;
+}
+
+/** Options handed to {@link CourseModule.init}. */
+export interface CourseInitOptions {
+  scene: THREE.Scene;
+  getTerrainHeight: TerrainHeightFn;
+  createSnowman: CreateSnowmanFn;
+}
+
+/** Result of {@link medalFor}: which medal a finished run earned. */
+export interface Medal {
+  key: 'gold' | 'silver' | 'bronze' | 'finish';
+  icon: string;
+  label: string;
+}
+
+/** Minimal positional shape the course reads from the player each frame. */
+export interface Vec3Like {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Lazily-built course HUD element handles. */
+interface CourseHud {
+  root?: HTMLDivElement;
+  fill?: HTMLDivElement;
+  distance?: HTMLSpanElement;
+  ghostDelta?: HTMLSpanElement;
+  flash?: HTMLDivElement;
+}
 
 export const CourseModule = (function () {
   'use strict';
@@ -44,26 +97,26 @@ export const CourseModule = (function () {
   const LS_GHOST = 'snowgliderGhost';
 
   // --- Module state ---
-  let scene = null;
-  let getTerrainHeight = null;
-  let createSnowman = null;
+  let scene: THREE.Scene | null = null;
+  let getTerrainHeight: TerrainHeightFn | null = null;
+  let createSnowman: CreateSnowmanFn | null = null;
 
-  let gateGroup = null;        // container for all gate meshes
-  let ghost = null;            // ghost snowman group (or null)
-  let ghostSamples = null;     // loaded best-run trajectory for playback
+  let gateGroup: THREE.Group | null = null;        // container for all gate meshes
+  let ghost: THREE.Object3D | null = null;         // ghost snowman group (or null)
+  let ghostSamples: GhostSample[] | null = null;   // loaded best-run trajectory for playback
   let ghostTotalTime = 0;
 
-  let bestSplits = null;       // array of best split times (per checkpoint + finish), or null
+  let bestSplits: number[] | null = null;  // best split times (per checkpoint + finish), or null
 
   // Per-run state
   let nextIndex = 0;           // index into the combined checkpoint+finish list
-  let runSplits = [];          // split times recorded this run
-  let recordSamples = [];      // trajectory recorded this run
+  let runSplits: number[] = [];          // split times recorded this run
+  let recordSamples: GhostSample[] = []; // trajectory recorded this run
   let sampleAccum = 0;
   let runActive = false;
 
   // Combined list of split gates (checkpoints then finish)
-  const splitPoints = CHECKPOINT_Z.map((z, i) => ({ z, label: `CHECKPOINT ${i + 1}` }))
+  const splitPoints: SplitPoint[] = CHECKPOINT_Z.map((z, i) => ({ z, label: `CHECKPOINT ${i + 1}` }))
     .concat([{ z: FINISH_Z, label: 'Finish' }]);
 
   const reduceMotion = typeof window !== 'undefined' &&
@@ -72,7 +125,7 @@ export const CourseModule = (function () {
   // ---------------------------------------------------------------------------
   // HUD construction
   // ---------------------------------------------------------------------------
-  let hud = {};
+  let hud: CourseHud = {};
 
   function buildHud() {
     if (hud.root) return;
@@ -132,8 +185,8 @@ export const CourseModule = (function () {
     hud = { root, fill, distance, ghostDelta, flash };
   }
 
-  let flashTimer = null;
-  function showFlash(html, color) {
+  let flashTimer: ReturnType<typeof setTimeout> | null = null;
+  function showFlash(html: string, color?: string) {
     if (!hud.flash) return;
     hud.flash.innerHTML = html;
     hud.flash.style.color = color || '#fff';
@@ -145,7 +198,7 @@ export const CourseModule = (function () {
   // ---------------------------------------------------------------------------
   // Gate / finish meshes
   // ---------------------------------------------------------------------------
-  function makeGate(zPos, colorHex, label, isFinish) {
+  function makeGate(zPos: number, colorHex: number, label: string, isFinish: boolean): THREE.Group {
     const group = new THREE.Group();
     const halfW = isFinish ? FINISH_HALF_WIDTH : GATE_HALF_WIDTH;
     const poleMat = new THREE.MeshStandardMaterial({ color: colorHex, roughness: 0.6 });
@@ -260,13 +313,15 @@ export const CourseModule = (function () {
     ghost = createSnowman(scene);
     // Make it a translucent blue apparition that never collides or shadows.
     ghost.traverse((obj) => {
-      if (obj.isMesh && obj.material) {
-        const m = obj.material.clone();
-        m.transparent = true;
-        m.opacity = 0.32;
-        if (m.color) m.color.lerp(new THREE.Color(0x66ccff), 0.6);
-        if ('emissive' in m && m.emissive) m.emissive = new THREE.Color(0x113355);
-        obj.material = m;
+      const mesh = obj as THREE.Mesh;
+      if (mesh.isMesh && mesh.material) {
+        // Ghost snowman meshes use a single MeshStandardMaterial (never an array).
+        const cloned = (mesh.material as THREE.MeshStandardMaterial).clone();
+        cloned.transparent = true;
+        cloned.opacity = 0.32;
+        if (cloned.color) cloned.color.lerp(new THREE.Color(0x66ccff), 0.6);
+        if ('emissive' in cloned && cloned.emissive) cloned.emissive = new THREE.Color(0x113355);
+        mesh.material = cloned;
         obj.castShadow = false;
         obj.receiveShadow = false;
       }
@@ -275,7 +330,7 @@ export const CourseModule = (function () {
   }
 
   // Interpolate the ghost's recorded position at time t (seconds since run start).
-  function ghostPositionAt(t) {
+  function ghostPositionAt(t: number) {
     if (!ghostSamples) return null;
     const s = ghostSamples;
     if (t <= s[0].t) return s[0];
@@ -297,7 +352,7 @@ export const CourseModule = (function () {
   }
 
   // The time at which the ghost reached a given downhill depth (z).
-  function ghostTimeAtZ(z) {
+  function ghostTimeAtZ(z: number) {
     if (!ghostSamples) return null;
     const s = ghostSamples;
     if (z >= s[0].z) return 0;
@@ -315,7 +370,7 @@ export const CourseModule = (function () {
   // Public API
   // ---------------------------------------------------------------------------
 
-  function init(opts) {
+  function init(opts: CourseInitOptions) {
     scene = opts.scene;
     getTerrainHeight = opts.getTerrainHeight;
     createSnowman = opts.createSnowman;
@@ -353,18 +408,18 @@ export const CourseModule = (function () {
     }
   }
 
-  function formatTime(t) {
+  function formatTime(t: number): string {
     return `${t.toFixed(2)}s`;
   }
 
-  function formatDelta(d) {
+  function formatDelta(d: number): string {
     const sign = d <= 0 ? '−' : '+';
     return `${sign}${Math.abs(d).toFixed(2)}s`;
   }
 
   // Called every frame from the animation loop.
   // pos: snowman position, elapsed: seconds since run start, snowman: the player group.
-  function update(pos, elapsed, snowman) {
+  function update(pos: Vec3Like, elapsed: number, snowman?: THREE.Object3D) {
     if (!runActive) return;
 
     // --- Progress HUD ---
@@ -442,7 +497,7 @@ export const CourseModule = (function () {
   }
 
   // Decide a medal based on the player's own pace (robust without a global par).
-  function medalFor(total, previousBest, isFirst) {
+  function medalFor(total: number, previousBest: number, isFirst: boolean): Medal {
     if (isFirst) return { key: 'gold', icon: '🥇', label: 'First descent!' };
     if (total < previousBest) return { key: 'gold', icon: '🥇', label: 'New record!' };
     if (total <= previousBest * 1.10) return { key: 'silver', icon: '🥈', label: 'Silver run' };
@@ -452,7 +507,7 @@ export const CourseModule = (function () {
 
   // Called from showGameOver() on a successful finish.
   // Returns a DOM node (the result panel) to insert into the game-over overlay.
-  function onFinish(totalTime, previousBest) {
+  function onFinish(totalTime: number, previousBest: number): HTMLDivElement {
     hideHud();
 
     const isFirst = !(previousBest < Infinity);
@@ -484,7 +539,7 @@ export const CourseModule = (function () {
     return buildResultPanel(totalTime, previousBest, isBest, isFirst, medal);
   }
 
-  function buildResultPanel(totalTime, previousBest, isBest, isFirst, medal) {
+  function buildResultPanel(totalTime: number, previousBest: number, isBest: boolean, isFirst: boolean, medal: Medal): HTMLDivElement {
     const panel = document.createElement('div');
     panel.id = 'courseResult';
     Object.assign(panel.style, {
@@ -540,7 +595,7 @@ export const CourseModule = (function () {
       display: 'grid', gridTemplateColumns: '1fr auto auto', gap: '4px 14px',
       fontSize: '13px', alignItems: 'center'
     });
-    const head = (txt, align) => {
+    const head = (txt: string, align?: string) => {
       const c = document.createElement('div');
       c.textContent = txt;
       Object.assign(c.style, {
@@ -593,4 +648,4 @@ export const CourseModule = (function () {
   };
 })();
 
-// The window.CourseModule bridge was removed (issue #84): snowglider.js imports it.
+// CourseModule is imported directly by snowglider.js (issue #84).

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,5 +1,4 @@
-// @ts-check
-// effects.js - Drama and "juice" effects for SnowGlider
+// effects.ts - Drama and "juice" effects for SnowGlider
 //
 // Two responsibilities:
 //   1. Avalanche telegraphing: a warning banner, a "distance behind you" danger meter,
@@ -15,11 +14,42 @@
 // Phase 2.6 (issue #84): converted off the classic global model. `EffectsModule`
 // is now `export`ed instead of being a bare script global. This module uses no
 // three.js (it only pokes a camera object handed to it), so there is no
-// `import * as THREE`. The window.EffectsModule assignment below is kept so the
-// still-classic consumer (snowglider.js, which reads `EffectsModule` by bare
-// name, converted last in PR 2.9) keeps working during the staged migration; it
-// is loaded into the page through the bundle entry (src/main.js) rather than the
-// classic script-loader.
+// `import * as THREE`. It is loaded into the page through the bundle entry
+// (src/main.js) and imported directly by snowglider.js.
+//
+// Phase 3.1 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file) and the previously inferred shapes are now real
+// `interface` declarations (the lazily-built UI handles, the per-frame shake
+// offset, and the minimal camera surface `tickCamera` pokes). Behaviour is
+// unchanged — every edit is type-only/erasable, so esbuild (Vite) and Node's
+// native type-stripping both run it exactly as before.
+
+/** Per-frame camera shake offset returned by {@link EffectsModule.tickCamera}. */
+export interface ShakeOffset {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Minimal camera surface `tickCamera` reads/writes. Satisfied by a real
+ * `THREE.PerspectiveCamera` (the live game) and by the plain object the headless
+ * DOM smoke test hands in.
+ */
+export interface ShakeCamera {
+  fov: number;
+  updateProjectionMatrix(): void;
+  position: { x: number; y: number; z: number };
+}
+
+/** Lazily-built avalanche-warning DOM overlays. */
+interface EffectsUI {
+  vignette?: HTMLDivElement;
+  banner?: HTMLDivElement;
+  meterWrap?: HTMLDivElement;
+  meterFill?: HTMLDivElement;
+  meterLabelR?: HTMLSpanElement;
+}
 
 export const EffectsModule = (function () {
   'use strict';
@@ -33,7 +63,7 @@ export const EffectsModule = (function () {
   const reduceMotion = typeof window !== 'undefined' &&
     window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  let ui = {};
+  let ui: EffectsUI = {};
   let shake = 0;        // current shake intensity (decays over time)
   let proximityShake = 0; // sustained shake from avalanche proximity
   let currentFov = BASE_FOV;
@@ -110,7 +140,7 @@ export const EffectsModule = (function () {
   // Called each frame with the live avalanche state.
   //   active:   whether the avalanche is currently bearing down
   //   distance: closest boulder distance to the player (units); Infinity if none
-  function updateAvalanche(active, distance) {
+  function updateAvalanche(active: boolean, distance: number) {
     if (!ui.banner) return;
 
     if (!active || !isFinite(distance)) {
@@ -140,14 +170,14 @@ export const EffectsModule = (function () {
   }
 
   // Other systems can request a one-off shake impulse (e.g. a hard landing).
-  function addShake(amount) {
+  function addShake(amount: number) {
     if (reduceMotion) return;
     shake = Math.min(2.5, shake + amount);
   }
 
   // Per-frame camera treatment. Returns the shake offset that was applied so the
   // caller can revert it after rendering.
-  function tickCamera(camera, dt, speed) {
+  function tickCamera(camera: ShakeCamera, dt: number, speed: number): ShakeOffset {
     // Speed-based FOV (smoothed). A zooming FOV is itself camera motion, so honor
     // prefers-reduced-motion by pinning to the base FOV and skipping the zoom.
     if (reduceMotion) {
@@ -189,4 +219,4 @@ export const EffectsModule = (function () {
   return { init, updateAvalanche, addShake, tickCamera, reset };
 })();
 
-// The window.EffectsModule bridge was removed (issue #84): snowglider.js imports it.
+// EffectsModule is imported directly by snowglider.js (issue #84).

--- a/tests/README.md
+++ b/tests/README.md
@@ -183,7 +183,7 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   Regenerate it **only** on a deliberate physics change:
   `git show <ref>:src/snowman.js > tests/verification/snowman_baseline.js`
   (re-add the file header), then re-run `npm run test:verify`.
-- **`dom_smoke_test.js`** — boots `effects.js` + `course.js` under jsdom with a
+- **`dom_smoke_test.js`** — boots `effects.ts` + `course.ts` under jsdom with a
   mocked THREE: both modules build their DOM/gates, the per-frame loop runs, every
   checkpoint and the finish are reached, the ghost trajectory and best splits
   persist, and a faster second run is reported as a new record.

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -1,14 +1,18 @@
 // dom_smoke_test.js
-// Headless coverage for course.js + effects.js under jsdom, without a browser.
+// Headless coverage for course.ts + effects.ts under jsdom, without a browser.
 // Requires jsdom (devDependency).
 //
-// Phase 2.2/2.6 (issue #84): course.js and effects.js are now ES modules, so they
-// can no longer be evaluated with a `new Function(src)` + mock-THREE injection —
-// that pattern can't load `import`/`export`. Both sections now `import()` the REAL
+// Phase 2.2/2.6 (issue #84): course and effects are ES modules, so they can no
+// longer be evaluated with a `new Function(src)` + mock-THREE injection — that
+// pattern can't load `import`/`export`. Both sections now `import()` the REAL
 // module (and, for course, REAL three: its geometry/material/texture constructors
 // need no WebGL, so they build fine headless under Node), exercising shipped code
-// directly. effects.js uses no three.js at all, so its import needs no mock; the
+// directly. effects uses no three.js at all, so its import needs no mock; the
 // previous mock-THREE scaffolding and `new Function` loader are gone.
+//
+// Phase 3.1 (issue #84): both modules were renamed `.js` -> `.ts`. Node does not
+// remap `.js` import specifiers to `.ts`, so these direct imports use the real
+// `.ts` extension (Node strips the erasable types natively, like `avalanche.ts`).
 const { JSDOM } = require('jsdom');
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
@@ -46,10 +50,10 @@ function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: $
 async function main() {
   // ---- EffectsModule (real ES module, PR 2.6; uses no three.js) ----
   console.log('--- EffectsModule ---');
-  // effects.js builds DOM overlays and pokes a plain camera object; it imports no
+  // effects builds DOM overlays and pokes a plain camera object; it imports no
   // three, so we import the REAL module directly. Its `document`/`window` reads
   // resolve to the jsdom globals wired up above.
-  const { EffectsModule: Effects } = await import('../../src/effects.js');
+  const { EffectsModule: Effects } = await import('../../src/effects.ts');
   check('module exports init/updateAvalanche/tickCamera', !!Effects && typeof Effects.init === 'function' && typeof Effects.tickCamera === 'function');
   Effects.init();
   const banner = window.document.body.querySelector('div');
@@ -70,12 +74,12 @@ async function main() {
 
   // ---- CourseModule (real ES module + real three, PR 2.2) ----
   console.log('\n--- CourseModule ---');
-  // course.js now `import`s three from npm, so we import the REAL module + REAL
-  // three rather than evaluating the source with a mock. The fake snowman is a
-  // real three Group whose mesh carries a MeshStandardMaterial so buildGhost's
+  // course `import`s three from npm, so we import the REAL module + REAL three
+  // rather than evaluating the source with a mock. The fake snowman is a real
+  // three Group whose mesh carries a MeshStandardMaterial so buildGhost's
   // material.clone()/color.lerp()/emissive path exercises shipped code.
   const RealTHREE = await import('three');
-  const { CourseModule: Course } = await import('../../src/course.js');
+  const { CourseModule: Course } = await import('../../src/course.ts');
   const fakeCreateSnowman = () => {
     const g = new RealTHREE.Group();
     g.add(new RealTHREE.Mesh(new RealTHREE.BoxGeometry(1, 1, 1), new RealTHREE.MeshStandardMaterial()));


### PR DESCRIPTION
## Phase 3.1 — `course.ts` + `effects.ts`

Stacked on **#96** (PR 3.0, `avalanche.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the two leaf UI/domain modules `.js` → `.ts`, dropping the now-implied `// @ts-check` pragma and promoting the previously inferred shapes into real `interface`/`type` declarations. Every edit is **type-only/erasable**, so esbuild (Vite) and Node's native type-stripping run both modules exactly as before — behaviour is unchanged.

### `course.ts`
Real types for the course/ghost/HUD domain: `TerrainHeightFn`, `CreateSnowmanFn`, `GhostSample`, `SplitPoint`, `CourseInitOptions`, `Medal`, `Vec3Like`, and the lazily-built `CourseHud` handles — plus typed module state and public function signatures. The one substantive `.js`→`.ts` difference was strict call arity: the local `head(txt, align)` helper is called with one arg, so `align` is now declared optional (matches its `align || 'left'` use).

### `effects.ts`
Real types for the per-frame `ShakeOffset`, the minimal `ShakeCamera` surface `tickCamera` pokes (satisfied by a real `THREE.PerspectiveCamera` and by the plain test object), and the lazily-built `EffectsUI` overlays.

### Resolution / build invariants (same approach proven in #96)
- **Browser/Vite specifiers stay `.js`** (`./course.js` / `./effects.js`) — resolved to the `.ts` files by Vite + `tsc` `moduleResolution: "Bundler"`. `src/snowglider.js` and `src/main.js` are untouched.
- **Node direct imports move to `.ts`** — only `tests/verification/dom_smoke_test.js`, since Node does not remap `.js` → `.ts`.
- **Static Pages artifact unchanged** — `vite.config`'s generic `copyStaticAppFiles` transpile already emits `dist/src/course.js` + `dist/src/effects.js` and removes the raw `.ts`; verified below.
- `eslint.config.js` drops `course.js`/`effects.js` from the module-override list (eslint does not lint `.ts` yet), following the `avalanche.ts` (Phase 3.0) pattern.

### Gates (all green locally)
- `npm run lint` ✅
- `npm run typecheck` ✅ (`tsc --noEmit`)
- `npm test` ✅ — dom_smoke 18/18 against the real `.ts` modules
- `npm run build` ✅ + artifact checks: `dist/src/course.js` & `dist/src/effects.js` present, raw `.ts` absent, bare `three` import rewritten
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites

> Note: CI (`ci.yml`) and the reviewdog workflow only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally on the rebased top-of-stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
