### PR TITLE
refactor(ts): PR 3.3 — rename trees.js → trees.ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,11 +63,11 @@ module.exports = [
     }
   },
   {
-    // avalanche.js (Phase 3.0), course.js/effects.js (Phase 3.1) and camera.js
-    // (Phase 3.2) were renamed to .ts (issue #84); `eslint .` does not lint .ts
-    // (no typescript-eslint configured), so those files are dropped from this
-    // module override.
-    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/controls.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/trees.js", "src/ui/start-menu.js"],
+    // avalanche.js (Phase 3.0), course.js/effects.js (Phase 3.1), camera.js
+    // (Phase 3.2) and trees.js (Phase 3.3) were renamed to .ts (issue #84);
+    // `eslint .` does not lint .ts (no typescript-eslint configured), so those
+    // files are dropped from this module override.
+    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/controls.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snow.js", "src/snowglider.js", "src/snowman.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:scores && npm run test:controls && npm run test:verify",
-    "test:terrain": "node tests/terrain-tests.js",
+    "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js",
-    "test:regression": "node tests/regression-tests.js",
+    "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
     "test:tree-collision": "node tests/tree-collision-tests.js",
     "test:avalanche": "node tests/avalanche-tests.js",
     "test:auth": "node tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",

--- a/src/trees.ts
+++ b/src/trees.ts
@@ -1,16 +1,37 @@
-// @ts-check
-// trees.js - Tree creation and management for snowglider
+// trees.ts - Tree creation and management for snowglider
 //
 // Phase 2.4 (issue #84): converted off the classic global model. `THREE` and the
 // terrain samplers (`Mountains`) now come from real ES-module imports instead of
 // the CDN global / window bridges, and `Trees` is `export`ed. mountains.js and
 // trees.js import each other (the cross-references are only used at call time, so
 // the circular import resolves cleanly).
+//
+// Phase 3.3 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file) and the placement/collision data shapes and
+// helper signatures are now real `interface`/`type` declarations. Behaviour is
+// unchanged — every edit is type-only/erasable, so esbuild (Vite) and Node's
+// native type-stripping both run it exactly as before. The trees <-> mountains
+// circular import is untouched: the `./mountains.js` specifier still resolves to
+// `mountains.js` (it converts in PR 3.6), and the cross-references stay call-time.
 import * as THREE from 'three';
 import { Mountains } from './mountains.js';
 
+/** A placed tree's world position and size; addTrees returns these for collision. */
+export interface TreePosition {
+  x: number;
+  y: number;
+  z: number;
+  scale: number;
+}
+
+/** Terrain gradient (slope components) returned by the Mountains sampler. */
+export interface TerrainGradient {
+  x: number;
+  z: number;
+}
+
 // Create a more realistic tree with visible branches and variability
-function createTree(scale = 1.0) {
+function createTree(scale = 1.0): THREE.Group {
   const group = new THREE.Group();
   
   // Add randomization factors for variety
@@ -86,7 +107,7 @@ function createTree(scale = 1.0) {
 }
 
 // Add visible branches sticking out of the main cone shape
-function addBranchesAtLayer(cone, radius, material) {
+function addBranchesAtLayer(cone: THREE.Mesh, radius: number, material: THREE.Material) {
   // Number of branches depends on radius
   const branchCount = Math.floor(3 + Math.random() * 3); // 3-5 visible branches
   
@@ -123,7 +144,7 @@ function addBranchesAtLayer(cone, radius, material) {
 }
 
 // Add snow caps on top of tree
-function addSnowCaps(tree, treeHeight, widthScale) {
+function addSnowCaps(tree: THREE.Object3D, treeHeight: number, widthScale: number) {
   // Add some snow on top
   const snowCapGeometry = new THREE.SphereGeometry(widthScale * 0.8, 8, 4, 0, Math.PI * 2, 0, Math.PI / 3);
   const snowMaterial = new THREE.MeshStandardMaterial({
@@ -163,7 +184,7 @@ function addSnowCaps(tree, treeHeight, widthScale) {
 }
 
 // Add trees to make the scene more interesting
-function addTrees(scene) {
+function addTrees(scene: THREE.Scene): TreePosition[] {
   // Remove any existing trees from the scene to prevent duplicates
   for (let i = scene.children.length - 1; i >= 0; i--) {
     const child = scene.children[i];
@@ -173,8 +194,8 @@ function addTrees(scene) {
     }
   }
   
-  const treePositions = [];
-  
+  const treePositions: TreePosition[] = [];
+
   // IMPORTANT: Log the ranges we're using to create trees for debugging
   console.log("Trees.addTrees: Creating trees in X range -100 to 100, Z range -180 to 80");
   
@@ -328,11 +349,13 @@ function addTrees(scene) {
   } 
   // Last resort - find by name or type
   else {
-    terrainMesh = scene.children.find(child => 
-      child.name === 'terrain' || 
-      (child.type === 'Mesh' && 
-       child.geometry && 
-       child.geometry.type === 'PlaneGeometry'));
+    terrainMesh = scene.children.find(child => {
+      const mesh = child as THREE.Mesh;
+      return child.name === 'terrain' ||
+        (child.type === 'Mesh' &&
+         !!mesh.geometry &&
+         mesh.geometry.type === 'PlaneGeometry');
+    });
   }
   
   // Create tree instances - ensure trees are properly anchored to terrain
@@ -354,7 +377,7 @@ function addTrees(scene) {
 }
 
 // Helper function to use the Mountains module to get terrain height.
-function getTerrainHeight(x, z) {
+function getTerrainHeight(x: number, z: number): number {
   if (Mountains && Mountains.getTerrainHeight) {
     return Mountains.getTerrainHeight(x, z);
   }
@@ -365,7 +388,7 @@ function getTerrainHeight(x, z) {
 }
 
 // Helper function to use the Mountains module to get terrain gradient.
-function getTerrainGradient(x, z) {
+function getTerrainGradient(x: number, z: number): TerrainGradient {
   if (Mountains && Mountains.getTerrainGradient) {
     return Mountains.getTerrainGradient(x, z);
   }
@@ -385,5 +408,4 @@ export const Trees = {
   getTerrainGradient
 };
 
-// The window.Trees bridge was removed (issue #84): snow.js and mountains.js
-// import Trees directly now.
+// Trees is imported directly by snow.js and mountains.js (issue #84).

--- a/tests/loaders/register-ts-resolve.mjs
+++ b/tests/loaders/register-ts-resolve.mjs
@@ -1,0 +1,8 @@
+// register-ts-resolve.mjs — registers the .js -> .ts resolution hook.
+//
+// Used via `node --import ./tests/loaders/register-ts-resolve.mjs <test>` for the
+// Node test runs that load a still-`.js` module which statically imports a
+// renamed `.ts` sibling. See tests/loaders/ts-js-resolve.mjs for the rationale.
+import { register } from 'node:module';
+
+register('./ts-js-resolve.mjs', import.meta.url);

--- a/tests/loaders/ts-js-resolve.mjs
+++ b/tests/loaders/ts-js-resolve.mjs
@@ -1,0 +1,27 @@
+// ts-js-resolve.mjs — Node ESM resolution hook for the TypeScript migration.
+//
+// Phase 3 (issue #84) renames src modules `.js` -> `.ts` one at a time while the
+// still-`.js` modules keep importing their browser-facing `./*.js` specifiers
+// (the migration keeps source specifiers as `.js` so Vite/tsc — and the deployed
+// static artifact — stay unchanged; both transparently resolve `./x.js` to `x.ts`).
+//
+// Node does NOT perform that `.js` -> `.ts` remap. So when a Node test imports a
+// still-`.js` module that statically imports a now-renamed sibling (e.g.
+// `mountains.js` / `snow.js` import `./trees.js`, which is now `trees.ts`),
+// resolution fails with ERR_MODULE_NOT_FOUND.
+//
+// This hook closes only that gap: if a specifier ending in `.js` cannot be
+// resolved, it retries the same path with a `.ts` extension. It is registered for
+// the affected Node test runs only (see tests/loaders/register-ts-resolve.mjs and
+// the package.json scripts); it never touches the browser, Vite, or build paths.
+// Node's native type-stripping then loads the resolved `.ts` file.
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (err && err.code === 'ERR_MODULE_NOT_FOUND' && specifier.endsWith('.js')) {
+      return nextResolve(specifier.slice(0, -'.js'.length) + '.ts', context);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Phase 3.3 — `trees.ts`

Stacked on **#100** (PR 3.2, `camera.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the tree placement/collision module `.js` → `.ts`, dropping the now-implied `// @ts-check` pragma and promoting the data shapes + helper signatures into real `interface`/`type` declarations. Every edit is **type-only/erasable**, so esbuild (Vite) and Node's native type-stripping run it exactly as before — behaviour is unchanged.

### `trees.ts`
- `TreePosition` (`{ x, y, z, scale }`, returned by `addTrees` for collision) and `TerrainGradient` (`{ x, z }`) interfaces.
- Typed signatures for `createTree`, `addBranchesAtLayer`, `addSnowCaps`, `addTrees`, `getTerrainHeight`, `getTerrainGradient`.
- Typing `addTrees(scene: THREE.Scene)` (was implicit `any`) surfaced the dead terrain-mesh lookup reading `child.geometry` on an `Object3D`; that `.find` callback now casts `child as THREE.Mesh` for the geometry probe — type-only, behaviour-identical.

### Node `.js`→`.ts` resolution — the trees ↔ mountains circular import
The interesting part of this PR. `mountains.js` and `snow.js` (both still `.js`) statically `import { Trees } from './trees.js'`, and the Node `terrain`/`regression` tests `import()` those real modules.

- **Source specifiers stay `./trees.js` everywhere** (per the migration principle — keep browser/Vite specifiers `.js`). Vite + `tsc` (`moduleResolution: "Bundler"`) resolve `./trees.js` → `trees.ts`, and the build transpile still emits a real `dist/src/trees.js`, so the **browser / Vite / build / deploy paths are completely untouched** (verified: copied `dist/src/mountains.js` & `snow.js` still import `./trees.js`, which resolves to the transpiled `dist/src/trees.js`).
- **Node does not remap `.js`→`.ts`**, so it hit `ERR_MODULE_NOT_FOUND` for `./trees.js`. Fix: a **Node-test-only** ESM resolution hook — `tests/loaders/ts-js-resolve.mjs` (retries `.ts` when a `.js` specifier fails) + `register-ts-resolve.mjs`, wired into `test:terrain` and `test:regression` via `node --import`. It touches no source module, no `tsconfig`, no build, and is reusable as `snow.js`/`mountains.js` convert in PR 3.5/3.6.

No browser-test migration (terrain/regression inject a `Trees` mock; tree-collision is self-contained; the browser tree suite drives the live bundled module). `eslint.config.js` drops `trees.js` from the module-override list.

### Gates (all green locally)
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ — terrain 7/7, regression 10/10, dom_smoke 18/18 (+ all others)
- `npm run build` ✅ + artifact checks (`dist/src/trees.js` present, raw `.ts` absent; copied modules still import `./trees.js`)
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites (incl. **tree**)

> Note: CI (`ci.yml`) and reviewdog only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
