### PR TITLE
refactor(ts): PR 3.8 — rename auth.js + scores.js to .ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,12 +63,12 @@ module.exports = [
     }
   },
   {
-    // avalanche.js (Phase 3.0), course.js/effects.js (Phase 3.1), camera.js
-    // (Phase 3.2), trees.js (Phase 3.3), controls.js (Phase 3.4), snow.js
-    // (Phase 3.5), mountains.js (Phase 3.6) and snowman.js (Phase 3.7) were renamed
+    // The game/app modules avalanche/course/effects/camera/trees/controls/snow/
+    // mountains/snowman (Phases 3.0-3.7) and auth/scores (Phase 3.8) were renamed
     // to .ts (issue #84); `eslint .` does not lint .ts (no typescript-eslint
-    // configured), so those files are dropped from this module override.
-    files: ["src/audio.js", "src/auth.js", "src/boot/script-loader.js", "src/main.js", "src/scores.js", "src/snowglider.js", "src/ui/start-menu.js"],
+    // configured), so those files are dropped from this module override. Only
+    // audio.js + the boot/orchestrator/ui scripts remain as `.js` modules here.
+    files: ["src/audio.js", "src/boot/script-loader.js", "src/main.js", "src/snowglider.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,14 @@
-// @ts-check
-// auth.js - Firebase Authentication module for SnowGlider
+// auth.ts - Firebase Authentication module for SnowGlider
 // Uses Firebase modular SDK (Popup-only Google Sign-In)
+//
+// Phase 3.8 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+// (implied for a real `.ts` file). The module keeps its existing Firebase-typed
+// JSDoc (`@param`/`@returns` with `import('firebase/auth').*` etc.) — TypeScript
+// reads JSDoc type annotations in `.ts` files too, so the popup-only auth flow and
+// the localStorage fallback stay byte-for-byte unchanged (no TS syntax added).
+// It still loads via firebase-bootstrap's `<script src="src/auth.js">` (Vite-dev
+// resolves `.js`->`.ts`; the build emits `dist/src/auth.js`), and the headless
+// auth test reads `src/auth.ts` now (Node does not remap `.js`->`.ts`).
 
 // Prevent Firebase from trying to auto-init via init.json that gives 404 on GitHub Pages
 window.FIREBASE_MANUAL_INIT = true;
@@ -179,7 +187,7 @@ function updateUIForLoggedInUser(user) {
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
   const profileName = document.getElementById('profileName');
-  const profileAvatar = /** @type {HTMLImageElement} */ (document.getElementById('profileAvatar'));
+  const profileAvatar = document.getElementById('profileAvatar') as HTMLImageElement;
 
   if (!authUI || !profileUI) {
     console.error("updateUIForLoggedInUser: Could not find authUI or profileUI elements!");
@@ -229,7 +237,7 @@ function updateUIForLoggedOutUser() {
 
 // Reset login button to default state
 function resetLoginButton() {
-  const loginBtn = /** @type {HTMLButtonElement} */ (document.getElementById('loginBtn'));
+  const loginBtn = document.getElementById('loginBtn') as HTMLButtonElement;
   if (loginBtn) {
     loginBtn.textContent = 'Login with Google';
     loginBtn.disabled = false;
@@ -242,7 +250,7 @@ function resetLoginButton() {
 // Set up login/logout button handlers
 function setupAuthButtons() {
   // Login button
-  const loginBtn = /** @type {HTMLButtonElement} */ (document.getElementById('loginBtn'));
+  const loginBtn = document.getElementById('loginBtn') as HTMLButtonElement;
   if (loginBtn) {
     // Function to handle sign-in process using Popup
     const handleSignIn = (e) => {
@@ -320,7 +328,7 @@ function setupAuthButtons() {
   }
 
   // Logout button
-  const logoutBtn = /** @type {HTMLButtonElement} */ (document.getElementById('logoutBtn'));
+  const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement;
   if (logoutBtn) {
     // Prevent default touch behavior if needed
     logoutBtn.addEventListener('touchstart', (e) => {

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -1,8 +1,15 @@
-// @ts-check
 /**
- * scores.js - User scoring and leaderboard module for SnowGlider
+ * scores.ts - User scoring and leaderboard module for SnowGlider
  *
- * This module handles player scoring, personal best tracking, and the global 
+ * Phase 3.8 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
+ * (implied for a real `.ts` file); the module keeps its existing Firebase-typed
+ * JSDoc (TypeScript reads JSDoc in `.ts` too), so score validation, the
+ * localStorage best-time store and the leaderboard sync/fallback stay byte-for-byte
+ * unchanged (no TS syntax added). It loads via firebase-bootstrap's
+ * `<script src="src/scores.js">` (Vite-dev resolves `.js`->`.ts`; the build emits
+ * `dist/src/scores.js`); the headless scores test reads `src/scores.ts` now.
+ *
+ * This module handles player scoring, personal best tracking, and the global
  * leaderboard functionality. It was split from auth.js to provide better
  * separation of concerns.
  * 

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -83,7 +83,16 @@ const mocks = {
 
 // ---- Load src/auth.js with imports/exports stripped, mocks injected ----
 function loadAuthModule() {
-  let code = fs.readFileSync(path.join(REPO, 'src', 'auth.js'), 'utf8');
+  // src/auth.ts is TypeScript (issue #84, Phase 3.8). Strip the types to runnable
+  // JS first (esbuild-equivalent transpile via the TypeScript devDependency) so the
+  // `new Function(...)` eval below — which can't parse `as` casts / annotations —
+  // sees plain JavaScript. ESNext output keeps the import/export statements as-is,
+  // so the existing import/export removal still works.
+  const ts = require('typescript');
+  const tsSource = fs.readFileSync(path.join(REPO, 'src', 'auth.ts'), 'utf8');
+  let code = ts.transpileModule(tsSource, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
+  }).outputText;
   code = code.replace(/import[\s\S]*?from\s+["'][^"']+["'];/g, ''); // drop CDN + local imports
   code = code.replace(/export\s+default\s+[^;]+;/g, '');            // drop `export default AuthModule;`
   const argNames = Object.keys(mocks);

--- a/tests/scores-tests.js
+++ b/tests/scores-tests.js
@@ -249,7 +249,15 @@ const mocks = {
 };
 
 function loadScoresModule() {
-  let code = fs.readFileSync(path.join(REPO, 'src', 'scores.js'), 'utf8');
+  // src/scores.ts is TypeScript (issue #84, Phase 3.8). Strip the types to runnable
+  // JS first (transpile via the TypeScript devDependency) so the `new Function(...)`
+  // eval below sees plain JavaScript. ESNext output keeps import/export statements
+  // as-is, so the existing import/export removal still works.
+  const ts = require('typescript');
+  const tsSource = fs.readFileSync(path.join(REPO, 'src', 'scores.ts'), 'utf8');
+  let code = ts.transpileModule(tsSource, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
+  }).outputText;
   code = code.replace(/import[\s\S]*?from\s+["'][^"']+["'];/g, '');
   code = code.replace(/export\s+default\s+[^;]+;/g, '');
   const argNames = Object.keys(mocks);


### PR DESCRIPTION
## Phase 3.8 — `auth.ts` + `scores.ts`

Stacked on **#105** (PR 3.7, `snowman.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the Firebase auth + scoring modules `.js` → `.ts`, dropping the now-implied `// @ts-check` pragma. Both already carried comprehensive Firebase-typed JSDoc (`@param`/`@returns` with `import('firebase/auth').*` / `import('firebase/firestore').*`), which TypeScript reads in `.ts` files too — so the **popup-only auth flow, localStorage fallback, and score sync/fallback stay byte-for-byte unchanged** (behavior > type cleanliness, per the issue).

### Only TS-syntax change
auth.ts's four `document.getElementById(...)` JSDoc casts (`/** @type {HTMLButtonElement} */ (...)`) become `as` casts — `.ts` does **not** honour JSDoc cast syntax (they were silently dropped, surfacing 6 DOM `.src`/`.disabled` errors). Type-only/erasable; behaviour identical.

### Runtime loading — unchanged, verified on both paths
This module is loaded differently from the game modules (raw `<script src>`, not the Vite bundle), so I verified both:
- `firebase-bootstrap.js` still injects `<script src="src/auth.js">` / `src/scores.js`. **The Vite dev server resolves the raw `.js` script-src to the `.ts` file** (confirmed: `GET /src/auth.js` → 200, transpiled), and the build emits `dist/src/auth.js` + `dist/src/scores.js` for production — so **no bootstrap change** and no deploy risk.
- auth.ts keeps `import ScoresModule from "./scores.js"` (Vite resolves `.js`→`.ts`).

### Node test loaders
The headless auth/scores tests read the source, strip imports/exports, and `new Function`-eval it. Since the source now contains `as` casts, `loadAuthModule`/`loadScoresModule` first **transpile it to plain JS via the TypeScript devDependency** (`ts.transpileModule`, ESNext output keeps import/export so the existing stripping still works).

`eslint.config.js` drops `auth.js`/`scores.js`; the module-override list now holds only `audio.js` + the boot/orchestrator/ui scripts.

### Gates (all green locally)
- `npm run lint` ✅ · `npm run typecheck` ✅
- `npm test` ✅ — **auth 23/23, scores 20/20**, terrain 7/7, regression 10/10, physics invariant OK, dom_smoke 18/18
- `npm run build` ✅ + artifact checks (`dist/src/auth.js` + `scores.js` present, `as` casts stripped, raw `.ts` absent; bootstrap still references `src/auth.js`)
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites (incl. **audio**, which loads auth/scores via firebase-bootstrap)

> Note: CI (`ci.yml`) and reviewdog only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
