### PR TITLE
test(controls): add c8-instrumented jsdom harness; retire test:controls stub (#126 PR 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:scores": "node --import ./tests/loaders/register-firebase-mock.mjs tests/scores-tests.js",
     "test:start-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/start-menu-tests.js",
     "test:firebase": "npx -y firebase-tools@15.20.0 emulators:exec --project snowglider-rules-test --only firestore \"node tests/firestore-rules-tests.js\"",
-    "test:controls": "echo 'Controls tests require browser - use index.html?test=controls'",
+    "test:controls": "node --import ./tests/loaders/register-ts-resolve.mjs tests/controls-node-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node tests/verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -1,0 +1,163 @@
+// controls-node-tests.js
+// Headless, c8-instrumented coverage for src/controls.ts (keyboard + touch input).
+//
+// controls.ts uses no three.js and no Firebase — only the DOM — so the harness just
+// sets up jsdom and `import`s the real `.ts` under the existing .js->.ts resolve hook;
+// c8 then instruments it with correct source-mapped lines. The browser suite already
+// exercises the keyboard path on desktop, so this run targets the gap: the mobile
+// touch path (`setupTouchControls` / `setupButtonTouchHandlers`), which the desktop
+// browser run can't reach.
+//
+// Two jsdom-specific tricks make the touch path testable:
+//  - `window.orientation = 0` makes isMobileDevice() true, so setup builds the visual
+//    controls + button handlers.
+//  - jsdom has no TouchEvent, but the handlers only read `event.changedTouches`, so a
+//    plain Event with a changedTouches array drives them faithfully.
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(`<!doctype html><html><body>
+  <button id="resetBtn">Reset</button>
+  <button id="cameraToggleBtn">Camera</button>
+  <div id="gameOverOverlay" style="display:none"><button>Restart</button></div>
+</body></html>`, { url: 'https://snowglider.ai/' });
+
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+// controls.ts references these bare (globalThis): the game-over observer and the
+// `new Event('resize')` that toggleTouchControls dispatches. (Node 22+ already
+// provides a built-in global `navigator`, which isMobileDevice never reaches because
+// window.orientation short-circuits it.)
+global.MutationObserver = window.MutationObserver;
+global.Event = window.Event;
+// Mark the environment "mobile" so setupTouchControls enables the visual controls and
+// the reset/camera/restart button touch handlers.
+window.orientation = 0;
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  if (condition) {
+    pass++;
+  } else {
+    fail++;
+  }
+}
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+function keydown(key) {
+  document.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+}
+function keyup(key) {
+  document.dispatchEvent(new window.KeyboardEvent('keyup', { key, bubbles: true }));
+}
+// jsdom lacks TouchEvent; the handlers only read event.changedTouches, so a plain
+// Event carrying a changedTouches array exercises them exactly.
+function dispatchTouch(type, target, points) {
+  const event = new window.Event(type, { bubbles: true, cancelable: true });
+  event.changedTouches = points;
+  target.dispatchEvent(event);
+}
+
+async function main() {
+  const { Controls } = await import('../src/controls.ts');
+
+  console.log('--- module surface ---');
+  check('exposes the Controls API',
+    !!Controls && ['setupControls', 'resetControls', 'getControls', 'isTouchDevice', 'toggleTouchControls']
+      .every(k => typeof Controls[k] === 'function'));
+
+  const controls = Controls.setupControls();
+  check('setupControls returns the shared control-state object',
+    controls && ['left', 'right', 'up', 'down', 'jump'].every(k => controls[k] === false));
+  check('isTouchDevice reports true when window.orientation is defined',
+    Controls.isTouchDevice() === true);
+
+  console.log('\n--- keyboard controls ---');
+  keydown('ArrowLeft');
+  check('ArrowLeft press sets left', controls.left === true);
+  keyup('ArrowLeft');
+  check('ArrowLeft release clears left', controls.left === false);
+  keydown('d');
+  check('"d" press sets right', controls.right === true);
+  keyup('d');
+  keydown('w');
+  check('"w" press sets up', controls.up === true);
+  keyup('w');
+  keydown('s');
+  check('"s" press sets down', controls.down === true);
+  keyup('s');
+  keydown(' ');
+  check('Spacebar press sets jump', controls.jump === true);
+  keyup(' ');
+  check('Spacebar release clears jump', controls.jump === false);
+
+  let cameraToggles = 0;
+  window.toggleCameraView = () => { cameraToggles++; };
+  keydown('v');
+  // controls.ts registers the keydown handler on BOTH window and document ("for
+  // better coverage"), so a bubbling keydown legitimately fires it on each.
+  check('"v" key invokes window.toggleCameraView', cameraToggles >= 1);
+
+  console.log('\n--- touch controls (region mapping) ---');
+  const W = window.innerWidth;
+  const H = window.innerHeight;
+  // Left region is x:[0, W/3], y:[H/3, 2H/3]; its centre is (W/6, H/2).
+  dispatchTouch('touchstart', document, [{ identifier: 1, clientX: W / 6, clientY: H / 2 }]);
+  check('touch in the left region sets left', controls.left === true);
+  dispatchTouch('touchend', document, [{ identifier: 1, clientX: W / 6, clientY: H / 2 }]);
+  check('lifting the last touch resets all controls', controls.left === false);
+  // Centre region (jump) is x:[W/3, 2W/3], y:[H/3, 2H/3]; centre is (W/2, H/2).
+  dispatchTouch('touchstart', document, [{ identifier: 2, clientX: W / 2, clientY: H / 2 }]);
+  check('touch in the centre region sets jump', controls.jump === true);
+  dispatchTouch('touchend', document, [{ identifier: 2, clientX: W / 2, clientY: H / 2 }]);
+
+  console.log('\n--- visual touch controls (mobile) ---');
+  check('mobile setup creates the 5 visual touch-control overlays',
+    document.querySelectorAll('.touch-control').length === 5);
+  check('toggleTouchControls(false) removes the visual controls and returns false',
+    Controls.toggleTouchControls(false) === false &&
+    document.querySelectorAll('.touch-control').length === 0);
+  check('toggleTouchControls(true) recreates the visual controls and returns true',
+    Controls.toggleTouchControls(true) === true &&
+    document.querySelectorAll('.touch-control').length === 5);
+
+  console.log('\n--- button touch handlers ---');
+  let resetCalls = 0;
+  window.resetSnowman = () => { resetCalls++; };
+  dispatchTouch('touchstart', document.getElementById('resetBtn'), [{ identifier: 3, clientX: 0, clientY: 0 }]);
+  check('resetBtn touchstart invokes window.resetSnowman', resetCalls === 1);
+
+  const cameraTogglesBefore = cameraToggles;
+  dispatchTouch('touchstart', document.getElementById('cameraToggleBtn'), [{ identifier: 4, clientX: 0, clientY: 0 }]);
+  check('cameraToggleBtn touchstart invokes window.toggleCameraView',
+    cameraToggles === cameraTogglesBefore + 1);
+
+  console.log('\n--- restart button via game-over MutationObserver ---');
+  let restarts = 0;
+  window.restartGame = () => { restarts++; };
+  // The observer attaches a touch handler to the restart button when the overlay
+  // becomes visible (style.display = 'flex').
+  document.getElementById('gameOverOverlay').style.display = 'flex';
+  await flush();
+  await flush();
+  const restartButton = document.querySelector('#gameOverOverlay button');
+  dispatchTouch('touchstart', restartButton, [{ identifier: 5, clientX: 0, clientY: 0 }]);
+  check('restart button touchstart invokes window.restartGame', restarts === 1);
+
+  console.log('\n--- resetControls ---');
+  keydown('ArrowRight');
+  const afterReset = Controls.resetControls();
+  check('resetControls clears every control',
+    ['left', 'right', 'up', 'down', 'jump'].every(k => afterReset[k] === false));
+  check('getControls returns the same shared object', Controls.getControls() === controls);
+
+  console.log(`\nCONTROLS TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

PR 4 of the #126 coverage stack — the last RED file. `test:controls` was a no-op `echo`, so `controls.ts` got **zero** Node coverage; its 54.85% on Codecov came entirely from the **desktop** browser run, which can't reach the mobile touch path (`setupTouchControls` / `setupButtonTouchHandlers`).

> **Stacked on #130 → #129 → #128.** Review/merge those first. This PR's diff is against `coverage/start-menu-coverage`.

## What

`controls.ts` uses no three.js and no Firebase — only the DOM — so the harness sets up jsdom and `import`s the real `.ts` under the existing `.js`→`.ts` resolve hook; c8 instruments it with correct source-mapped lines. Two jsdom tricks open the touch path:

- **`window.orientation = 0`** makes `isMobileDevice()` true, so setup builds the visual controls and the reset/camera/restart button handlers.
- jsdom has no `TouchEvent`, but the handlers only read `event.changedTouches`, so a **plain `Event` carrying a `changedTouches` array** drives them faithfully.

Covers:
- **Keyboard** — arrows / WASD / space, and the `v` camera-toggle (note: controls.ts registers the handler on both `window` and `document` "for better coverage", so a bubbling keydown fires it on each — asserted accordingly).
- **Touch region mapping** — left region + centre/jump region, and the all-touches-lifted reset.
- **Visual overlays** — the 5 `.touch-control` elements + `toggleTouchControls(false/true)` (incl. the resize-driven recreate).
- **Button handlers** — `resetBtn`→`resetSnowman`, `cameraToggleBtn`→`toggleCameraView`, and the restart button wired by the game-over **MutationObserver** when `#gameOverOverlay` becomes visible.

`test:controls` now points at this harness so it runs in the `npm test` chain (the existing browser `controls-tests.js` still runs in the puppeteer suite).

## Result

| | before | after |
|---|---:|---:|
| `controls.ts` Node `c8` lines | 0% | **~93%** |

Merges on top of the browser run, moving `controls.ts` from RED (54.85%) into solid green. `22/22` checks pass; full `npm test` chain green; lint + typecheck clean.

## Stack recap (#126)

All four RED files now have a c8-visible Node harness:

| PR | file | Node c8 after | Codecov before |
|----|------|----:|----:|
| #128 | `scores.ts` | ~82% | 33.59% |
| #129 | `auth.ts` | ~78% | 45.39% |
| #130 | `start-menu.ts` | ~90% | 50.52% |
| #131 | `controls.ts` | ~93% | 54.85% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
