### PR TITLE
test(scores): make Node coverage harness c8-visible + cover displayLeaderboard (#126 PR 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:tree-collision": "node tests/tree-collision-tests.js",
     "test:avalanche": "node tests/avalanche-tests.js",
     "test:auth": "node tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",
-    "test:scores": "node tests/scores-tests.js",
+    "test:scores": "node --import ./tests/loaders/register-firebase-mock.mjs tests/scores-tests.js",
     "test:firebase": "npx -y firebase-tools@15.20.0 emulators:exec --project snowglider-rules-test --only firestore \"node tests/firestore-rules-tests.js\"",
     "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",

--- a/tests/loaders/firebase-cdn-mock.hooks.mjs
+++ b/tests/loaders/firebase-cdn-mock.hooks.mjs
@@ -1,0 +1,24 @@
+// firebase-cdn-mock.hooks.mjs — Node ESM resolution hook that redirects the
+// Firebase SDK CDN imports to the in-memory mock in tests/mocks/firebase.mjs.
+//
+// src/scores.ts and src/auth.ts statically import the Firebase SDK from gstatic
+// CDN URLs, e.g.
+//   import { getFirestore, ... } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore.js";
+// Node's default loader only understands `file:`/`data:` URLs, so importing those
+// modules directly fails with ERR_UNSUPPORTED_ESM_URL_SCHEME. This hook rewrites
+// any `firebase-{app,firestore,analytics,auth}.js` CDN specifier to the local mock
+// module, letting the Node test harnesses `import` the REAL `.ts` under test
+// (rather than eval it) so c8 instruments it with correct source-mapped lines.
+//
+// Registered via tests/loaders/register-firebase-mock.mjs. It never touches the
+// browser, Vite, or build paths.
+const MOCK_URL = new URL('../mocks/firebase.mjs', import.meta.url).href;
+
+const FIREBASE_CDN_MODULE = /\/firebasejs\/[\d.]+\/firebase-(app|firestore|analytics|auth)\.js$/;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (FIREBASE_CDN_MODULE.test(specifier)) {
+    return { url: MOCK_URL, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}

--- a/tests/loaders/register-firebase-mock.mjs
+++ b/tests/loaders/register-firebase-mock.mjs
@@ -1,0 +1,13 @@
+// register-firebase-mock.mjs — registers the resolution hooks the headless
+// score/auth coverage harnesses need.
+//
+// Used via `node --import ./tests/loaders/register-firebase-mock.mjs <test>`:
+//  1. firebase-cdn-mock.hooks.mjs redirects the Firebase SDK CDN imports in
+//     src/scores.ts / src/auth.ts to the in-memory mock (tests/mocks/firebase.mjs),
+//     so the real `.ts` can be imported (and c8-instrumented) instead of eval'd.
+//  2. ts-js-resolve.mjs keeps the `.js` -> `.ts` fallback so a module that imports a
+//     renamed sibling via a `./x.js` specifier still resolves under Node.
+import { register } from 'node:module';
+
+register('./firebase-cdn-mock.hooks.mjs', import.meta.url);
+register('./ts-js-resolve.mjs', import.meta.url);

--- a/tests/mocks/firebase.mjs
+++ b/tests/mocks/firebase.mjs
@@ -1,0 +1,226 @@
+// firebase.mjs — in-memory Firebase (Firestore + Analytics) mock for Node coverage.
+//
+// The headless score/auth harnesses used to load the module-under-test through a
+// `new Function(...)` eval so they could strip the gstatic CDN imports and inject
+// mocks. That eval is invisible to c8 (V8 cannot attribute an anonymous eval to
+// `src/*.ts`), so none of those assertions counted toward coverage — the Codecov
+// numbers came entirely from the browser run.
+//
+// Instead, this single ES module IS the mock: the resolve hook in
+// tests/loaders/firebase-cdn-mock.hooks.mjs redirects the three
+// `https://www.gstatic.com/firebasejs/.../firebase-{firestore,analytics,auth}.js`
+// specifiers here, so the real `src/scores.ts` / `src/auth.ts` import these
+// functions in place of the CDN SDK. The test harness imports the SAME module
+// (same resolved file URL ⇒ same instance) to seed data, drive deferred writes,
+// and assert recorded calls. Because the module is imported (not eval'd), Node
+// type-strips the `.ts` under test and c8 instruments it with correct source-mapped
+// line numbers.
+//
+// The Firestore behavior below is a faithful extraction of the in-memory mock that
+// previously lived inline in tests/scores-tests.js (compare-and-write semantics,
+// where('>=')/orderBy/limit query support, and the deferred-write hook used to
+// model an offline setDoc that flushes on reconnect).
+
+// ---- shared, test-controllable state ----
+export const db = {
+  users: new Map(),
+  leaderboard: new Map()
+};
+
+export const calls = {
+  getDoc: [],
+  setDoc: [],
+  getDocs: [],
+  logEvent: []
+};
+
+// Sentinels handed back to callers that ask the SDK for the service instances.
+export const firestoreInstance = { __firestore: true };
+export const analyticsInstance = { __analytics: true };
+
+let pendingWritePath = null;
+let pendingWrite = null;
+let timestampCounter = 0;
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function getCollectionStore(name) {
+  if (!db[name]) {
+    throw new Error(`Unknown collection: ${name}`);
+  }
+  return db[name];
+}
+
+function makeDocSnap(ref) {
+  const store = getCollectionStore(ref.collectionName);
+  const value = store.get(ref.id);
+  return {
+    id: ref.id,
+    exists: () => value !== undefined,
+    data: () => clone(value)
+  };
+}
+
+function writeDoc(ref, data, options) {
+  const store = getCollectionStore(ref.collectionName);
+  const existing = store.get(ref.id) || {};
+  const next = options && options.merge ? { ...existing, ...clone(data) } : clone(data);
+  store.set(ref.id, next);
+}
+
+// ---- test control surface ----
+
+/** Clear all in-memory documents, recorded calls, and any armed deferred write. */
+export function reset() {
+  db.users.clear();
+  db.leaderboard.clear();
+  calls.getDoc = [];
+  calls.setDoc = [];
+  calls.getDocs = [];
+  calls.logEvent = [];
+  pendingWritePath = null;
+  pendingWrite = null;
+  timestampCounter = 0;
+}
+
+export function seed(collectionName, id, value) {
+  getCollectionStore(collectionName).set(id, clone(value));
+}
+
+export function read(collectionName, id) {
+  return getCollectionStore(collectionName).get(id);
+}
+
+/**
+ * Arm a one-shot deferred write for the given document path. The next setDoc to
+ * that path will not commit until the returned controller's promise is resolved —
+ * modelling a setDoc that stays queued offline and flushes on reconnect.
+ * @param {string} path - e.g. 'users/u4'
+ */
+export function setPendingWrite(path) {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  pendingWritePath = path;
+  pendingWrite = { promise, resolve, reject };
+  return pendingWrite;
+}
+
+// ---- firebase-firestore.js surface ----
+export function getFirestore() {
+  return firestoreInstance;
+}
+
+export function doc(firestore, collectionName, id) {
+  return {
+    firestore,
+    collectionName,
+    id,
+    path: `${collectionName}/${id}`
+  };
+}
+
+export function collection(firestore, collectionName) {
+  return {
+    firestore,
+    collectionName,
+    path: collectionName
+  };
+}
+
+export function where(field, op, value) {
+  return { kind: 'where', field, op, value };
+}
+
+export function orderBy(field, direction) {
+  return { kind: 'orderBy', field, direction };
+}
+
+export function query(collectionRef, ...constraints) {
+  return { collectionRef, constraints };
+}
+
+export function limit(count) {
+  return { kind: 'limit', count };
+}
+
+export function serverTimestamp() {
+  timestampCounter++;
+  return { __serverTimestamp: timestampCounter };
+}
+
+export function getDoc(ref) {
+  calls.getDoc.push(ref.path);
+  return Promise.resolve(makeDocSnap(ref));
+}
+
+export function setDoc(ref, data, options) {
+  calls.setDoc.push({ path: ref.path, data: clone(data), options: clone(options) });
+  const commit = () => writeDoc(ref, data, options);
+
+  if (pendingWritePath === ref.path && pendingWrite) {
+    const write = pendingWrite;
+    pendingWritePath = null;
+    pendingWrite = null;
+    return write.promise.then(() => commit());
+  }
+
+  commit();
+  return Promise.resolve();
+}
+
+export function getDocs(q) {
+  calls.getDocs.push(q);
+  let rows = Array.from(getCollectionStore(q.collectionRef.collectionName).entries())
+    .map(([id, data]) => ({ id, data: clone(data) }));
+
+  q.constraints.forEach(constraint => {
+    if (constraint.kind === 'where') {
+      rows = rows.filter(row => {
+        const value = row.data[constraint.field];
+        if (constraint.op === '>=') {
+          return value >= constraint.value;
+        }
+        throw new Error(`Unsupported where op: ${constraint.op}`);
+      });
+    }
+
+    if (constraint.kind === 'orderBy') {
+      const direction = constraint.direction === 'desc' ? -1 : 1;
+      rows = rows.slice().sort((a, b) => {
+        const av = a.data[constraint.field];
+        const bv = b.data[constraint.field];
+        return av === bv ? 0 : (av < bv ? -1 : 1) * direction;
+      });
+    }
+
+    if (constraint.kind === 'limit') {
+      rows = rows.slice(0, constraint.count);
+    }
+  });
+
+  return Promise.resolve({
+    forEach: callback => {
+      rows.forEach(row => {
+        callback({
+          id: row.id,
+          data: () => clone(row.data)
+        });
+      });
+    }
+  });
+}
+
+// ---- firebase-analytics.js surface ----
+export function getAnalytics() {
+  return analyticsInstance;
+}
+
+export function logEvent(_analytics, name, params) {
+  calls.logEvent.push({ name, params });
+}

--- a/tests/scores-tests.js
+++ b/tests/scores-tests.js
@@ -1,14 +1,13 @@
 // scores-tests.js
-// Headless coverage for src/scores.js against the real module code.
+// Headless, c8-instrumented coverage for src/scores.ts against the real module.
 //
-// scores.js imports Firebase from CDN URLs, which Node cannot resolve directly.
-// Match the auth-tests.js harness: strip import/export syntax, evaluate the
-// shipped source under jsdom, and inject a small in-memory Firestore mock.
-const fs = require('fs');
-const path = require('path');
+// src/scores.ts imports the Firebase SDK from gstatic CDN URLs, which Node cannot
+// resolve. Instead of eval'ing the source (which is invisible to c8), the resolve
+// hook in tests/loaders/register-firebase-mock.mjs redirects those CDN imports to
+// the in-memory mock in tests/mocks/firebase.mjs, so we `import` the real `.ts`
+// under jsdom and c8 instruments it with correct source-mapped lines. Run via the
+// `test:scores` npm script, which wires in that loader.
 const { JSDOM } = require('jsdom');
-
-const REPO = path.join(__dirname, '..');
 
 const dom = new JSDOM(`<!doctype html><html><body>
   <div id="leaderboard"></div>
@@ -32,240 +31,47 @@ Object.defineProperty(window.navigator, 'onLine', {
   get: () => online
 });
 
-const firestoreInstance = { __firestore: true };
-const analyticsInstance = { __analytics: true };
-const db = {
-  users: new Map(),
-  leaderboard: new Map()
-};
-const calls = {
-  getDoc: [],
-  setDoc: [],
-  getDocs: [],
-  logEvent: [],
-  reinitializeFirestore: 0
-};
-
+// AuthModule-driven flags. The Firestore/Analytics mock state lives in
+// tests/mocks/firebase.mjs and is bound below once the mock is imported.
 let firestoreAvailable = true;
 let currentAuthUser = null;
 let reinitializeSucceeds = false;
-let pendingWritePath = null;
-let pendingWrite = null;
-let timestampCounter = 0;
 
-function clone(value) {
-  return value == null ? value : JSON.parse(JSON.stringify(value));
-}
+// Bound from the shared Firebase mock in loadScoresModule(). The resolve hook hands
+// src/scores.ts the SAME module instance, so seeding/reading here mutates exactly
+// the store the module under test reads and writes.
+let fb;
+let firestoreInstance;
+let analyticsInstance;
+let calls;
+let doc;
+let seed;
+let read;
+let setPendingWrite;
 
-function getCollectionStore(name) {
-  if (!db[name]) {
-    throw new Error(`Unknown collection: ${name}`);
-  }
-  return db[name];
-}
-
-function makeDocSnap(ref) {
-  const store = getCollectionStore(ref.collectionName);
-  const value = store.get(ref.id);
-  return {
-    id: ref.id,
-    exists: () => value !== undefined,
-    data: () => clone(value)
-  };
-}
-
-function writeDoc(ref, data, options) {
-  const store = getCollectionStore(ref.collectionName);
-  const existing = store.get(ref.id) || {};
-  const next = options && options.merge ? { ...existing, ...clone(data) } : clone(data);
-  store.set(ref.id, next);
-}
-
-function makeDeferredWrite() {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-function seed(collectionName, id, value) {
-  getCollectionStore(collectionName).set(id, clone(value));
-}
-
-function read(collectionName, id) {
-  return getCollectionStore(collectionName).get(id);
+async function loadScoresModule() {
+  fb = await import('./mocks/firebase.mjs');
+  ({ firestoreInstance, analyticsInstance, calls, doc, seed, read, setPendingWrite } = fb);
+  // AuthModule.reinitializeFirestore is mocked in this harness (not in the Firebase
+  // mock), so track its call count alongside the Firestore call log.
+  calls.reinitializeFirestore = 0;
+  // Importing the real module (rather than eval'ing it) is what makes it c8-visible;
+  // its CDN Firebase imports resolve to `fb` via the registered hook.
+  const scoresModule = await import('../src/scores.ts');
+  return scoresModule.default;
 }
 
 function resetState(ScoresModule) {
   localStore = {};
-  db.users.clear();
-  db.leaderboard.clear();
-  calls.getDoc = [];
-  calls.setDoc = [];
-  calls.getDocs = [];
-  calls.logEvent = [];
+  fb.reset();
   calls.reinitializeFirestore = 0;
   firestoreAvailable = true;
   currentAuthUser = null;
   reinitializeSucceeds = false;
-  pendingWritePath = null;
-  pendingWrite = null;
   online = true;
-  timestampCounter = 0;
   document.getElementById('leaderboard').innerHTML = '';
   ScoresModule.setCurrentUser(null);
   ScoresModule.initializeScores(null, null);
-}
-
-function getFirestore() {
-  return firestoreInstance;
-}
-
-function getAnalytics() {
-  return analyticsInstance;
-}
-
-function logEvent(_analytics, name, params) {
-  calls.logEvent.push({ name, params });
-}
-
-function doc(firestore, collectionName, id) {
-  return {
-    firestore,
-    collectionName,
-    id,
-    path: `${collectionName}/${id}`
-  };
-}
-
-function collection(firestore, collectionName) {
-  return {
-    firestore,
-    collectionName,
-    path: collectionName
-  };
-}
-
-function where(field, op, value) {
-  return { kind: 'where', field, op, value };
-}
-
-function orderBy(field, direction) {
-  return { kind: 'orderBy', field, direction };
-}
-
-function query(collectionRef, ...constraints) {
-  return { collectionRef, constraints };
-}
-
-function limit(count) {
-  return { kind: 'limit', count };
-}
-
-function serverTimestamp() {
-  timestampCounter++;
-  return { __serverTimestamp: timestampCounter };
-}
-
-function getDoc(ref) {
-  calls.getDoc.push(ref.path);
-  return Promise.resolve(makeDocSnap(ref));
-}
-
-function setDoc(ref, data, options) {
-  calls.setDoc.push({ path: ref.path, data: clone(data), options: clone(options) });
-  const commit = () => writeDoc(ref, data, options);
-
-  if (pendingWritePath === ref.path && pendingWrite) {
-    const write = pendingWrite;
-    pendingWritePath = null;
-    pendingWrite = null;
-    return write.promise.then(() => commit());
-  }
-
-  commit();
-  return Promise.resolve();
-}
-
-function getDocs(q) {
-  calls.getDocs.push(q);
-  let rows = Array.from(getCollectionStore(q.collectionRef.collectionName).entries())
-    .map(([id, data]) => ({ id, data: clone(data) }));
-
-  q.constraints.forEach(constraint => {
-    if (constraint.kind === 'where') {
-      rows = rows.filter(row => {
-        const value = row.data[constraint.field];
-        if (constraint.op === '>=') {
-          return value >= constraint.value;
-        }
-        throw new Error(`Unsupported where op: ${constraint.op}`);
-      });
-    }
-
-    if (constraint.kind === 'orderBy') {
-      const direction = constraint.direction === 'desc' ? -1 : 1;
-      rows = rows.slice().sort((a, b) => {
-        const av = a.data[constraint.field];
-        const bv = b.data[constraint.field];
-        return av === bv ? 0 : (av < bv ? -1 : 1) * direction;
-      });
-    }
-
-    if (constraint.kind === 'limit') {
-      rows = rows.slice(0, constraint.count);
-    }
-  });
-
-  return Promise.resolve({
-    forEach: callback => {
-      rows.forEach(row => {
-        callback({
-          id: row.id,
-          data: () => clone(row.data)
-        });
-      });
-    }
-  });
-}
-
-const mocks = {
-  getFirestore,
-  doc,
-  setDoc,
-  getDoc,
-  collection,
-  where,
-  orderBy,
-  query,
-  limit,
-  getDocs,
-  serverTimestamp,
-  getAnalytics,
-  logEvent
-};
-
-function loadScoresModule() {
-  // src/scores.ts is TypeScript (issue #84, Phase 3.8). Strip the types to runnable
-  // JS first (transpile via the TypeScript devDependency) so the `new Function(...)`
-  // eval below sees plain JavaScript. ESNext output keeps import/export statements
-  // as-is, so the existing import/export removal still works.
-  const ts = require('typescript');
-  const tsSource = fs.readFileSync(path.join(REPO, 'src', 'scores.ts'), 'utf8');
-  let code = ts.transpileModule(tsSource, {
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 }
-  }).outputText;
-  code = code.replace(/import[\s\S]*?from\s+["'][^"']+["'];/g, '');
-  code = code.replace(/export\s+default\s+[^;]+;/g, '');
-  const argNames = Object.keys(mocks);
-  const fn = new Function(
-    'window', 'document', 'localStorage', 'console', ...argNames,
-    code + '\nreturn window.ScoresModule;'
-  );
-  return fn(window, window.document, global.localStorage, console, ...argNames.map(name => mocks[name]));
 }
 
 window.AuthModule = {
@@ -305,7 +111,7 @@ async function flushAll() {
 }
 
 async function main() {
-  const ScoresModule = loadScoresModule();
+  const ScoresModule = await loadScoresModule();
 
   console.log('--- ScoresModule load & validation ---');
   check('module exposes the expected public surface',
@@ -416,9 +222,7 @@ async function main() {
   console.log('\n--- Offline write ordering ---');
   resetState(ScoresModule);
   ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
-  pendingWritePath = 'users/u4';
-  pendingWrite = makeDeferredWrite();
-  const write = pendingWrite;
+  const write = setPendingWrite('users/u4');
   ScoresModule.updateUserBestTime('u4', 18);
   await flushAll();
   check('queued user write starts before leaderboard reconciliation',
@@ -429,6 +233,100 @@ async function main() {
   await flushAll();
   check('leaderboard reconciliation runs after the queued user write settles',
     read('leaderboard', 'u4')?.time === 18);
+
+  console.log('\n--- New high score analytics ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  currentAuthUser = { uid: 'hs', displayName: 'HS' };
+  ScoresModule.setCurrentUser(currentAuthUser);
+  ScoresModule.recordScore(15); // first finish, no stored best => a new personal best
+  await flushAll();
+  check('a new authenticated personal best logs new_high_score',
+    calls.logEvent.some(event => event.name === 'new_high_score' && event.params.time === 15));
+  check('new personal best is also synced to the user doc',
+    read('users', 'hs')?.bestTime === 15);
+
+  console.log('\n--- getActiveUser falls back to AuthModule ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  // No setCurrentUser() call: recordScore must resolve the signed-in user via the
+  // AuthModule.getAuthState()/getCurrentUser() fallback path.
+  currentAuthUser = { uid: 'fallback', displayName: 'Fallback' };
+  ScoresModule.recordScore(16);
+  await flushAll();
+  check('getActiveUser pulls the user from AuthModule when none was set',
+    read('users', 'fallback')?.bestTime === 16);
+
+  console.log('\n--- isFirestoreAvailable reflects AuthModule + local instance ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  check('isFirestoreAvailable is true when AuthModule is available and the local instance is set',
+    ScoresModule.isFirestoreAvailable() === true);
+  firestoreAvailable = false;
+  check('isFirestoreAvailable is false when AuthModule reports unavailable',
+    ScoresModule.isFirestoreAvailable() === false);
+
+  console.log('\n--- displayLeaderboard: offline ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  online = false;
+  ScoresModule.displayLeaderboard();
+  await flushAll();
+  check('offline displayLeaderboard renders the offline message',
+    document.getElementById('leaderboard').innerHTML.includes('offline'));
+  online = true;
+
+  console.log('\n--- displayLeaderboard: renders ranked table and highlights current user ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  currentAuthUser = { uid: 'me', displayName: 'Me' };
+  ScoresModule.setCurrentUser(currentAuthUser);
+  seed('leaderboard', 'me', { user: doc(firestoreInstance, 'users', 'me'), time: 12.34 });
+  seed('leaderboard', 'other', { user: doc(firestoreInstance, 'users', 'other'), time: 20 });
+  ScoresModule.displayLeaderboard();
+  await flushAll();
+  let lbHtml = document.getElementById('leaderboard').innerHTML;
+  check('displayLeaderboard renders the Top 10 Times table',
+    lbHtml.includes('Top 10 Times') && lbHtml.includes('<table>'));
+  check('displayLeaderboard renders rows ascending with formatted times',
+    lbHtml.includes('12.34s') && lbHtml.includes('20.00s') &&
+    lbHtml.indexOf('12.34s') < lbHtml.indexOf('20.00s'));
+  check('displayLeaderboard highlights and names the current user row',
+    lbHtml.includes('current-user-score') && lbHtml.includes('Me'));
+
+  console.log('\n--- displayLeaderboard: empty board ---');
+  resetState(ScoresModule);
+  ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
+  ScoresModule.displayLeaderboard();
+  await flushAll();
+  check('empty leaderboard renders the no-scores message',
+    document.getElementById('leaderboard').innerHTML.includes('No scores recorded yet'));
+
+  console.log('\n--- displayLeaderboard: unavailable Firestore, failed reinitialization ---');
+  resetState(ScoresModule);
+  // Local instance stays null (resetState initializes with null) and AuthModule reports
+  // unavailable, so the reinitialization attempt fails => unavailable message.
+  firestoreAvailable = false;
+  reinitializeSucceeds = false;
+  ScoresModule.displayLeaderboard();
+  await flushAll();
+  check('displayLeaderboard attempts reinitialization when Firestore is unavailable',
+    calls.reinitializeFirestore > 0);
+  check('failed reinitialization renders the unavailable message',
+    document.getElementById('leaderboard').innerHTML === '<h3>Leaderboard unavailable</h3>');
+
+  console.log('\n--- displayLeaderboard: reinitializes a null local instance then renders ---');
+  resetState(ScoresModule);
+  // AuthModule reports available but the local instance is null; a successful
+  // reinitialization must restore it and let the fetch+render proceed.
+  firestoreAvailable = true;
+  reinitializeSucceeds = true;
+  seed('leaderboard', 'x', { user: doc(firestoreInstance, 'users', 'x'), time: 30 });
+  ScoresModule.displayLeaderboard();
+  await flushAll();
+  check('successful reinitialization restores the local instance and renders scores',
+    calls.reinitializeFirestore > 0 &&
+    document.getElementById('leaderboard').innerHTML.includes('30.00s'));
 
   console.log(`\nSCORES TEST TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Why

Part of #126 (improve coverage on the RED files). While starting that work I found that **the Node coverage harnesses don't count toward Codecov at all**:

- `scores.ts` browser LCOV = 213 covered lines; merged LCOV = 213. The Node `c8` run contributes **zero** real hits.
- Cause: `scores-tests.js` (and `auth-tests.js`) load the module-under-test via `new Function(...)` eval — to strip the gstatic CDN Firebase imports and inject mocks. c8/V8 can't attribute an anonymous eval to `src/scores.ts`, so the ~21 existing assertions registered **0%**. The 33.59% on Codecov came **entirely from the browser run**, which can't reach the Firebase-sync logic.

This PR is the foundational unlock of the stack: make the Node harness genuinely c8-instrumented, so its assertions (and all future ones) count honestly.

## What

- **`tests/mocks/firebase.mjs`** — the in-memory Firestore/Analytics mock as a single ES module (a faithful extraction of the logic that was inline in `scores-tests.js`: compare-and-write docs, `where('>=')`/`orderBy`/`limit` queries, and the deferred-write hook that models an offline `setDoc` flushing on reconnect).
- **`tests/loaders/firebase-cdn-mock.hooks.mjs`** — a `resolve` hook that redirects the `firebasejs/<ver>/firebase-{app,firestore,analytics,auth}.js` CDN specifiers to that mock, so the real `src/scores.ts` imports the mock in place of the SDK.
- **`tests/loaders/register-firebase-mock.mjs`** — registers the hook (+ the existing `.js`→`.ts` fallback); wired into `test:scores` via `--import`.
- **`scores-tests.js`** now `import`s the mock control surface + `../src/scores.ts` (same module instance both sides). Node type-strips the `.ts`; c8 instruments it with correct source-mapped lines.

Plus new assertions for the previously untested **`displayLeaderboard`** (offline, empty, ranked-table render + current-user highlight, unavailable+failed-reinit, reinitialize-then-render), the `recordScore` `new_high_score` path, `isFirestoreAvailable`, and the `getActiveUser` AuthModule fallback.

## Result

| | before | after |
|---|---:|---:|
| `scores.ts` Node `c8` lines | 0% | **~82%** (100% funcs) |

This merges **on top of** the browser run's 213 lines, so the honest Codecov number for `scores.ts` moves from RED (33.59%) into green. `34/34` scores checks pass; full `npm test` chain green; lint + typecheck clean.

## Notes for reviewers

- No production code changed — test harness + loader infra only.
- The hook only touches Node test resolution; it never affects the browser, Vite, or build paths (it matches only the gstatic Firebase CDN specifiers).
- This is **PR 1 of a stack**. PR 2 reuses the hook to convert `auth-tests.js` the same way; PR 3 adds a `start-menu.ts` jsdom harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
