### PR TITLE
refactor(ts): PR 3.7 — rename snowman.js → snowman.ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,10 +65,10 @@ module.exports = [
   {
     // avalanche.js (Phase 3.0), course.js/effects.js (Phase 3.1), camera.js
     // (Phase 3.2), trees.js (Phase 3.3), controls.js (Phase 3.4), snow.js
-    // (Phase 3.5) and mountains.js (Phase 3.6) were renamed to .ts (issue #84);
-    // `eslint .` does not lint .ts (no typescript-eslint configured), so those
-    // files are dropped from this module override.
-    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/main.js", "src/scores.js", "src/snowglider.js", "src/snowman.js", "src/ui/start-menu.js"],
+    // (Phase 3.5), mountains.js (Phase 3.6) and snowman.js (Phase 3.7) were renamed
+    // to .ts (issue #84); `eslint .` does not lint .ts (no typescript-eslint
+    // configured), so those files are dropped from this module override.
+    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/main.js", "src/scores.js", "src/snowglider.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/snowman.ts
+++ b/src/snowman.ts
@@ -1,20 +1,91 @@
-// @ts-check
-// snowman.js - Snowman model and functions for SnowGlider game
+// snowman.ts - Snowman model and functions for SnowGlider game
 //
 // Phase 2.8 (issue #84): final terrain-cluster module converted off the classic
 // global model. `THREE` now comes from the npm package via a real ES-module
-// import instead of the CDN global, and `Snowman` is `export`ed. The
-// window.Snowman assignment below is kept so the still-classic consumer
-// (snowglider.js, which reads `Snowman` by bare name, e.g.
-// `Snowman.createSnowman(scene)`, converted last in PR 2.9) keeps working during
-// the staged migration. snowman.js reads the terrain samplers (getTerrainHeight/
-// getTerrainGradient/getDownhillDirection) by bare name at call time; those
-// resolve to the window bridges published by mountains.js (PR 2.7). It is loaded
-// into the page through the bundle entry (src/main.js), not the classic loader.
+// import instead of the CDN global, and `Snowman` is `export`ed. snowman.js
+// receives the terrain samplers (getTerrainHeight/getTerrainGradient/
+// getDownhillDirection) as function arguments (not globals); it is loaded into the
+// page through the bundle entry (src/main.js) and imported by snowglider.js.
+//
+// Phase 3.7 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file) and the movement/physics contract is now
+// expressed as real type declarations: the player position/velocity inputs, the
+// injected terrain samplers, the controls object, the tree-collision shape, the
+// camera-manager seam, and the per-frame `UpdateResult`. The physics math is
+// byte-identical — every edit is type-only/erasable, so esbuild (Vite) and Node's
+// native type-stripping run it exactly as before; the physics-invariant harness
+// confirms coasting stays bit-identical to the frozen baseline.
 import * as THREE from 'three';
 
+/** Mutable player position the physics integrates each frame. */
+interface PlayerPos {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Mutable horizontal velocity (vertical motion is tracked by verticalVelocity). */
+interface PlanarVelocity {
+  x: number;
+  z: number;
+}
+
+/** A 2D terrain vector: a gradient or a unit downhill direction. */
+interface TerrainVec2 {
+  x: number;
+  z: number;
+}
+
+/** Terrain height sampler injected by the orchestrator. */
+type TerrainHeightFn = (x: number, z: number) => number;
+/** Terrain gradient / downhill-direction sampler injected by the orchestrator. */
+type TerrainVecFn = (x: number, z: number) => TerrainVec2;
+
+/** The control flags updateSnowman reads each frame. */
+interface SnowmanControls {
+  left: boolean;
+  right: boolean;
+  up: boolean;
+  down: boolean;
+  jump: boolean;
+}
+
+/** Minimal tree-position shape the collision check reads. */
+interface TreePos {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** The camera-manager seam resetSnowman drives (satisfied by the Camera class). */
+interface CameraManagerLike {
+  initialize(position: THREE.Vector3, rotation: THREE.Euler): void;
+}
+
+/** Game-over callback handed in by the orchestrator. */
+type ShowGameOverFn = (reason: string) => void;
+
+/** Ski technique surfaced for the HUD + ski pose. */
+type SkiTechnique = 'air' | 'glide' | 'snowplow' | 'skid' | 'carve' | 'tuck';
+
+/** Per-frame physics output returned by updateSnowman. */
+interface UpdateResult {
+  isInAir: boolean;
+  verticalVelocity: number;
+  lastTerrainHeight: number;
+  airTime: number;
+  jumpCooldown: number;
+  turnPhase: number;
+  currentTurnDirection: number;
+  turnChangeCooldown: number;
+  currentSpeed: number;
+  technique: SkiTechnique;
+  justLanded: boolean;
+  landingForce: number;
+}
+
 // Create Snowman (Three Spheres)
-function createSnowman(scene) {
+function createSnowman(scene: THREE.Scene): THREE.Group {
   const group = new THREE.Group();
   const snowMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.9 });
   const blackMaterial = new THREE.MeshStandardMaterial({ color: 0x000000 });
@@ -71,7 +142,7 @@ function createSnowman(scene) {
   
   // --- Stick Arms ---
   // Create a function to build a branched arm
-  function createBranchArm(isLeft) {
+  function createBranchArm(isLeft: boolean): THREE.Group {
     const armGroup = new THREE.Group();
     const mainStickLength = 2.5;
     const mainStickRadius = 0.08; // Slightly thinner radius
@@ -205,7 +276,7 @@ function createSnowman(scene) {
 }
 
 // Reset the snowman to initial position
-function resetSnowman(snowman, pos, velocity, getTerrainHeight, cameraManager) {
+function resetSnowman(snowman: THREE.Object3D, pos: PlayerPos, velocity: PlanarVelocity, getTerrainHeight: TerrainHeightFn, cameraManager: CameraManagerLike): number {
   // Start higher up the mountain (z=-20 instead of -40 for a longer run)
   // With extended terrain, we can start even higher up at z=-15
   pos.x = 0;
@@ -238,11 +309,11 @@ function resetSnowman(snowman, pos, velocity, getTerrainHeight, cameraManager) {
 }
 
 // Update snowman physics and movement
-function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity, 
-                      lastTerrainHeight, airTime, jumpCooldown, controls, 
-                      turnPhase, currentTurnDirection, turnChangeCooldown, turnAmplitude,
-                      getTerrainHeight, getTerrainGradient, getDownhillDirection, 
-                      treePositions, gameActive, showGameOver) {
+function updateSnowman(snowman: THREE.Object3D, delta: number, pos: PlayerPos, velocity: PlanarVelocity, isInAir: boolean, verticalVelocity: number,
+                      lastTerrainHeight: number, airTime: number, jumpCooldown: number, controls: SnowmanControls,
+                      turnPhase: number, currentTurnDirection: number, turnChangeCooldown: number, turnAmplitude: number,
+                      getTerrainHeight: TerrainHeightFn, getTerrainGradient: TerrainVecFn, getDownhillDirection: TerrainVecFn,
+                      treePositions: TreePos[], gameActive: boolean, showGameOver: ShowGameOverFn): UpdateResult {
   
   // Update jump cooldown
   if (jumpCooldown > 0) {
@@ -250,7 +321,7 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
   }
   
   // Outer-scope outputs surfaced in the return value (HUD + camera juice).
-  let technique = isInAir ? 'air' : 'glide';
+  let technique: SkiTechnique = isInAir ? 'air' : 'glide';
   let justLanded = false;
   let landingForce = 0;
   
@@ -696,7 +767,7 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
 }
 
 // Add test hook functions for tree collision testing
-function addTestHooks(pos, showGameOver, getTerrainHeight) {
+function addTestHooks(pos: PlayerPos, showGameOver: ShowGameOverFn, getTerrainHeight: TerrainHeightFn) {
   console.log("Snowman.addTestHooks called - setting up test hooks");
   
   if (!window.testHooks) {
@@ -861,5 +932,5 @@ export const Snowman = {
   addTestHooks
 };
 
-// The window.Snowman bridge was removed (issue #84): snowglider.js and the
-// gameplay browser tests import Snowman.
+// Snowman is imported directly by snowglider.js and the gameplay browser tests
+// (issue #84).

--- a/tests/verification/physics_invariant_harness.js
+++ b/tests/verification/physics_invariant_harness.js
@@ -85,14 +85,19 @@ function simulate(updateFn, controls, seed, steps = 220, dt = 1 / 60) {
 }
 
 // The frozen baseline is still a classic script, so it loads via vm.runInContext.
-// src/snowman.js is now an ES module (issue #84, PR 2.8) and can't be evaluated
+// src/snowman is now an ES module (issue #84, PR 2.8) and can't be evaluated
 // that way, so import the REAL module and read its updateSnowman directly. The
 // comparison is unchanged: both return the same updateSnowman(...) contract, and
-// the harness injects terrain + controls as arguments (snowman.js reads no terrain
+// the harness injects terrain + controls as arguments (snowman reads no terrain
 // globals). The async import means the checks run inside an async IIFE.
+//
+// Phase 3.7 (issue #84): snowman was renamed `.js` -> `.ts`. This harness runs
+// under `npm run test:verify` (no `.js`->`.ts` resolve hook), and it imports
+// snowman directly, so use the real `.ts` extension (Node strips the erasable
+// types natively, like avalanche.ts).
 (async () => {
 const orig = loadUpdate(path.join(__dirname, 'snowman_baseline.js'));
-const mod = (await import('../../src/snowman.js')).Snowman.updateSnowman;
+const mod = (await import('../../src/snowman.ts')).Snowman.updateSnowman;
 // updateSnowman reads window.treeCollisionRadius / window.location.search for its
 // test-hook + debug-logging paths; the frozen baseline gets these from its vm
 // sandbox, so provide the same minimal stub on the global for the imported module.


### PR DESCRIPTION
## Phase 3.7 — `snowman.ts`

Stacked on **#104** (PR 3.6, `mountains.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the snowman model + physics module `.js` → `.ts`. This is the **largest, most core** module (player movement, jumps, tree collision, finish logic, ski-technique model), so the diff is strictly **type-only/erasable** and the physics math is byte-identical. The physics-invariant harness confirms coasting stays **bit-identical** to the frozen baseline (max abs diff `0.000e+0`).

### The movement/physics contract, now typed
- New types: `PlayerPos` (`{ x, y, z }`), `PlanarVelocity` (`{ x, z }`), `TerrainVec2`, `TerrainHeightFn`, `TerrainVecFn`, `SnowmanControls`, `TreePos`, `CameraManagerLike`, `ShowGameOverFn`, `SkiTechnique`, and the per-frame `UpdateResult` returned by `updateSnowman`.
- `createSnowman` / `createBranchArm` / `resetSnowman` / `updateSnowman` / `addTestHooks` get typed signatures. `updateSnowman`'s **22-param contract is fully typed**, and since `snowglider.js` is checked by `tsc`, the compiler verifies its call against the new signature. `technique` is typed `SkiTechnique`.

### Resolution
- `snowman` reads no terrain globals (samplers come in as args), so it imports only `three` — **no transitive `.js`→`.ts` issue**.
- The physics-invariant harness imports `snowman` directly and runs under `npm run test:verify` (no resolve hook), so its import moves to the real `.ts` extension (the `avalanche.ts` pattern).
- The browser gameplay suite imports `../src/snowman.js` through Vite, which resolves `.js`→`.ts`. Static artifact gets `dist/src/snowman.js` from the transpile (verified, raw `.ts` removed).
- `eslint.config.js` drops `snowman.js`; the module-override list now holds only the still-`.js` modules (audio/auth/scores/main/snowglider/boot/ui).

### Gates (all green locally)
- `npm run lint` ✅ · `npm run typecheck` ✅
- `npm test` ✅ — **physics invariant coasting bit-identical (max abs diff 0.000e+0)**, terrain 7/7, regression 10/10, auth 23/23, scores 20/20, dom_smoke 18/18
- `npm run build` ✅ + artifact checks (`dist/src/snowman.js` present, raw `.ts` absent)
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites (gameplay/regression/tree exercise the physics)

> Note: CI (`ci.yml`) and reviewdog only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
