### PR TITLE
refactor(ts): PR 3.11 — rename the boot/entry cluster (main, script-loader, start-menu) to .ts (issue #84)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,18 +62,15 @@ module.exports = [
       "no-unused-vars": "off"
     }
   },
-  {
-    // Every game/app module was renamed to .ts through Phase 3 (issue #84):
-    // avalanche/course/effects/camera/trees/controls/snow/mountains/snowman
-    // (3.0-3.7), auth/scores (3.8), the snowglider.js orchestrator (3.9) and
-    // audio.js (3.10). `eslint .` does not lint .ts (no typescript-eslint
-    // configured), so they are dropped from this module override. Only the
-    // boot/bundle-entry/ui scripts remain as `.js` ES modules here.
-    files: ["src/boot/script-loader.js", "src/main.js", "src/ui/start-menu.js"],
-    languageOptions: {
-      sourceType: "module"
-    }
-  },
+  // Phase 3 (issue #84) renamed every src game/app module to .ts — the game
+  // modules (3.0-3.7), auth/scores (3.8), the snowglider orchestrator (3.9),
+  // audio.js (3.10) and finally the bundle entry + boot/ui scripts (main.js,
+  // boot/script-loader.js, ui/start-menu.js → .ts, 3.11). `eslint .` does not
+  // lint .ts (no typescript-eslint configured), so there is no longer a
+  // sourceType:"module" override for src. The only remaining `.js` files under
+  // src are the classic Firebase/local-auth bootstrap `<script>`s
+  // (boot/firebase-bootstrap.js, boot/local-auth.js); they are NOT modules, so
+  // the default `**/*.js` block (sourceType:"script") above is correct for them.
   {
     files: ["vite.config.js"],
     languageOptions: {

--- a/index.html
+++ b/index.html
@@ -170,13 +170,13 @@
   <!--
     ES-module bundle entry (issue #84, Phase 2). Deferred like every module
     script, so it runs before DOMContentLoaded and before the module loader
-    triggers the deferred snowglider orchestrator. main.js imports three and the
+    triggers the deferred snowglider orchestrator. main.ts imports three and the
     game modules from npm/src directly; the old `window.THREE` and per-module
     `window.*` migration bridges are gone. PR 2.10 removed the redundant CDN UMD
     <script> global that used to sit here; three is now bundled (Vite build) or
     import-mapped from node_modules (raw source) — a single copy.
   -->
-  <script type="module" src="src/main.js"></script>
+  <script type="module" src="src/main.ts"></script>
   <!--
     Boot + start-menu scripts. As of issue #84 these are ES modules too (loaded
     with type="module"), so they `import { AudioModule }` from src/audio.js
@@ -184,7 +184,7 @@
     module script they are deferred and run in document order after main.js but
     before DOMContentLoaded, so their DOMContentLoaded handlers still fire.
   -->
-  <script type="module" src="src/boot/script-loader.js"></script>
-  <script type="module" src="src/ui/start-menu.js"></script>
+  <script type="module" src="src/boot/script-loader.ts"></script>
+  <script type="module" src="src/ui/start-menu.ts"></script>
 </body>
 </html>

--- a/src/boot/script-loader.ts
+++ b/src/boot/script-loader.ts
@@ -1,8 +1,13 @@
-// @ts-check
 // Phase 2 (issue #84): converted to an ES module so it imports AudioModule from
 // the real src module instead of reading the window.AudioModule bridge. index.html
 // loads it as `<script type="module">` (deferred, like every module script), so it
 // still registers its DOMContentLoaded handler before that event fires.
+//
+// Phase 3.11 (issue #84): renamed `.js` -> `.ts`. No type surface to promote (this
+// is a boot orchestration script with implicitly-`any` DOM helper params under the
+// current non-strict config); the only edit is the JSDoc `(window)` cast → `as`.
+// The `../audio.js` import specifier is unchanged — Vite/tsc Bundler resolve it to
+// audio.ts.
 import { AudioModule } from '../audio.js';
 
 (function () {
@@ -62,8 +67,8 @@ import { AudioModule } from '../audio.js';
     avalanche: ['browser-avalanche-tests']
   };
 
-  function appendScript(src, configureScript) {
-    return new Promise((resolve, reject) => {
+  function appendScript(src: string, configureScript?: (script: HTMLScriptElement) => void) {
+    return new Promise<void>((resolve, reject) => {
       const script = document.createElement('script');
       if (typeof configureScript === 'function') {
         configureScript(script);
@@ -110,7 +115,7 @@ import { AudioModule } from '../audio.js';
     if (testParam === 'unified') {
       // Set this before module test suites evaluate so they publish their
       // window.run*Tests hooks without also self-starting.
-      /** @type {any} */ (window)._unifiedTestRunnerActive = true;
+      (window as any)._unifiedTestRunnerActive = true;
     }
 
     const testModuleLoads = selectedScripts.map((scriptName) => {
@@ -147,7 +152,7 @@ import { AudioModule } from '../audio.js';
   }
 
   function announceGameScriptsReady() {
-    /** @type {any} */ (window).SnowGliderGameScriptsReady = true;
+    (window as any).SnowGliderGameScriptsReady = true;
     window.dispatchEvent(new CustomEvent('snowglider:game-scripts-ready'));
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,14 @@
-// @ts-check
 import * as THREE from 'three';
 
 // Phase 2.0 (issue #84): a real ES-module entry that Vite bundles into a
 // hashed asset, importing three.js from the npm package instead of the CDN
-// global. index.html loads this as `<script type="module">`.
+// global. index.html loads this as `<script type="module" src="src/main.ts">`.
+//
+// Phase 3.11 (issue #84): renamed `.js` -> `.ts` (index.html's module `src` now
+// points at src/main.ts). The only edits are dropping the implied `// @ts-check`
+// pragma and converting the two JSDoc `(window)` casts to `as`; the `./*.js`
+// import specifiers are unchanged — Vite/tsc Bundler resolve them to the `.ts`
+// modules.
 //
 // Game modules are imported here only so they're part of the eagerly-loaded
 // bundle graph; snowglider.js (the deferred orchestrator) imports them too, the
@@ -27,7 +32,7 @@ import './audio.js';
 export const BUNDLED_THREE_REVISION = THREE.REVISION;
 
 if (typeof window !== 'undefined') {
-  /** @type {any} */ (window).__SNOWGLIDER_BUNDLE__ = {
+  (window as any).__SNOWGLIDER_BUNDLE__ = {
     threeRevision: THREE.REVISION
   };
 
@@ -45,7 +50,7 @@ if (typeof window !== 'undefined') {
   // Vite still bundles it into the shared module graph (one Snow/Snowman/etc.
   // instance), while raw-source serving resolves it to /src/snowglider.js (the
   // request the puppeteer start-menu regression intercepts).
-  /** @type {any} */ (window).__loadSnowGliderOrchestrator = () => import('./snowglider.js');
+  (window as any).__loadSnowGliderOrchestrator = () => import('./snowglider.js');
 }
 
 console.log(`[snowglider] bundled three.js r${THREE.REVISION}`);

--- a/src/ui/start-menu.ts
+++ b/src/ui/start-menu.ts
@@ -1,8 +1,12 @@
-// @ts-check
 // Phase 2 (issue #84): converted to an ES module so it imports AudioModule from
 // the real src module instead of reading the window.AudioModule bridge. index.html
 // loads it as `<script type="module">`; like every module script it is deferred,
 // so it still runs before DOMContentLoaded and its listeners are registered in time.
+//
+// Phase 3.11 (issue #84): renamed `.js` -> `.ts`. The only edit is the JSDoc
+// `(window)` cast → `as`; the DOM/menu wiring carries no type surface to promote
+// under the current non-strict config. The `../audio.js` import specifier is
+// unchanged — Vite/tsc Bundler resolve it to audio.ts.
 import { AudioModule } from '../audio.js';
 
 (function () {
@@ -115,7 +119,7 @@ import { AudioModule } from '../audio.js';
 
   function initializeStartMenu() {
     addBuildBadge();
-    if (/** @type {any} */ (window).SnowGliderGameScriptsReady) {
+    if ((window as any).SnowGliderGameScriptsReady) {
       startPendingGameIfReady();
     }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -120,8 +120,8 @@ export default defineConfig({
     rollupOptions: {
       input: {
         // index.html is Vite's HTML entry. As of Phase 2.1 (issue #84) it loads
-        // the ES-module bundle via `<script type="module" src="src/main.js">`,
-        // so Vite discovers src/main.js (and its imports: three + avalanche.js)
+        // the ES-module bundle via `<script type="module" src="src/main.ts">`,
+        // so Vite discovers src/main.ts (and its imports: three + avalanche.ts)
         // from the page itself and emits one hashed chunk referenced by
         // dist/index.html — no separate standalone input needed anymore.
         index: path.resolve(rootDir, 'index.html')


### PR DESCRIPTION
## PR 3.11 — rename the boot/entry cluster (`main`, `script-loader`, `start-menu`) to `.ts` (issue #84)

Completes the Phase 3 `.js`→`.ts` rename sweep for every src **module** file. Stacked on #108 (PR 3.10, `claude/ts-phase-3-10-audio`).

- `git mv` `src/main.js → src/main.ts`, `src/boot/script-loader.js → .ts`, `src/ui/start-menu.js → .ts`; drop the implied `// @ts-check`.
- These are boot orchestration / DOM-wiring scripts with no domain type surface to promote under the current non-strict config (DOM helper params stay implicitly `any`), so the only code edits are JSDoc `(window)` casts → `(window as any)`. Behaviour unchanged — every edit is type-only/erasable.
- `index.html`: the three `<script type="module" src=…>` tags now point at `src/main.ts` / `src/boot/script-loader.ts` / `src/ui/start-menu.ts` (Vite transpiles/bundles `.ts` module-script entries natively).
- `vite.config.js`: the entry comment now names `src/main.ts`.
- `eslint.config.js`: removed the now-empty src module-override block.

### What stays `.js` (by design)
The two classic Firebase/local-auth bootstrap scripts — `src/boot/local-auth.js`, `src/boot/firebase-bootstrap.js` — are loaded via plain `<script src>` (not modules) and are intentionally left as classic scripts per `docs/TYPESCRIPT_MIGRATION.md`. They're correctly covered by eslint's default `**/*.js` (`sourceType: "script"`) block.

**After this PR, every src game/app *module* is `.ts`.** The only `.js` left under `src/` are those two deliberate classic bootstrap scripts. The strict-flag ratchet (`strictNullChecks` first; per-file error spec in #98) is the next Phase 3 step.

### Gates (all green, verified locally)
- `npm run lint` ✓
- `npm run typecheck` (`tsc --noEmit`) ✓
- `npm test` ✓ (terrain 7/7, regression 10/10, avalanche 12/12, verify 18/18, + physics/tree-collision/auth/scores)
- `npm run build` ✓ — dist transpiles the three `.ts` → `.js`; Vite bundles the three module scripts into one hashed chunk that contains the `SnowGliderStartMenu` / `SnowGliderScriptLoader` / orchestrator logic; classic bootstrap scripts preserved as `<script src>`.
- `npm run test:browser` ✓ **87/0 across 7/7 suites** (controls, camera, audio, gameplay, tree, avalanche, regression)

> Stacked PR — base is `claude/ts-phase-3-10-audio`, not `main`, so `ci.yml`/reviewdog don't run here; gates verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Restack update (post-#94 rebase):** restacked from the old #107 (`bac0be6`) onto the rebased #107 (`401b030`)/audio (`#108`) and force-pushed with lease. The new base inherited the #94 `script-loader` refactor (`loadModuleScript`/`appendScript` + a `_unifiedTestRunnerActive` flag). That code type-checks loosely as `.js` but not once renamed to `.ts`, so this PR now also resolves three errors it surfaced:
- `appendScript(src: string, configureScript?: (script: HTMLScriptElement) => void)` — optional param so `loadScript(src)` is valid (TS2554)
- `new Promise<void>(…)` for the no-arg `resolve()` in `script.onload` (TS2794)
- the inherited `/** @type {any} */ (window)._unifiedTestRunnerActive` JSDoc cast → `(window as any)…` (TS2339)

All gates re-verified green on the new base (incl. the newly-inherited `firebase-bootstrap-tests` 5/5 and browser **87/0**, which exercises the #94 test-loading path). Now `mergeable: clean`.