### PR TITLE
ci: validate the production Vite build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Type-check (tsc --noEmit)
         run: npm run typecheck
 
+      # Validate the production Vite bundle on every PR (tsc --noEmit above does
+      # NOT run the bundler). Catches a build/transpile regression before merge so
+      # it can't reach the Pages deploy. Same dist guard the build-pages job uses.
+      - name: Production build (Vite) + dist guard
+        run: |
+          npm run build
+          bash scripts/verify-pages-dist.sh
+
       - name: Run Node.js tests with coverage
         run: npm run test:coverage
       
@@ -110,23 +118,10 @@ jobs:
           # Guard against a raw-TypeScript Pages artifact (defense-in-depth). The
           # real prod-outage fix was switching the Pages source to GitHub Actions
           # (build_type=workflow) so the legacy branch builder can't serve raw src/;
-          # this assertion additionally fails the build if Vite ever stops emitting
-          # transpiled .js — which on Pages would be served as MIME video/mp2t and
-          # break every module entrypoint.
-          test -f dist/src/main.js
-          test -f dist/src/boot/script-loader.js
-          test -f dist/src/ui/start-menu.js
-          test -f dist/src/auth.js
-          test -f dist/src/scores.js
-          if grep -En 'src/(main|boot/script-loader|ui/start-menu)\.ts|<script[^>]+type="module"[^>]+src="src/[^"]+\.ts"' dist/index.html; then
-            echo "::error::dist/index.html references raw TypeScript module entrypoints"
-            exit 1
-          fi
-          if find dist/src -name '*.ts' -print -quit | grep -q .; then
-            echo "::error::dist/src contains raw TypeScript files"
-            find dist/src -name '*.ts' -print
-            exit 1
-          fi
+          # this fails the build if Vite ever stops emitting transpiled .js — which
+          # on Pages is served as MIME video/mp2t and breaks every module
+          # entrypoint. Shared with the per-PR test gate via this script.
+          bash scripts/verify-pages-dist.sh
           # The verbatim-copied browser tests import bare `three`; Pages has no
           # node_modules, so the page import map's three build must be published.
           test -f dist/node_modules/three/build/three.module.min.js

--- a/scripts/verify-pages-dist.sh
+++ b/scripts/verify-pages-dist.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Verify the Vite production build (dist/) emitted transpiled JavaScript and that
+# no raw TypeScript leaked into the deployable output.
+#
+# Why this exists: on GitHub Pages a raw .ts file is served with MIME
+# "video/mp2t" and a missing .js 404s, which breaks every ES-module entrypoint —
+# the exact failure mode of the 2026-06 production outage. The load-bearing fix
+# for that outage was switching the Pages source to GitHub Actions
+# (build_type=workflow) so the legacy "deploy from a branch" builder can no longer
+# serve raw src/. This script is defense-in-depth: if the Vite build ever stops
+# transpiling .ts -> .js, CI fails instead of shipping a broken artifact.
+#
+# Run AFTER `npm run build`. Shared by the per-PR `test` gate and the `build-pages`
+# job so the assertion lives in exactly one place.
+set -euo pipefail
+
+require_js() {
+  if [ ! -f "$1" ]; then
+    echo "::error::expected transpiled $1 — the Vite build did not emit it"
+    exit 1
+  fi
+}
+
+require_js dist/src/main.js
+require_js dist/src/boot/script-loader.js
+require_js dist/src/ui/start-menu.js
+require_js dist/src/auth.js
+require_js dist/src/scores.js
+
+if grep -En 'src/(main|boot/script-loader|ui/start-menu)\.ts|<script[^>]+type="module"[^>]+src="src/[^"]+\.ts"' dist/index.html; then
+  echo "::error::dist/index.html references raw TypeScript module entrypoints"
+  exit 1
+fi
+
+if find dist/src -name '*.ts' -print -quit | grep -q .; then
+  echo "::error::dist/src contains raw TypeScript files (build did not transpile)"
+  find dist/src -name '*.ts' -print
+  exit 1
+fi
+
+echo "dist guard OK: transpiled JS present, no raw TypeScript in dist/"


### PR DESCRIPTION
## Why

The per-PR `test` job ran `lint` + `tsc --noEmit` + node/browser tests, but **never ran the production bundler (`npm run build`)**. `tsc --noEmit` does not exercise Vite, so a build/transpile regression could pass the PR gate, reach `main`, and only surface in the push-only `build-pages` job — and during a rapid merge burst those deploys get cancelled by `cancel-in-progress`, masking it further. This is the gap behind the recent Pages incident class.

## What

- Add a **`Production build (Vite) + dist guard`** step to the `test` job: runs `npm run build` and asserts the `dist/` is fully transpiled. Now every PR validates the production bundle pre-merge.
- Extract the raw-`.ts` guard into **`scripts/verify-pages-dist.sh`**, shared by both the `test` gate and the existing `build-pages` step (single source of truth — the assertion can no longer drift between the two jobs).

No runtime/app code changes. This PR self-validates: its own `test` run executes the new build step.

### Note on the real fix
The load-bearing fix for the outage itself was switching GitHub Pages source to **GitHub Actions** (`build_type=workflow`), which disabled the legacy branch builder that was serving raw `src/`. This PR is defense-in-depth on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)