### PR TITLE
refactor(ts): PR 3.9 — rename snowglider.js → snowglider.ts (orchestrator, last) (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,12 +63,13 @@ module.exports = [
     }
   },
   {
-    // The game/app modules avalanche/course/effects/camera/trees/controls/snow/
-    // mountains/snowman (Phases 3.0-3.7) and auth/scores (Phase 3.8) were renamed
-    // to .ts (issue #84); `eslint .` does not lint .ts (no typescript-eslint
-    // configured), so those files are dropped from this module override. Only
-    // audio.js + the boot/orchestrator/ui scripts remain as `.js` modules here.
-    files: ["src/audio.js", "src/boot/script-loader.js", "src/main.js", "src/snowglider.js", "src/ui/start-menu.js"],
+    // Every game/app module was renamed to .ts through Phase 3 (issue #84):
+    // avalanche/course/effects/camera/trees/controls/snow/mountains/snowman
+    // (3.0-3.7), auth/scores (3.8) and the snowglider.js orchestrator (3.9).
+    // `eslint .` does not lint .ts (no typescript-eslint configured), so they are
+    // dropped from this module override. Only audio.js + the boot/bundle-entry/ui
+    // scripts remain as `.js` ES modules here.
+    files: ["src/audio.js", "src/boot/script-loader.js", "src/main.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -1,4 +1,15 @@
-// @ts-check
+// snowglider.ts - Orchestrator: scene/render/game loop wiring for SnowGlider.
+//
+// Phase 3.9 (issue #84): the orchestrator is the LAST module renamed `.js` -> `.ts`,
+// after every leaf module was stable. The `@ts-check` pragma is gone (implied for a
+// real `.ts` file) and the three `/** @type {any} */ (...)` JSDoc casts (the r160
+// color-management / renderer opt-outs) are now `as any` casts — `.ts` does not
+// honour JSDoc cast syntax. No behaviour change and no GameState refactor: the
+// module-scoped state and its window accessors are unchanged. It still loads via the
+// deferred dynamic import below (Vite resolves `./snowglider.js` -> `snowglider.ts`;
+// the build emits a `dist/src/snowglider.js` chunk), and the puppeteer start-menu
+// regression now matches the delayed `/src/snowglider.{js,ts}` request.
+//
 // --- Imports (Phase 2.9, issue #84) ---
 // snowglider.js is the orchestrator and the LAST game module converted off the
 // classic global-namespace model. three.js and every converted game module now
@@ -34,13 +45,13 @@ Controls.setupControls();
 // and brightness. Opt out to preserve the original r134 look on this version
 // bump; adopting modern color/lighting is a deliberate later change.
 // (See docs/THREEJS_UPGRADE.md, Stage A.)
-const THREECompat = /** @type {any} */ (THREE);
+const THREECompat = THREE as any;
 THREECompat.ColorManagement.enabled = false;
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x87CEEB);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
-/** @type {any} */ (renderer).outputColorSpace = THREECompat.LinearSRGBColorSpace;
-/** @type {any} */ (renderer).useLegacyLights = true;
+(renderer as any).outputColorSpace = THREECompat.LinearSRGBColorSpace;
+(renderer as any).useLegacyLights = true;
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.shadowMap.enabled = true;
 // Update to assign renderer to a specific div with an ID

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -159,7 +159,11 @@ async function runStartMenuRaceRegression(browser) {
     } catch {
       pathname = request.url();
     }
-    if (pathname.endsWith('/src/snowglider.js')) {
+    // snowglider was renamed .js -> .ts (issue #84, Phase 3.9). Depending on how
+    // Vite rewrites the deferred dynamic import, the served request may be `.js`
+    // (Vite serves the .ts content for it) or the resolved `.ts` path — match both
+    // so the delayed-load start-menu regression keeps exercising the deferral.
+    if (pathname.endsWith('/src/snowglider.js') || pathname.endsWith('/src/snowglider.ts')) {
       snowgliderRequestSeen();
       await releaseSnowgliderScriptPromise;
     }


### PR DESCRIPTION
## Phase 3.9 — `snowglider.ts` (orchestrator, last rename)

Stacked on **#106** (PR 3.8, `auth.ts`/`scores.ts`). Part of the Phase 3 plan in #98 (issue #84).

Renames the orchestrator `.js` → `.ts` — the **last** module converted, after every leaf module was stable. **With this, every `src/` game/app module is TypeScript** (only `audio.js` + the boot/bundle-entry/ui scripts remain `.js`, out of Phase 3 rename scope).

### Minimal, behaviour-preserving
- Drop the now-implied `// @ts-check` pragma.
- Convert the three `/** @type {any} */ (...)` JSDoc casts (the r160 color-management + renderer opt-outs) to `as any` casts — `.ts` does not honour JSDoc cast syntax.
- **No GameState refactor** — the module-scoped game state and its `window` accessors (the bare-name seam the browser suites drive) are unchanged. `tsc` now verifies the orchestrator's calls into every typed module (`createSnowman`, `resetSnowman`, `updateSnowman`'s 22-param contract, `cameraManager.update`, Course/Effects/Avalanche integration) all type-check cleanly.

### Loading + test seams
- `src/main.js` keeps the deferred dynamic import `import('./snowglider.js')` (Vite resolves `.js`→`.ts`; the build emits a `dist/src/snowglider.js` chunk — verified).
- The puppeteer **start-menu deferred-load regression** intercepts the delayed snowglider request; it now matches `/src/snowglider.{js,ts}` so it keeps exercising the deferral regardless of how Vite rewrites the dynamic import.
- `AuthModule`/`ScoresModule`/`firebaseModules` stay `window.*` reads (Firebase bootstrap).

`eslint.config.js` drops `snowglider.js` — the module-override list now holds only the still-`.js` modules (audio + boot/main/ui).

### Gates (all green locally)
- `npm run lint` ✅ · `npm run typecheck` ✅
- `npm test` ✅ — all suites incl. **physics invariant coasting bit-identical**, auth 23/23, scores 20/20, dom_smoke 18/18
- `npm run build` ✅ + artifact checks (`dist/src/snowglider.js` + bundled chunk present, raw `.ts` absent, `as` casts stripped)
- `npm run test:browser` ✅ — **87 passed / 0 failed**, 7/7 suites (incl. the **start-menu deferred-load regression**)

> Note: CI (`ci.yml`) and reviewdog only trigger on PRs targeting `main`, so this stacked PR runs no GitHub Actions checks; gates above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
