### PR TITLE
ci: guard Pages artifact against raw TypeScript (defense-in-depth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,26 @@ jobs:
           test -f dist/LICENSE
           test -f dist/README.md
           test ! -d dist/tests/verification
+          # Guard against a raw-TypeScript Pages artifact (defense-in-depth). The
+          # real prod-outage fix was switching the Pages source to GitHub Actions
+          # (build_type=workflow) so the legacy branch builder can't serve raw src/;
+          # this assertion additionally fails the build if Vite ever stops emitting
+          # transpiled .js — which on Pages would be served as MIME video/mp2t and
+          # break every module entrypoint.
+          test -f dist/src/main.js
+          test -f dist/src/boot/script-loader.js
+          test -f dist/src/ui/start-menu.js
+          test -f dist/src/auth.js
+          test -f dist/src/scores.js
+          if grep -En 'src/(main|boot/script-loader|ui/start-menu)\.ts|<script[^>]+type="module"[^>]+src="src/[^"]+\.ts"' dist/index.html; then
+            echo "::error::dist/index.html references raw TypeScript module entrypoints"
+            exit 1
+          fi
+          if find dist/src -name '*.ts' -print -quit | grep -q .; then
+            echo "::error::dist/src contains raw TypeScript files"
+            find dist/src -name '*.ts' -print
+            exit 1
+          fi
           # The verbatim-copied browser tests import bare `three`; Pages has no
           # node_modules, so the page import map's three build must be published.
           test -f dist/node_modules/three/build/three.module.min.js


### PR DESCRIPTION
## Context

Production (`snowglider.ai`) flapped between broken and working during the TypeScript stack merge. **Root cause:** GitHub Pages was configured as legacy *Deploy from a branch* (`build_type: legacy`), which serves the **raw repo root** — raw `.ts` (MIME `video/mp2t`) and missing `.js` (404) — *in parallel* with the CI `actions/deploy-pages` Vite-`dist` deploy. The two fought every push.

**Load-bearing fix (already applied out-of-band):** switched Pages source to GitHub Actions (`build_type: workflow`), disabling the legacy raw-source builder. A `workflow_dispatch` deploy purged the edge cache; hard refresh confirmed working.

## This PR

Defense-in-depth only: extends the existing *Verify Pages artifact contents* step in `build-pages` to fail the build if the Vite output is ever a raw-TypeScript artifact:
- requires `dist/src/{main,boot/script-loader,ui/start-menu,auth,scores}.js`
- fails if `dist/index.html` references raw `.ts` module entrypoints
- fails if any `*.ts` remain under `dist/src`

No runtime/code changes. Validated locally (`npm run build` then the assertions pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)