### PR TITLE
chore(ci): honest full-source coverage — Node + browser merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,17 @@ jobs:
         run: npm run test:browser
         env:
           CI: true
-      
+          # Collect Chromium V8 coverage during the unified browser suite so the
+          # browser-only src/ modules are counted. Writes coverage/browser/lcov.info.
+          BROWSER_COVERAGE: 'true'
+
+      - name: Merge browser coverage into LCOV
+        # Line-merge c8 (Node + verification) coverage with the browser LCOV into
+        # coverage/lcov.info before upload. Resilient: skips missing inputs, so it
+        # is a no-op normalize if the browser run produced no coverage.
+        if: always()
+        run: npm run coverage:merge
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         if: ${{ always() && hashFiles('coverage/lcov.info') != '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,9 @@ test-results/
 # GitHub Pages build output
 dist/
 
-# Coverage reports
-coverage/
+# Coverage reports (anchored to the repo-root output dir so it does not also
+# ignore the tests/coverage/ tooling sources)
+/coverage/
 
 # Large video files
 *.mov

--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ The game automatically detects mobile devices and enables touch controls with vi
 ## Testing
 Run the Node suite with `npm test`; in-browser suites load via `?test=…` URL parameters. See [`tests/README.md`](tests/README.md) for the full test matrix, the browser parameters, the verification harness, and per-suite details.
 
-Coverage runs through `npm run test:coverage`, which uses c8/Codecov against the
-entire `src/` tree. The report is intentionally non-gating in CI and includes
-all migrated JavaScript/TypeScript source files, so browser-only or eval-loaded
-modules appear as `0%` until they have importable or browser-collected coverage.
+Coverage is reported to Codecov against the entire `src/` tree and is
+intentionally non-gating in CI. It combines two passes: `npm run test:coverage`
+measures the Node + verification suites with c8 (`--all --src src`), and the
+browser suite collects Chromium V8 coverage that is mapped back to `src/*.ts` and
+line-merged into the same `coverage/lcov.info`. Run the whole pipeline locally
+with `npm run test:coverage:all`. Browser-only modules are therefore counted, not
+shown as `0%`; remaining gaps reflect untested code rather than uninstrumented
+files.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # ❄️ SnowGlider ❄️
 
 [![CI/CD](https://github.com/den-run-ai/snowglider/actions/workflows/ci.yml/badge.svg)](https://github.com/den-run-ai/snowglider/actions/workflows/ci.yml)
-<!-- Coverage badge disabled until tests are refactored to use ES modules for proper instrumentation -->
-<!-- [![codecov](https://codecov.io/gh/den-run-ai/snowglider/branch/main/graph/badge.svg)](https://codecov.io/gh/den-run-ai/snowglider) -->
+[![codecov](https://codecov.io/gh/den-run-ai/snowglider/branch/main/graph/badge.svg)](https://codecov.io/gh/den-run-ai/snowglider)
 
 A cheerful snowman shredding mountain snow powder in a playful Three.js animation. ⛄️🎿
 
@@ -92,6 +91,11 @@ The game automatically detects mobile devices and enables touch controls with vi
 
 ## Testing
 Run the Node suite with `npm test`; in-browser suites load via `?test=…` URL parameters. See [`tests/README.md`](tests/README.md) for the full test matrix, the browser parameters, the verification harness, and per-suite details.
+
+Coverage runs through `npm run test:coverage`, which uses c8/Codecov against the
+entire `src/` tree. The report is intentionally non-gating in CI and includes
+all migrated JavaScript/TypeScript source files, so browser-only or eval-loaded
+modules appear as `0%` until they have importable or browser-collected coverage.
 
 ## Development
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,24 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Honest full-source coverage — Node + browser merged (#122)
+- `npm run test:coverage` now runs c8 with `--all --src src`, so the Node and
+  verification suites count every migrated `src/` file instead of only the ones
+  Node tests `import`.
+- The browser suite collects Chromium V8 coverage (`BROWSER_COVERAGE=1` →
+  `tests/coverage/browser-coverage.js`) and attributes it back to `src/*.ts` via
+  Vite's inline source maps. `tests/coverage/merge-lcov.js` line-merges that with
+  the c8 LCOV into a single `coverage/lcov.info` (`npm run test:coverage:all` runs
+  the whole pipeline; CI runs it across the existing test/browser steps).
+- Line-level merge is deliberate: c8 instruments Node's type-stripped `.ts` while
+  Vite instruments its esbuild output, so the two emit different statement
+  structures for the same file; an Istanbul-object merge would mis-attribute hits.
+- Net effect: browser-only modules (snowglider, course, effects, main, the boot
+  and start-menu modules) and the auth/scores browser suites now report real
+  coverage instead of `0%`; the merged report rose from ~28% (Node-only) to ~76%.
+  Coverage stays informational and non-gating (`fail_ci_if_error: false`, no
+  threshold); the Codecov badge is re-enabled now that the denominator is honest.
+
 ### TypeScript migration — Phase 2 (conversion) complete (#84)
 - Every game module is now an ES module that imports `three` from npm (the CDN
   UMD global is gone) and imports the others directly. The final classic module

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,14 @@
         "eslint": "^9.39.4",
         "globals": "^15.15.0",
         "http-server": "^14.1.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
         "jsdom": "^27.0.1",
         "puppeteer": "^23.11.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
+        "v8-to-istanbul": "^9.3.0",
         "vite": "^8.0.16"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:verify": "node tests/verification/physics_invariant_harness.js && node tests/verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:all": "npm test && npm run test:browser",
-    "test:coverage": "c8 --reporter=lcov --reporter=text npm run test",
+    "test:coverage": "c8 --all --src src --reporter=lcov --reporter=text npm run test",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:scores && npm run test:controls && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:scores && npm run test:controls && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/physics-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -14,10 +14,14 @@
     "test:auth": "node tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",
     "test:scores": "node tests/scores-tests.js",
     "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
+    "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node tests/verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",
+    "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:all": "npm test && npm run test:browser",
     "test:coverage": "c8 --all --src src --reporter=lcov --reporter=text npm run test",
+    "coverage:merge": "node tests/coverage/merge-lcov.js --out coverage/lcov.info coverage/lcov.info coverage/browser/lcov.info",
+    "test:coverage:all": "npm run test:coverage && npm run test:browser:coverage && npm run coverage:merge",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "dev": "vite --host 0.0.0.0",
@@ -37,10 +41,14 @@
     "eslint": "^9.39.4",
     "globals": "^15.15.0",
     "http-server": "^14.1.1",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
     "jsdom": "^27.0.1",
     "puppeteer": "^23.11.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
+    "v8-to-istanbul": "^9.3.0",
     "vite": "^8.0.16"
   }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,18 +89,36 @@ npm run test:verify         # Verification harness (physics invariant + DOM smok
 
 Other useful commands:
 ```bash
-npm run test:coverage       # Node suite under c8 coverage for all src/ files
+npm run test:coverage       # Node + verification suites under c8 coverage
 npm run test:browser        # Puppeteer browser suite
-npm run test:all            # Node suite + Puppeteer
+npm run test:browser:coverage  # Puppeteer suite with Chromium V8 coverage
+npm run coverage:merge      # Line-merge c8 + browser LCOV -> coverage/lcov.info
+npm run test:coverage:all   # Full pipeline: c8 + browser + merge
+npm run test:all            # Node suite + Puppeteer (no coverage)
 ```
 
-`npm run test:coverage` passes `--all --src src` to c8 so the generated
-`coverage/lcov.info` counts every source file in the migrated `src/` tree, not
-only files imported by Node tests. This keeps Codecov honest during the
-TypeScript migration: browser-only modules and harnesses that still execute
-transpiled/eval-loaded source are reported as uncovered until they are wired into
-importable Node tests or browser coverage collection. CI uploads the LCOV to
-Codecov as an informational, non-gating report; no coverage threshold is enforced.
+Coverage is collected from every suite and merged into a single
+`coverage/lcov.info`:
+
+- `npm run test:coverage` passes `--all --src src` to c8 so the Node and
+  verification suites count every source file in the migrated `src/` tree, not
+  only files imported by Node tests.
+- `npm run test:browser:coverage` sets `BROWSER_COVERAGE=1`, so
+  `tests/puppeteer-runner.js` records Chromium V8 coverage while the unified
+  browser suite runs. `tests/coverage/browser-coverage.js` converts that V8
+  coverage to Istanbul/LCOV, using Vite's inline source maps to attribute it back
+  to `src/*.ts` lines, and writes `coverage/browser/lcov.info`.
+- `npm run coverage:merge` (`tests/coverage/merge-lcov.js`) unions the two reports
+  at the LCOV line level — required because c8 (Node type-stripping) and Vite
+  (esbuild) emit different statement structures for the same file, so an
+  Istanbul-object merge would mis-attribute hits.
+
+This keeps Codecov honest: browser-only game modules are counted instead of
+showing as `0%`. The auth/scores modules are exercised by the browser auth/scores
+suites, so they now report real browser coverage too. CI runs `test:coverage`,
+then the browser suite with `BROWSER_COVERAGE`, then `coverage:merge`, and uploads
+the merged LCOV to Codecov as an informational, non-gating report; no coverage
+threshold is enforced.
 
 ### Browser Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -89,10 +89,18 @@ npm run test:verify         # Verification harness (physics invariant + DOM smok
 
 Other useful commands:
 ```bash
-npm run test:coverage       # Node suite under c8 coverage
+npm run test:coverage       # Node suite under c8 coverage for all src/ files
 npm run test:browser        # Puppeteer browser suite
 npm run test:all            # Node suite + Puppeteer
 ```
+
+`npm run test:coverage` passes `--all --src src` to c8 so the generated
+`coverage/lcov.info` counts every source file in the migrated `src/` tree, not
+only files imported by Node tests. This keeps Codecov honest during the
+TypeScript migration: browser-only modules and harnesses that still execute
+transpiled/eval-loaded source are reported as uncovered until they are wired into
+importable Node tests or browser coverage collection. CI uploads the LCOV to
+Codecov as an informational, non-gating report; no coverage threshold is enforced.
 
 ### Browser Tests
 

--- a/tests/coverage-merge-tests.js
+++ b/tests/coverage-merge-tests.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the LCOV line-level merger (tests/coverage/merge-lcov.js).
+ *
+ * Guards the merge contract used to combine c8 (Node + verification) coverage
+ * with Chromium browser coverage into a single coverage/lcov.info:
+ *   - line (DA) hit counts are unioned/summed across reports
+ *   - c8's `--all` synthetic `(empty-report)` function record is dropped
+ *   - function (FN/FNDA) hits sum by name; branches (BRDA) union by position
+ *   - LF/LH/FNF/FNH/BRF/BRH counters are recomputed and internally consistent
+ *   - SF paths are normalized so absolute (c8) and relative (istanbul) keys merge
+ */
+
+const { mergeLcovText, normalizeSourcePath } = require('./coverage/merge-lcov');
+
+console.log('\n🏂 SNOWGLIDER COVERAGE-MERGE TESTS 🏂');
+console.log('=====================================\n');
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`✅ PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`❌ FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+// Parse a serialized LCOV back into a per-file record lookup for assertions.
+function recordsFor(lcov, sf) {
+  const rec = { lines: {}, fns: {}, branches: {}, counters: {} };
+  let inFile = false;
+  for (const line of lcov.split('\n')) {
+    if (line.startsWith('SF:')) inFile = line.slice(3) === sf;
+    else if (!inFile) continue;
+    else if (line.startsWith('DA:')) {
+      const [l, c] = line.slice(3).split(',');
+      rec.lines[l] = Number(c);
+    } else if (line.startsWith('FNDA:')) {
+      const [c, name] = [line.slice(5, line.indexOf(',', 5)), line.slice(line.indexOf(',', 5) + 1)];
+      rec.fns[name] = Number(c);
+    } else if (line.startsWith('BRDA:')) {
+      const p = line.slice(5).split(',');
+      rec.branches[`${p[0]},${p[1]},${p[2]}`] = p[3];
+    } else if (/^(LF|LH|FNF|FNH|BRF|BRH):/.test(line)) {
+      const [k, v] = line.split(':');
+      rec.counters[k] = Number(v);
+    } else if (line === 'end_of_record') {
+      inFile = false;
+    }
+  }
+  return rec;
+}
+
+// --- Report A: c8-style. File covered, plus an `--all` empty-report placeholder. ---
+const reportA = [
+  'TN:',
+  'SF:src/physics.ts',
+  'FN:10,stepPlayer',
+  'FNDA:3,stepPlayer',
+  'FNF:1',
+  'FNH:1',
+  'BRDA:10,0,0,2',
+  'BRDA:10,0,1,0',
+  'BRF:2',
+  'BRH:1',
+  'DA:1,1',
+  'DA:2,0',
+  'DA:3,1',
+  'LF:3',
+  'LH:2',
+  'end_of_record',
+  'TN:',
+  'SF:src/snowglider.ts',
+  'FN:1,(empty-report)',
+  'FNDA:0,(empty-report)',
+  'FNF:1',
+  'FNH:0',
+  'DA:1,0',
+  'DA:2,0',
+  'LF:2',
+  'LH:0',
+  'end_of_record',
+  ''
+].join('\n');
+
+// --- Report B: browser-style. Adds coverage for the same and the browser-only file. ---
+const reportB = [
+  'TN:',
+  'SF:src/physics.ts',
+  'FN:10,stepPlayer',
+  'FNDA:5,stepPlayer',
+  'FNF:1',
+  'FNH:1',
+  'BRDA:10,0,0,1',
+  'BRDA:10,0,1,4',
+  'BRF:2',
+  'BRH:2',
+  'DA:1,1',
+  'DA:2,7',
+  'DA:3,1',
+  'LF:3',
+  'LH:3',
+  'end_of_record',
+  'TN:',
+  'SF:src/snowglider.ts',
+  'FN:20,startGame',
+  'FNDA:2,startGame',
+  'FNF:1',
+  'FNH:1',
+  'DA:1,1',
+  'DA:2,4',
+  'LF:2',
+  'LH:2',
+  'end_of_record',
+  ''
+].join('\n');
+
+const merged = mergeLcovText([reportA, reportB]);
+
+const physics = recordsFor(merged, 'src/physics.ts');
+check('line hits sum across reports', physics.lines['2'] === 7, `got DA:2,${physics.lines['2']}`);
+check('line covered in only one report becomes covered',
+  physics.counters.LH === 3 && physics.counters.LF === 3,
+  `LH:${physics.counters.LH} LF:${physics.counters.LF}`);
+check('function hits sum by name', physics.fns.stepPlayer === 8, `got ${physics.fns.stepPlayer}`);
+check('branch taken counts sum by position',
+  physics.branches['10,0,0'] === '3' && physics.branches['10,0,1'] === '4',
+  `b0=${physics.branches['10,0,0']} b1=${physics.branches['10,0,1']}`);
+check('BRF/BRH recomputed', physics.counters.BRF === 2 && physics.counters.BRH === 2,
+  `BRF:${physics.counters.BRF} BRH:${physics.counters.BRH}`);
+
+const snow = recordsFor(merged, 'src/snowglider.ts');
+check('empty-report placeholder dropped, real function kept',
+  snow.fns['(empty-report)'] === undefined && snow.fns.startGame === 2,
+  `keys=${Object.keys(snow.fns).join('|')}`);
+check('browser coverage replaces all-zero c8 placeholder lines',
+  snow.lines['2'] === 4 && snow.counters.LH === 2,
+  `DA:2,${snow.lines['2']} LH:${snow.counters.LH}`);
+check('FNF/FNH recomputed without placeholder',
+  snow.counters.FNF === 1 && snow.counters.FNH === 1,
+  `FNF:${snow.counters.FNF} FNH:${snow.counters.FNH}`);
+
+check('no duplicate SF records', (merged.match(/^SF:/gm) || []).length === 2,
+  `${(merged.match(/^SF:/gm) || []).length} SF lines`);
+check('no (empty-report) anywhere in merged output', !merged.includes('(empty-report)'));
+
+// Path normalization: absolute c8-style path and relative path collapse to one file.
+const abs = `TN:\nSF:${process.cwd()}/src/audio.ts\nDA:1,1\nLF:1\nLH:1\nend_of_record\n`;
+const rel = 'TN:\nSF:src/audio.ts\nDA:1,1\nDA:2,1\nLF:2\nLH:2\nend_of_record\n';
+const mergedPaths = mergeLcovText([abs, rel]);
+check('absolute and relative SF normalize to one record',
+  (mergedPaths.match(/^SF:/gm) || []).length === 1 && mergedPaths.includes('SF:src/audio.ts'),
+  mergedPaths.match(/^SF:.*/m) && mergedPaths.match(/^SF:.*/m)[0]);
+check('normalizeSourcePath strips cwd prefix and ./',
+  normalizeSourcePath(`${process.cwd()}/src/x.ts`) === 'src/x.ts' &&
+  normalizeSourcePath('./src/y.ts') === 'src/y.ts');
+
+console.log(`\n${failures === 0 ? '✅ ALL COVERAGE-MERGE TESTS PASSED' : `❌ ${failures} TEST(S) FAILED`}\n`);
+process.exit(failures > 0 ? 1 : 0);

--- a/tests/coverage/browser-coverage.js
+++ b/tests/coverage/browser-coverage.js
@@ -1,0 +1,137 @@
+/**
+ * Browser coverage helper (step 2 of the honest-coverage work).
+ *
+ * The Node/c8 pass (`npm run test:coverage`) only sees the `src/` modules that
+ * Node tests `import`; the browser-only game modules (snowglider, trees, camera,
+ * controls, course, effects, …) execute exclusively inside Chromium and would
+ * otherwise show as 0% forever. This helper drives Puppeteer's V8 coverage API
+ * while the unified browser suite runs, then converts the raw V8 coverage to
+ * Istanbul/LCOV.
+ *
+ * Attribution: the suite is served by Vite, which transpiles each `.ts` module on
+ * the fly and appends an inline base64 source map (`sources: ["physics.ts"]`,
+ * `sourcesContent` included). `v8-to-istanbul` walks those maps so coverage is
+ * attributed back to `src/*.ts` lines, matching the line numbers c8 reports for
+ * the same files. The emitted LCOV is line-merged with c8's LCOV by
+ * `merge-lcov.js`; merging at the line level (rather than the Istanbul-object
+ * level) is required because c8 (Node type-stripping) and Vite (esbuild) produce
+ * different statement structures for the same source.
+ *
+ * These libraries ship transitively with c8 and are declared as explicit
+ * devDependencies so this direct `require` stays supported.
+ */
+
+const path = require('path');
+const v8toIstanbul = require('v8-to-istanbul');
+const libCoverage = require('istanbul-lib-coverage');
+const libReport = require('istanbul-lib-report');
+const reports = require('istanbul-reports');
+
+// Only attribute coverage for served `/src/**/*.ts|.js` URLs. Everything else
+// (the Vite client, node_modules/three, inline <script> glue in index.html,
+// eval'd anonymous scripts) is intentionally dropped.
+const SRC_URL_RE = /^\/src\/.+\.(ts|js)$/;
+
+/**
+ * Begin collecting JS coverage on a page. Must be called before `page.goto` so
+ * the initial module graph is instrumented. `resetOnNavigation` is false so a
+ * redirect/navigation inside the suite does not discard earlier coverage.
+ *
+ * @param {import('puppeteer').Page} page
+ */
+async function startBrowserCoverage(page) {
+  await page.coverage.startJSCoverage({
+    resetOnNavigation: false,
+    includeRawScriptCoverage: true,
+    useBlockCoverage: true
+  });
+}
+
+/**
+ * Pull the trailing `//# sourceMappingURL=data:...` inline map out of a served
+ * module and return the parsed source map object, or null when absent. Supports
+ * both base64 and URL/plain-text JSON data URIs. Vite uses base64 in dev.
+ *
+ * @param {string} source
+ * @returns {object | null}
+ */
+function extractInlineSourceMap(source) {
+  const match = /\/\/[#@]\s*sourceMappingURL=data:application\/json;(?:charset=[^;]+;)?(base64,)?([^\s'"]+)\s*$/m.exec(source);
+  if (!match) return null;
+  try {
+    const isBase64 = Boolean(match[1]);
+    const payload = isBase64
+      ? Buffer.from(match[2], 'base64').toString('utf8')
+      : decodeURIComponent(match[2]);
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stop coverage on a page and fold every `src/` entry into `coverageMap`
+ * (an `istanbul-lib-coverage` CoverageMap). Safe to call for multiple pages so a
+ * single browser session can aggregate coverage across them.
+ *
+ * @param {import('puppeteer').Page} page
+ * @param {import('istanbul-lib-coverage').CoverageMap} coverageMap
+ * @param {string} root absolute repo root used to resolve `/src/...` URLs
+ */
+async function foldPageCoverage(page, coverageMap, root) {
+  const entries = await page.coverage.stopJSCoverage();
+
+  for (const entry of entries) {
+    let pathname;
+    try {
+      pathname = decodeURIComponent(new URL(entry.url).pathname);
+    } catch {
+      continue;
+    }
+    if (!SRC_URL_RE.test(pathname)) continue;
+    if (!entry.rawScriptCoverage || !Array.isArray(entry.rawScriptCoverage.functions)) continue;
+
+    const relative = pathname.replace(/^\//, '');
+    const scriptPath = path.resolve(root, relative);
+    const sourcemap = extractInlineSourceMap(entry.text);
+
+    try {
+      // wrapperLength 0: browser ES modules are not CJS-wrapped, so V8 offsets
+      // index the served source directly.
+      const converter = v8toIstanbul(scriptPath, 0, {
+        source: entry.text,
+        sourceMap: sourcemap ? { sourcemap } : undefined
+      });
+      await converter.load();
+      converter.applyCoverage(entry.rawScriptCoverage.functions);
+      // Identical instrumentation per file (same source + map), so Istanbul-level
+      // merge across duplicate URL queries for one module is safe here.
+      coverageMap.merge(libCoverage.createCoverageMap(converter.toIstanbul()));
+      converter.destroy();
+    } catch (err) {
+      console.warn(`Browser coverage: skipped ${relative} (${err.message})`);
+    }
+  }
+}
+
+/**
+ * Write `<outDir>/lcov.info` and `<outDir>/coverage-final.json` from a
+ * CoverageMap. The LCOV keys are absolute paths; `merge-lcov.js` normalizes them
+ * to repo-relative before combining with c8's LCOV.
+ *
+ * @param {import('istanbul-lib-coverage').CoverageMap} coverageMap
+ * @param {string} outDir
+ */
+function writeBrowserReports(coverageMap, outDir) {
+  const context = libReport.createContext({ dir: outDir, coverageMap });
+  reports.create('lcovonly', { file: 'lcov.info' }).execute(context);
+  reports.create('json', { file: 'coverage-final.json' }).execute(context);
+}
+
+module.exports = {
+  startBrowserCoverage,
+  foldPageCoverage,
+  writeBrowserReports,
+  extractInlineSourceMap,
+  createCoverageMap: () => libCoverage.createCoverageMap({})
+};

--- a/tests/coverage/merge-lcov.js
+++ b/tests/coverage/merge-lcov.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Line-level LCOV merger for the honest-coverage work.
+ *
+ * Combines the c8 Node/verification LCOV (`coverage/lcov.info`) with the browser
+ * LCOV produced by `browser-coverage.js` (`coverage/browser/lcov.info`) into a
+ * single `coverage/lcov.info` for the Codecov upload.
+ *
+ * Why merge at the LCOV (line) level instead of with istanbul-lib-coverage:
+ * c8 instruments Node's type-stripped `.ts` and Vite instruments its esbuild
+ * output, so the two produce *different* statement/function/branch structures for
+ * the same source file. Summing them as Istanbul objects (keyed by statement
+ * index) would mis-attribute hits. LCOV records are keyed by the original `.ts`
+ * line/function name/branch position, which both tools map back to identically,
+ * so a record-level union is correct.
+ *
+ * Usage:
+ *   node tests/coverage/merge-lcov.js --out coverage/lcov.info \
+ *       coverage/lcov.info coverage/browser/lcov.info
+ *
+ * Missing inputs are skipped with a warning so the step is a no-op (or a simple
+ * normalize) when, e.g., browser coverage was not collected. The output is fully
+ * buffered before writing, so naming an input as the output is safe.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// c8's `--all` placeholder for files with zero coverage. It is meaningless once
+// real coverage exists, so it is dropped from function records during merge.
+const EMPTY_REPORT_FN = '(empty-report)';
+
+function parseArgs(argv) {
+  let out = path.join('coverage', 'lcov.info');
+  const inputs = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--out') {
+      out = argv[++i];
+    } else {
+      inputs.push(argv[i]);
+    }
+  }
+  if (inputs.length === 0) {
+    inputs.push(path.join('coverage', 'lcov.info'), path.join('coverage', 'browser', 'lcov.info'));
+  }
+  return { out, inputs };
+}
+
+// Normalize an SF path to a stable repo-relative key so absolute (c8 in some
+// environments) and relative (istanbul) paths for the same file collapse.
+function normalizeSourcePath(sf) {
+  let p = sf.trim().replace(/\\/g, '/');
+  const cwd = process.cwd().replace(/\\/g, '/');
+  if (p.startsWith(cwd + '/')) p = p.slice(cwd.length + 1);
+  p = p.replace(/^\.\//, '');
+  const srcIdx = p.indexOf('/src/');
+  if (path.isAbsolute(p) && srcIdx !== -1) p = p.slice(srcIdx + 1);
+  return p;
+}
+
+function emptyFile(sf) {
+  return {
+    sf,
+    lines: new Map(),        // line -> hit count
+    fns: new Map(),          // name -> { line, hits }
+    branches: new Map()      // "line,block,branch" -> taken (number) | null
+  };
+}
+
+function parseLcov(text) {
+  const files = new Map();
+  let cur = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith('SF:')) {
+      const sf = normalizeSourcePath(line.slice(3));
+      cur = files.get(sf);
+      if (!cur) {
+        cur = emptyFile(sf);
+        files.set(sf, cur);
+      }
+    } else if (!cur) {
+      continue;
+    } else if (line.startsWith('DA:')) {
+      const [lineNo, count] = line.slice(3).split(',');
+      const n = Number(lineNo);
+      cur.lines.set(n, (cur.lines.get(n) || 0) + Number(count));
+    } else if (line.startsWith('FN:')) {
+      const idx = line.indexOf(',');
+      const fnLine = Number(line.slice(3, idx));
+      const name = line.slice(idx + 1);
+      if (name !== EMPTY_REPORT_FN && !cur.fns.has(name)) {
+        cur.fns.set(name, { line: fnLine, hits: 0 });
+      }
+    } else if (line.startsWith('FNDA:')) {
+      const idx = line.indexOf(',');
+      const hits = Number(line.slice(5, idx));
+      const name = line.slice(idx + 1);
+      if (name === EMPTY_REPORT_FN) continue;
+      const fn = cur.fns.get(name) || { line: 0, hits: 0 };
+      fn.hits += hits;
+      cur.fns.set(name, fn);
+    } else if (line.startsWith('BRDA:')) {
+      const parts = line.slice(5).split(',');
+      const key = `${parts[0]},${parts[1]},${parts[2]}`;
+      const takenRaw = parts[3];
+      const prev = cur.branches.get(key);
+      if (takenRaw === '-') {
+        if (prev === undefined) cur.branches.set(key, null);
+      } else {
+        cur.branches.set(key, (prev || 0) + Number(takenRaw));
+      }
+    }
+    // LF/LH/FNF/FNH/BRF/BRH/TN are recomputed, so ignore them on input.
+  }
+  return files;
+}
+
+function mergeInto(target, incoming) {
+  for (const [sf, file] of incoming) {
+    let dst = target.get(sf);
+    if (!dst) {
+      dst = emptyFile(sf);
+      target.set(sf, dst);
+    }
+    for (const [ln, count] of file.lines) {
+      dst.lines.set(ln, (dst.lines.get(ln) || 0) + count);
+    }
+    for (const [name, fn] of file.fns) {
+      const existing = dst.fns.get(name);
+      if (existing) {
+        existing.hits += fn.hits;
+        if (!existing.line) existing.line = fn.line;
+      } else {
+        dst.fns.set(name, { line: fn.line, hits: fn.hits });
+      }
+    }
+    for (const [key, taken] of file.branches) {
+      if (dst.branches.has(key)) {
+        const prev = dst.branches.get(key);
+        if (taken === null && prev === null) continue;
+        dst.branches.set(key, (prev || 0) + (taken || 0));
+      } else {
+        dst.branches.set(key, taken);
+      }
+    }
+  }
+}
+
+function serialize(files) {
+  const out = [];
+  for (const sf of [...files.keys()].sort()) {
+    const file = files.get(sf);
+    out.push('TN:');
+    out.push(`SF:${sf}`);
+
+    const fnNames = [...file.fns.keys()].sort((a, b) => file.fns.get(a).line - file.fns.get(b).line);
+    let fnHit = 0;
+    for (const name of fnNames) {
+      out.push(`FN:${file.fns.get(name).line},${name}`);
+    }
+    for (const name of fnNames) {
+      const hits = file.fns.get(name).hits;
+      if (hits > 0) fnHit++;
+      out.push(`FNDA:${hits},${name}`);
+    }
+    out.push(`FNF:${fnNames.length}`);
+    out.push(`FNH:${fnHit}`);
+
+    const branchKeys = [...file.branches.keys()].sort((a, b) => {
+      const pa = a.split(',').map(Number);
+      const pb = b.split(',').map(Number);
+      return pa[0] - pb[0] || pa[1] - pb[1] || pa[2] - pb[2];
+    });
+    let brHit = 0;
+    for (const key of branchKeys) {
+      const taken = file.branches.get(key);
+      if (taken !== null && taken > 0) brHit++;
+      out.push(`BRDA:${key},${taken === null ? '-' : taken}`);
+    }
+    if (branchKeys.length > 0) {
+      out.push(`BRF:${branchKeys.length}`);
+      out.push(`BRH:${brHit}`);
+    }
+
+    const lineNos = [...file.lines.keys()].sort((a, b) => a - b);
+    let lineHit = 0;
+    for (const ln of lineNos) {
+      const count = file.lines.get(ln);
+      if (count > 0) lineHit++;
+      out.push(`DA:${ln},${count}`);
+    }
+    out.push(`LF:${lineNos.length}`);
+    out.push(`LH:${lineHit}`);
+    out.push('end_of_record');
+  }
+  return out.join('\n') + '\n';
+}
+
+function mergeLcovText(texts) {
+  const merged = new Map();
+  for (const text of texts) {
+    mergeInto(merged, parseLcov(text));
+  }
+  return serialize(merged);
+}
+
+function main() {
+  const { out, inputs } = parseArgs(process.argv.slice(2));
+  const merged = new Map();
+  let read = 0;
+  for (const input of inputs) {
+    if (!fs.existsSync(input)) {
+      console.warn(`merge-lcov: input not found, skipping: ${input}`);
+      continue;
+    }
+    mergeInto(merged, parseLcov(fs.readFileSync(input, 'utf8')));
+    read++;
+  }
+  if (read === 0) {
+    console.error('merge-lcov: no input LCOV files found; nothing written');
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+  fs.writeFileSync(out, serialize(merged));
+
+  let totalLF = 0;
+  let totalLH = 0;
+  for (const file of merged.values()) {
+    totalLF += file.lines.size;
+    for (const c of file.lines.values()) if (c > 0) totalLH++;
+  }
+  const pct = totalLF === 0 ? 0 : ((totalLH / totalLF) * 100).toFixed(2);
+  console.log(`merge-lcov: merged ${read} report(s) into ${out}`);
+  console.log(`merge-lcov: ${merged.size} files, ${totalLH}/${totalLF} lines (${pct}%)`);
+}
+
+module.exports = {
+  parseLcov,
+  mergeInto,
+  serialize,
+  mergeLcovText,
+  normalizeSourcePath
+};
+
+if (require.main === module) {
+  main();
+}

--- a/tests/puppeteer-runner.js
+++ b/tests/puppeteer-runner.js
@@ -11,10 +11,23 @@ const http = require('http');
 const net = require('net');
 const fs = require('fs');
 const path = require('path');
+const {
+  startBrowserCoverage,
+  foldPageCoverage,
+  writeBrowserReports,
+  createCoverageMap
+} = require('./coverage/browser-coverage');
 
 const PORT = process.env.TEST_PORT || 8081;  // Use different port to avoid conflicts
 const TEST_TIMEOUT = 120000; // 2 minutes for all tests
 const RESULTS_DIR = path.join(__dirname, '..', 'test-results');
+const ROOT = path.join(__dirname, '..');
+// Opt-in browser coverage (step 2 of the honest-coverage work). Off by default so
+// `npm run test:browser` stays fast/unchanged; CI sets BROWSER_COVERAGE for the
+// coverage upload. The unified suite (index.html?test=unified) runs every browser
+// test, so instrumenting that one page captures the full browser surface.
+const COLLECT_COVERAGE = process.env.BROWSER_COVERAGE === '1' || process.env.BROWSER_COVERAGE === 'true';
+const COVERAGE_DIR = path.join(ROOT, 'coverage', 'browser');
 
 // Ensure results directory exists
 if (!fs.existsSync(RESULTS_DIR)) {
@@ -265,9 +278,19 @@ async function runBrowserTests() {
     });
 
     await runStartMenuRaceRegression(browser);
-    
+
     const page = await browser.newPage();
-    
+
+    // Start V8 coverage before navigating so the initial module graph is
+    // instrumented. Best-effort: a coverage failure must never fail the suite.
+    if (COLLECT_COVERAGE) {
+      try {
+        await startBrowserCoverage(page);
+      } catch (covErr) {
+        console.warn('Browser coverage: failed to start:', covErr.message);
+      }
+    }
+
     // Collect console logs
     const consoleLogs = [];
     page.on('console', (msg) => {
@@ -385,6 +408,20 @@ async function runBrowserTests() {
       });
     });
     
+    // Stop and persist browser coverage now that the suite has finished but the
+    // page is still alive. Best-effort: never let coverage break the test run.
+    if (COLLECT_COVERAGE) {
+      try {
+        const coverageMap = createCoverageMap();
+        await foldPageCoverage(page, coverageMap, ROOT);
+        fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+        writeBrowserReports(coverageMap, COVERAGE_DIR);
+        console.log(`Browser coverage written: ${coverageMap.files().filter(f => f.includes(`${path.sep}src${path.sep}`)).length} src files -> ${path.relative(ROOT, COVERAGE_DIR)}/lcov.info`);
+      } catch (covErr) {
+        console.warn('Browser coverage: failed to write report:', covErr.message);
+      }
+    }
+
     // Take a screenshot of results
     await page.screenshot({
       path: path.join(RESULTS_DIR, 'test-results.png'),


### PR DESCRIPTION
Stacked on #121 (`claude/ts-phase-3-22-gamestate-lifecycle`). This is intended to land after the TypeScript migration branch so existing migration PRs keep their current CI/Codecov behavior.

This PR makes the coverage report honest **and** complete: the c8 Node/verification pass now counts the full migrated `src/` tree, and the browser suite's Chromium coverage is merged in, so browser-only modules are measured instead of disappearing from the denominator.

## What

**Step 1 — full-source Node coverage**
- `npm run test:coverage` runs `c8 --all --src src`, so `coverage/lcov.info` includes every migrated `src/` JS/TS file, not only files imported by Node tests.
- Re-enables the Codecov badge now that the report is deliberately full-source rather than selectively sparse.

**Step 2 — browser coverage merged (this PR)**
- `tests/coverage/browser-coverage.js` drives Puppeteer's V8 coverage API during the unified browser suite, converts the raw V8 coverage to Istanbul via `v8-to-istanbul`, and uses Vite's inline source maps to attribute it back to `src/*.ts` lines. Writes `coverage/browser/lcov.info`. Opt-in via `BROWSER_COVERAGE=1` (off for plain `npm run test:browser`), and best-effort so coverage never fails the suite.
- `tests/coverage/merge-lcov.js` line-merges the c8 and browser LCOVs into a single `coverage/lcov.info`. Merging at the **line** level (DA/FN/BRDA keyed by line/name/position) is required because c8 (Node type-stripping) and Vite (esbuild) emit different statement structures for the same file, so an Istanbul-object merge would mis-attribute hits. It strips c8's `--all` `(empty-report)` placeholder and recomputes `LF/LH/FNF/FNH/BRF/BRH`.
- New scripts: `test:browser:coverage`, `coverage:merge`, and `test:coverage:all` (full local pipeline). A deterministic unit test (`tests/coverage-merge-tests.js`) for the merger is wired into `npm test`.
- CI sets `BROWSER_COVERAGE` on the browser step and runs `coverage:merge` before the Codecov upload.

## Coverage scope

Now included in `coverage/lcov.info`:

- Node tests run by `npm test`.
- Verification harnesses (`npm run test:verify`, already part of `npm test`).
- Chromium V8 coverage from the unified browser suite (`npm run test:browser` with `BROWSER_COVERAGE`).
- All other migrated `src/` files as uncovered (via `c8 --all --src src`) when no test exercises them.

The auth/scores modules are exercised by the browser auth/scores suites, so they now report real browser coverage too (rather than needing separate eval-loaded attribution).

## CI safety

This does not add a coverage threshold and does not make the Codecov upload blocking. The workflow still uploads LCOV with `fail_ci_if_error: false`, so CI remains gated by tests/lint/typecheck rather than by a coverage percentage. The merge step is `if: always()` and skips missing inputs, so it degrades to a normalize/no-op if the browser run produced no coverage.

## Validation

- `npm run test:coverage:all` produces a merged `coverage/lcov.info`; line coverage rises from **27.58%** (Node-only) to **~76%** (Node + browser), with browser-only modules (`snowglider`, `course`, `effects`, `main`, `boot/*`, `ui/*`) now measured.
- `npm test` passes (incl. the new merge unit test), `npm run lint` passes (existing 28 `any` warnings), `npm run typecheck` passes.
- Browser suite stays green (87 passed / 0 failed, all 7 suites) with coverage collection enabled.
