### PR TITLE
refactor(ts): PR 3.6 — rename mountains.js → mountains.ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,11 +64,11 @@ module.exports = [
   },
   {
     // avalanche.js (Phase 3.0), course.js/effects.js (Phase 3.1), camera.js
-    // (Phase 3.2), trees.js (Phase 3.3), controls.js (Phase 3.4) and snow.js
-    // (Phase 3.5) were renamed to .ts (issue #84); `eslint .` does not lint .ts
-    // (no typescript-eslint configured), so those files are dropped from this
-    // module override.
-    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/main.js", "src/mountains.js", "src/scores.js", "src/snowglider.js", "src/snowman.js", "src/ui/start-menu.js"],
+    // (Phase 3.2), trees.js (Phase 3.3), controls.js (Phase 3.4), snow.js
+    // (Phase 3.5) and mountains.js (Phase 3.6) were renamed to .ts (issue #84);
+    // `eslint .` does not lint .ts (no typescript-eslint configured), so those
+    // files are dropped from this module override.
+    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/main.js", "src/scores.js", "src/snowglider.js", "src/snowman.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/mountains.ts
+++ b/src/mountains.ts
@@ -1,33 +1,58 @@
-// @ts-check
-// mountains.js - Terrain and mountain features for snowglider
+// mountains.ts - Terrain and mountain features for snowglider
 //
 // Phase 2.7 (issue #84): converted off the classic global model. `THREE` and the
 // `Trees` module now come from real ES-module imports, and `Mountains` is
 // `export`ed. mountains.js and trees.js import each other (the cross-references
-// run only at call time, so the circular import resolves cleanly).
+// run only at call time, so the circular import resolves cleanly). The terrain
+// samplers (`getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) are
+// reached via the `Mountains` import or as injected parameters — the old window
+// bridges are gone.
 //
-// The bottom of this file still republishes the terrain sampler functions
-// (`getTerrainHeight`/`getTerrainGradient`/`getDownhillDirection`) onto `window`,
-// because snowman.js, camera.js and course.js still read them by bare name
-// (resolving via the window bridge). Those bridges stay until those modules take
-// the samplers as imports/parameters.
+// Phase 3.6 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file), the `SimplexNoise` fields and the terrain
+// sampler/geometry helper signatures are now real type declarations, and the
+// JSDoc `/** @type {Float32Array} */` buffer casts are now `as` casts. The terrain
+// math is byte-identical — every edit is type-only/erasable, so esbuild (Vite) and
+// Node's native type-stripping both run it exactly as before, preserving terrain
+// height consistency (the seam camera/trees/snow/physics all depend on).
+// The `./trees.js` specifier stays `.js` (Vite/tsc resolve it to `trees.ts`; the
+// Node terrain/regression tests use the `.js`->`.ts` resolve hook added in PR 3.3).
 import * as THREE from 'three';
 import { Trees } from './trees.js';
 
+/** A 2D vector in the terrain x/z plane: a gradient or a unit downhill direction. */
+export interface TerrainVec2 {
+  x: number;
+  z: number;
+}
+
+/** A placed rock's world position and size. */
+interface RockPosition {
+  x: number;
+  y: number;
+  z: number;
+  size: number;
+}
+
 // --- SimplexNoise implementation ---
 class SimplexNoise {
+  grad3: number[][];
+  p: number[];
+  perm: number[];
+  gradP: number[][];
+
   constructor() {
-    this.grad3 = [[1,1,0],[-1,1,0],[1,-1,0],[-1,-1,0], 
-                 [1,0,1],[-1,0,1],[1,0,-1],[-1,0,-1], 
-                 [0,1,1],[0,-1,1],[0,1,-1],[0,-1,-1]]; 
+    this.grad3 = [[1,1,0],[-1,1,0],[1,-1,0],[-1,-1,0],
+                 [1,0,1],[-1,0,1],[1,0,-1],[-1,0,-1],
+                 [0,1,1],[0,-1,1],[0,1,-1],[0,-1,-1]];
     this.p = [];
     for (let i = 0; i < 256; i++) {
       this.p[i] = Math.floor(Math.random() * 256);
     }
-    
-    // To remove the need for index wrapping, double the permutation table length 
-    this.perm = new Array(512); 
-    this.gradP = new Array(512); 
+
+    // To remove the need for index wrapping, double the permutation table length
+    this.perm = new Array(512);
+    this.gradP = new Array(512);
     
     // Populate permutation table
     for(let i = 0; i < 512; i++) { 
@@ -36,7 +61,7 @@ class SimplexNoise {
     } 
   }
   
-  noise(xin, yin) {
+  noise(xin: number, yin: number): number {
     // Simple 2D noise implementation - produces values between -1 and 1
     let n0, n1, n2; // Noise contributions from the three corners
     
@@ -107,7 +132,7 @@ class SimplexNoise {
     return 70 * (n0 + n1 + n2);
   }
   
-  dot(g, x, y) {
+  dot(g: number[], x: number, y: number): number {
     return g[0]*x + g[1]*y;
   }
 }
@@ -115,10 +140,10 @@ class SimplexNoise {
 // --- Terrain utilities ---
 
 // Global height map for efficient lookup - will be populated when terrain is created
-const heightMap = {}; 
+const heightMap: Record<string, number> = {};
 
 // Calculate terrain height at (x, z)
-function getTerrainHeight(x, z) {
+function getTerrainHeight(x: number, z: number): number {
   // First check if we have this position in our cached height map
   const key = `${Math.round(x*10)},${Math.round(z*10)}`;
   if (heightMap[key] !== undefined) {
@@ -150,7 +175,7 @@ function getTerrainHeight(x, z) {
 }
 
 // Calculate terrain gradient for physics and tree placement
-function getTerrainGradient(x, z) {
+function getTerrainGradient(x: number, z: number): TerrainVec2 {
   const eps = 0.1;
   const h = getTerrainHeight(x, z);
   const hX = getTerrainHeight(x + eps, z);
@@ -159,7 +184,7 @@ function getTerrainGradient(x, z) {
 }
 
 // Compute Downhill Direction (Approximate Gradient)
-function getDownhillDirection(x, z) {
+function getDownhillDirection(x: number, z: number): TerrainVec2 {
   const eps = 0.1;
   const h = getTerrainHeight(x, z);
   const hX = getTerrainHeight(x + eps, z);
@@ -174,7 +199,7 @@ function getDownhillDirection(x, z) {
 // --- Terrain creation functions ---
 
 // Create Terrain (Natural Mountain)
-function createTerrain(scene) {
+function createTerrain(scene: THREE.Scene) {
   // Create a large natural mountain terrain
   const geometry = new THREE.PlaneGeometry(300, 400, 150, 200);
   geometry.rotateX(-Math.PI / 2);
@@ -185,7 +210,7 @@ function createTerrain(scene) {
   
   // BufferAttribute.array is typed ArrayLike<number> (read-only); the concrete
   // buffer is a writable Float32Array, which we mutate in place below.
-  const vertices = /** @type {Float32Array} */ (geometry.attributes.position.array);
+  const vertices = geometry.attributes.position.array as Float32Array;
 
   // Create Perlin noise for natural terrain variation
   const perlin = new SimplexNoise();
@@ -300,19 +325,20 @@ function createTerrain(scene) {
 }
 
 // Add rocks to create a more realistic mountain environment
-function addRocks(scene) {
+function addRocks(scene: THREE.Scene) {
   // Remove any existing rocks from the scene to prevent duplicates
   for (let i = scene.children.length - 1; i >= 0; i--) {
     const child = scene.children[i];
     // Rocks are typically meshes with dodecahedron geometry
-    if (child.type === 'Mesh' && child.geometry && 
-        child.geometry.type && child.geometry.type.includes('Dodecahedron')) {
+    const mesh = child as THREE.Mesh;
+    if (child.type === 'Mesh' && mesh.geometry &&
+        mesh.geometry.type && mesh.geometry.type.includes('Dodecahedron')) {
       scene.remove(child);
     }
   }
-  
+
   // Create rock positions with higher density on steeper parts of mountain
-  const rockPositions = [];
+  const rockPositions: RockPosition[] = [];
   
   // Add rocks scattered across the entire mountain
   for(let z = -180; z < 90; z += 10) {
@@ -353,11 +379,13 @@ function addRocks(scene) {
   } 
   // Last resort - find by name or type
   else {
-    terrainMesh = scene.children.find(child => 
-      child.name === 'terrain' || 
-      (child.type === 'Mesh' && 
-       child.geometry && 
-       child.geometry.type === 'PlaneGeometry'));
+    terrainMesh = scene.children.find(child => {
+      const mesh = child as THREE.Mesh;
+      return child.name === 'terrain' ||
+        (child.type === 'Mesh' &&
+         !!mesh.geometry &&
+         mesh.geometry.type === 'PlaneGeometry');
+    });
   }
   
   // Create rock instances
@@ -384,13 +412,13 @@ function addRocks(scene) {
 }
 
 // Create a rock with variable size
-function createRock(size) {
+function createRock(size: number): THREE.Mesh {
   // Use dodecahedron as base shape for rocks
   const geometry = new THREE.DodecahedronGeometry(size, 1);
-  
+
   // Deform vertices slightly for more natural rock shape
   // (writable Float32Array under the read-only ArrayLike<number> type)
-  const positions = /** @type {Float32Array} */ (geometry.attributes.position.array);
+  const positions = geometry.attributes.position.array as Float32Array;
   for (let i = 0; i < positions.length; i += 3) {
     const noise = Math.random() * 0.2;
     positions[i] *= (1 + noise);
@@ -418,7 +446,7 @@ function createRock(size) {
 }
 
 // Debug utility to verify the height map is working
-function debugHeightMap(x, z) {
+function debugHeightMap(x: number, z: number): number {
   const key = `${Math.round(x*10)},${Math.round(z*10)}`;
   console.log(`Height Map Debug at (${x}, ${z}):`);
   console.log(`- Height Map Entry: ${heightMap[key]}`);


### PR DESCRIPTION
## Phase 3.6 — `mountains.ts`

Stacked on **#103** (PR 3.5, `snow.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the terrain module `.js` → `.ts`. This is the **high-risk** one — camera, trees, snow and the physics all depend on the terrain sampler — so the diff is strictly **type-only/erasable** and the terrain math is **byte-identical**. The physics-invariant harness confirms coasting stays bit-identical to the frozen baseline (terrain height consistency preserved).

### Changes
- `SimplexNoise` gets explicit typed fields (`grad3`/`p`/`perm`/`gradP`) and typed `noise()` / `dot()` signatures.
- **New types** — `TerrainVec2` (`{ x, z }`; gradient or unit downhill direction) and `RockPosition`. `heightMap` is `Record<string, number>`. Typed signatures for `getTerrainHeight` / `getTerrainGradient` / `getDownhillDirection` / `createTerrain` / `addRocks` / `createRock` / `debugHeightMap`.
- The two JSDoc `/** @type {Float32Array} */` buffer casts become `as Float32Array`.
- Typing `addRocks` / `createTerrain` scene params (was implicit `any`) surfaced the dead terrain-mesh lookups reading `child.geometry` on `Object3D`; those now cast `child as THREE.Mesh` for the geometry probe — type-only, behaviour-identical.
- Refreshed the stale header note (the window terrain-sampler bridges were already removed in Phase 2).

### Node `.js`→`.ts` resolution
- The `./trees.js` specifier stays `.js` — Vite/tsc resolve it to `trees.ts`, and the copied static-artifact `mountains.js` still imports `./trees.js`, resolving to the transpiled dist `trees.js` (verified).
- The Node `terrain`/`regression` tests `import('../src/mountains.js')` hit `mountains.ts` via the **`.js`→`.ts` resolve hook added in PR 3.3** — no new test wiring.

`eslint.config.js` drops `mountains.js` from the module-override list.

### Gates (all green locally)
- `npm run lint` ✅ · `npm run typecheck` ✅
- `npm test` ✅ — terrain 7/7, regression 10/10, **physics invariant coasting bit-identical**, auth 23/23, scores 20/20, dom_smoke 18/18
- `npm run build` ✅ + artifact checks (`dist/src/mountains.js` present, raw `.ts` absent; copied `mountains.js` still imports `./trees.js`)
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites (incl. camera/tree/regression)

> Note: CI (`ci.yml`) and reviewdog only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
