### PR TITLE
refactor(ts): PR 3.10 — rename audio.js → audio.ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,11 +65,11 @@ module.exports = [
   {
     // Every game/app module was renamed to .ts through Phase 3 (issue #84):
     // avalanche/course/effects/camera/trees/controls/snow/mountains/snowman
-    // (3.0-3.7), auth/scores (3.8) and the snowglider.js orchestrator (3.9).
-    // `eslint .` does not lint .ts (no typescript-eslint configured), so they are
-    // dropped from this module override. Only audio.js + the boot/bundle-entry/ui
-    // scripts remain as `.js` ES modules here.
-    files: ["src/audio.js", "src/boot/script-loader.js", "src/main.js", "src/ui/start-menu.js"],
+    // (3.0-3.7), auth/scores (3.8), the snowglider.js orchestrator (3.9) and
+    // audio.js (3.10). `eslint .` does not lint .ts (no typescript-eslint
+    // configured), so they are dropped from this module override. Only the
+    // boot/bundle-entry/ui scripts remain as `.js` ES modules here.
+    files: ["src/boot/script-loader.js", "src/main.js", "src/ui/start-menu.js"],
     languageOptions: {
       sourceType: "module"
     }

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,5 +1,4 @@
-// @ts-check
-// audio.js - Radically simplified audio using native HTML5 Audio
+// audio.ts - Radically simplified audio using native HTML5 Audio
 // ~100 lines max, single track, minimal state management
 //
 // Phase 2 (issue #84): converted off the classic global model. `AudioModule` is
@@ -7,6 +6,12 @@
 // the classic script-loader. This module uses no three.js, so there is no
 // `import * as THREE`. Every consumer imports `AudioModule` directly now, so the
 // previous `window.AudioModule` namespace bridge has been removed.
+//
+// Phase 3 (issue #84): renamed `.js` -> `.ts`, dropping the now-implied
+// `// @ts-check` pragma and promoting the `AudioStatus` JSDoc typedef into a real
+// `interface` plus typed fields/params. Every edit is type-only/erasable, so
+// esbuild (Vite) and Node's native type-stripping run it exactly as before —
+// behaviour is unchanged.
 //
 // Design principles:
 // 1. Native HTML5 Audio element - no library dependencies
@@ -23,27 +28,28 @@ const AUDIO_ENABLED = true;
 /**
  * Status object returned by getStatus(). The native HTML5 implementation only
  * populates the first fields; bufferLoaded/contextReady/contextState are legacy
- * (Howler/AudioContext-era) fields that callers (snowglider.js checkAudioStatus)
+ * (Howler/AudioContext-era) fields that callers (snowglider.ts checkAudioStatus)
  * still probe — kept optional so those compat checks type-check and read as
  * undefined at runtime.
- * @typedef {Object} AudioStatus
- * @property {boolean} initialized
- * @property {boolean} disabled
- * @property {boolean} muted
- * @property {boolean} playing
- * @property {string} [currentTrack]
- * @property {boolean} [bufferLoaded]
- * @property {boolean} [contextReady]
- * @property {string} [contextState]
  */
+interface AudioStatus {
+  initialized: boolean;
+  disabled: boolean;
+  muted: boolean;
+  playing: boolean;
+  currentTrack?: string;
+  bufferLoaded?: boolean;
+  contextReady?: boolean;
+  contextState?: string;
+}
 
 export const AudioModule = (function() {
-  let audio = null;
+  let audio: HTMLAudioElement | null = null;
   let muted = false;
   let initialized = false;
-  
+
   const AUDIO_PATH = 'assets/drum_loop_are_you_heaven.wav';
-  
+
   // Load mute preference from localStorage
   function loadPreferences() {
     const stored = localStorage.getItem('snowgliderMuted');
@@ -51,33 +57,33 @@ export const AudioModule = (function() {
       muted = stored === 'true';
     }
   }
-  
+
   // Save mute preference
   function savePreferences() {
     localStorage.setItem('snowgliderMuted', String(muted));
   }
-  
+
   // Create the audio element
-  function createAudio() {
+  function createAudio(): HTMLAudioElement {
     if (audio) return audio;
-    
+
     audio = new Audio(AUDIO_PATH);
     audio.loop = true;
     audio.volume = 0.5;
-    
+
     audio.addEventListener('error', (e) => {
-      const mediaEl = /** @type {HTMLMediaElement} */ (e.target);
+      const mediaEl = e.target as HTMLMediaElement;
       console.warn('[Audio] Load error:', mediaEl?.error?.message || 'unknown');
     });
-    
+
     return audio;
   }
-  
+
   // Create minimal UI - just a mute button
   function createUI() {
     if (!AUDIO_ENABLED) return;
     if (document.getElementById('audioControlBtn')) return;
-    
+
     const btn = document.createElement('button');
     btn.id = 'audioControlBtn';
     btn.style.cssText = `
@@ -87,57 +93,57 @@ export const AudioModule = (function() {
       font-size: 20px; cursor: pointer;
     `;
     updateButtonUI(btn);
-    
+
     btn.addEventListener('click', () => {
       AudioModule.toggleMute();
       // Button UI is already updated by toggleMute()
     });
-    
+
     document.body.appendChild(btn);
   }
-  
-  function updateButtonUI(btn) {
+
+  function updateButtonUI(btn: HTMLElement) {
     btn.textContent = muted ? '🔇' : '🔊';
     btn.title = muted ? 'Unmute' : 'Mute';
   }
-  
+
   // Public API
   return {
     // _scene accepted (and ignored) for backward-compat with the old Three.js
     // Audio API surface; the native HTML5 implementation needs no scene.
-    init: function(_scene) {
+    init: function(_scene?: unknown) {
       if (!AUDIO_ENABLED) return { initialized: false, disabled: true };
       if (initialized) return { initialized: true };
-      
+
       loadPreferences();
       initialized = true;
       console.log('[Audio] Initialized (simplified)');
       return { initialized: true };
     },
-    
+
     setupUI: function() {
       if (!AUDIO_ENABLED) return;
       createUI();
     },
-    
+
     startAudio: function() {
       if (!AUDIO_ENABLED || muted) return false;
-      
-      createAudio();
-      audio.play().then(() => {
+
+      const el = createAudio();
+      el.play().then(() => {
         console.log('[Audio] Playing');
       }).catch((e) => {
         console.warn('[Audio] Play failed:', e.message);
       });
       return true;
     },
-    
+
     toggleMute: function() {
       if (!AUDIO_ENABLED) return false;
-      
+
       muted = !muted;
       savePreferences();
-      
+
       if (audio) {
         if (muted) {
           audio.pause();
@@ -145,20 +151,20 @@ export const AudioModule = (function() {
           audio.play().catch(() => {});
         }
       }
-      
+
       // Update button if exists
       const btn = document.getElementById('audioControlBtn');
       if (btn) updateButtonUI(btn);
-      
+
       return muted;
     },
-    
-    setVolume: function(level) {
+
+    setVolume: function(level: number) {
       if (!AUDIO_ENABLED || !audio) return;
       audio.volume = Math.max(0, Math.min(1, level));
     },
-    
-    enableSound: function(enable) {
+
+    enableSound: function(enable: boolean) {
       if (!AUDIO_ENABLED) return;
       if (enable && !muted && audio) {
         audio.play().catch(() => {});
@@ -166,9 +172,8 @@ export const AudioModule = (function() {
         audio.pause();
       }
     },
-    
-    /** @returns {AudioStatus} */
-    getStatus: function() {
+
+    getStatus: function(): AudioStatus {
       if (!AUDIO_ENABLED) {
         return { initialized: false, disabled: true, muted: true, playing: false };
       }
@@ -180,20 +185,20 @@ export const AudioModule = (function() {
         currentTrack: 'drum_loop'
       };
     },
-    
+
     isEnabled: function() {
       return AUDIO_ENABLED;
     },
-    
+
     // Compatibility stubs for existing code. preloadAudio accepts (and ignores) a
     // track name for parity with the old Howler API surface — the boot
     // script-loader still calls preloadAudio('drum_loop').
-    preloadAudio: function(_track) { return Promise.resolve(); },
+    preloadAudio: function(_track?: string) { return Promise.resolve(); },
     playPreloadedAudio: function() { return this.startAudio(); },
     resumeAudioContext: function() { return Promise.resolve(); },
     changeTrack: function() { return false; },
-    addAudioListener: function(_listener) {},
-    showMessage: function(msg, duration = 3000) {
+    addAudioListener: function(_listener?: unknown) {},
+    showMessage: function(msg: string, duration = 3000) {
       // Keep message functionality
       const div = document.createElement('div');
       div.textContent = msg;
@@ -210,5 +215,5 @@ export const AudioModule = (function() {
 })();
 
 // The window.AudioModule bridge was removed (issue #84): every consumer now
-// imports AudioModule directly — snowglider.js (orchestrator), the boot
+// imports AudioModule directly — snowglider.ts (orchestrator), the boot
 // script-loader, the start menu, and the audio browser test suite.


### PR DESCRIPTION
## PR 3.10 — rename `audio.js` → `audio.ts` (issue #84)

Continues the Phase 3 rename sweep. Stacked on #107 (PR 3.9, `claude/ts-phase-3-9-snowglider`).

After the 3.0–3.9 chain renamed every **game** module to `.ts`, the only `.js` files left under `src/` are the leaf audio module + the boot/entry/UI scripts + the two classic Firebase bootstrap scripts. This PR converts the leaf:

- `git mv src/audio.js → src/audio.ts`, drop the now-implied `// @ts-check`.
- `AudioStatus` JSDoc typedef → real `interface` (legacy Howler/AudioContext fields kept optional — `snowglider.ts`'s `checkAudioStatus` still probes them).
- Typed module state + helper signatures (`audio: HTMLAudioElement | null`, `createAudio(): HTMLAudioElement`, `setVolume(level: number)`, `getStatus(): AudioStatus`, …); JSDoc cast → `as`. Behaviour unchanged — every edit is type-only/erasable.
- `eslint.config.js` drops `src/audio.js` from the module-override list.

**Resolution:** importers keep the `./audio.js` / `../audio.js` specifier (Vite/tsc Bundler map it to `audio.ts`; the copied Pages artifact resolves to the transpiled `dist/src/audio.js`). The `audio` browser suite imports `../src/audio.js` and is served through Vite, so no test wiring changes; it's browser-only (not in the Node `npm test` chain), so the `.js`→`.ts` Node resolve hook isn't involved.

### Gates (all green, verified locally)
- `npm run lint` ✓
- `npm run typecheck` (`tsc --noEmit`) ✓
- `npm test` ✓ (terrain 7/7, regression 10/10, avalanche 12/12, verify 18/18, + physics/tree-collision/auth/scores)
- `npm run build` ✓ (`dist/src/audio.ts` transpiled to `dist/src/audio.js`, no raw `.ts` shipped)
- `npm run test:browser` ✓ **87/0 across 7/7 suites** (controls, camera, audio, gameplay, tree, avalanche, regression)

> Stacked PR — base is `claude/ts-phase-3-9-snowglider`, not `main`, so `ci.yml`/reviewdog don't run here; gates verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Restack update (post-#94 rebase):** the upstream stack (#102–#107) was rebased to inherit the #94 script-loader fix + the auth-fallback fix/test. This branch was restacked from the old #107 (`bac0be6`) onto the rebased #107 (`401b030`) and force-pushed with lease. The audio commit is **content-identical** after the rebase (`git range-diff` shows `=`); gates re-verified green on the new base. Now `mergeable: clean`.