### PR TITLE
docs(roadmap): sync with issue tracker + post-roadmap PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,25 @@
 > symlink to this file, so Claude Code and Codex (and other agents) read identical guidance.
 
 ## Project Overview
-SnowGlider is a Three.js animation/game project with HTML/JS implementation featuring a snowman skiing on natural backcountry mountain terrain. It is a no-build static site: `index.html` loads the application modules from `src/` via dynamic script tags. The core files are:
-- `index.html` - Main entry point and UI (loads modules from `src/`)
-- `auth.html` - Standalone Firebase authentication page (loads `src/auth.js`)
-- `src/snowglider.js` - Game logic and Three.js implementation
-- `src/snow.js` - Utility functions and snow effects
-- `src/mountains.js` - Natural backcountry terrain generation code
-- `src/trees.js` - Tree creation and placement throughout the mountain
-- `src/avalanche.js` - Avalanche system with snow boulder physics and burial detection
-- `src/course.js` - Checkpoint gates, split timing, ghost racing, and result screen
-- `src/effects.js` - Avalanche warning UI and camera juice (speed FOV, shake)
-- `src/camera.js` - Camera management system
-- `src/snowman.js` - Snowman model and physics
-- `src/controls.js` - Keyboard and touch controls implementation
-- `src/audio.js` - Background music and audio controls
-- `src/auth.js` - Firebase authentication implementation
-- `src/scores.js` - User scoring and leaderboard functionality
+SnowGlider is a Three.js animation/game featuring a snowman skiing on natural backcountry mountain terrain. It is a **Vite-bundled, ES-module TypeScript** app — the TypeScript migration is complete (see [`docs/TYPESCRIPT_MIGRATION.md`](docs/TYPESCRIPT_MIGRATION.md)): `index.html` loads the bundle entry `src/main.ts` (plus the `boot/`/`ui/` module scripts) as `<script type="module">`, and `npm run build` emits static `dist/` output for GitHub Pages. The core files are:
+- `index.html` - Main entry point and UI (loads the Vite bundle entry `src/main.ts`)
+- `auth.html` - Standalone Firebase authentication page (loads the `auth.ts` module)
+- `src/main.ts` - ES-module bundle entry; imports every game module into one graph
+- `src/snowglider.ts` - Game logic and Three.js implementation (the orchestrator)
+- `src/physics.ts` - Typed per-frame `PlayerState` layer over the `snowman.ts` kernel
+- `src/snow.ts` - Utility functions and snow effects
+- `src/mountains.ts` - Natural backcountry terrain generation code
+- `src/trees.ts` - Tree creation and placement throughout the mountain
+- `src/avalanche.ts` - Avalanche system with snow boulder physics and burial detection
+- `src/course.ts` - Checkpoint gates, split timing, ghost racing, and result screen
+- `src/effects.ts` - Avalanche warning UI and camera juice (speed FOV, shake)
+- `src/camera.ts` - Camera management system
+- `src/snowman.ts` - Snowman model and physics
+- `src/controls.ts` - Keyboard and touch controls implementation
+- `src/audio.ts` - Background music and audio controls
+- `src/auth.ts` - Firebase authentication implementation
+- `src/scores.ts` - User scoring and leaderboard functionality
+- `src/boot/` - Classic-script local-auth fallback + Firebase bootstrap (the only remaining `.js`), and `script-loader.ts` (startup driver)
 - `assets/` - Media (audio, video) tracked with Git LFS
 - `tests/` - Test files for terrain, physics, camera, avalanche, and collision detection
 - `tests/verification/` - Headless physics-invariant and DOM smoke harnesses (`npm run test:verify`)
@@ -27,7 +30,7 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - `docs/PHYSICS.md` - Terrain, skiing, jumps, collision, and avalanche simulation model
 - `docs/CHANGELOG.md` - Notable changes, including the skill/structure layer (#56) and the audio history
 - `docs/ROADMAP.md` - Phased P0–P3 feature roadmap and gap analysis
-- `docs/TYPESCRIPT_MIGRATION.md` - Incremental `@ts-check`/TypeScript migration plan and phase status
+- `docs/TYPESCRIPT_MIGRATION.md` - TypeScript migration plan and phase status (migration complete; all `src/` is `.ts` under `"strict": true`)
 - `docs/THREEJS_UPGRADE.md` - Staged three.js upgrade plan from r160 to latest
 
 ## Commands
@@ -47,13 +50,13 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
   - `npm run test:physics` - Physics simulation tests
   - `npm run test:regression` - Regression tests
   - `npm run test:tree-collision` - Tree collision tests
-- Browser tests: 
- - All tests: `index.html?test=unified`
- - Camera tests: `index.html?test=camera`
- - Gameplay tests: `index.html?test=true`
- - Tree tests: `index.html?test=trees`
- - Avalanche tests: `index.html?test=avalanche`
- - Regression tests: `index.html?test=regression`
+- Browser tests (serve first with `npm start`, then append `?test=` — `file://` no longer works):
+ - All tests: `http://localhost:8080/?test=unified`
+ - Camera tests: `http://localhost:8080/?test=camera`
+ - Gameplay tests: `http://localhost:8080/?test=true`
+ - Tree tests: `http://localhost:8080/?test=trees`
+ - Avalanche tests: `http://localhost:8080/?test=avalanche`
+ - Regression tests: `http://localhost:8080/?test=regression`
 
 ## GitHub & Pull Requests (for AI agents)
 - The `gh` CLI is **not installed** here and there is no `GITHUB_TOKEN`/`GH_TOKEN` env var, so `gh pr create` will fail. Do not assume you cannot open a PR.
@@ -77,8 +80,8 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - **Functions**: Use function declarations with descriptive names
 - **Documentation**: JSDoc-style comments for public functions
 - **Classes**: ES6 class syntax with clear method responsibilities
-- **Dependencies**: Three.js loaded via CDN (r128), Firebase v11.5.0
-- **Imports**: Use ES6 module imports when adding new functionality
+- **Dependencies**: Three.js via npm (`three@0.160.0`, r160) — bundled by Vite, import-mapped from `node_modules` in raw source (no CDN); Firebase v11.5.0
+- **Imports**: ES module `import`/`export` throughout; cross-module imports use a `.js` specifier that resolves to the `.ts` source (e.g. `import { Mountains } from './mountains.js'`)
 - **Error Handling**: Validation with boundary checks, meaningful console logging
 - **Testing**: Browser-based with visual feedback, unified test runner
 - **Firebase**: Authentication and leaderboard implementation via Firebase
@@ -100,8 +103,8 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Provide visual feedback for touch controls on mobile devices
 - Automatically detect device type to enable appropriate controls
 ## Audio Implementation (ENABLED — simplified native HTML5)
-- **Audio is enabled** via `AUDIO_ENABLED = true` in `src/audio.js`. The current implementation is the simplified, dependency-free native HTML5 `<audio>` approach: a single background-music track (`assets/drum_loop_are_you_heaven.wav`), two state variables (`muted`, `initialized`), loaded on first play, with no visibility-change handling (the browser manages it). Howler.js and Three.js Audio were both removed.
-- To disable: set `AUDIO_ENABLED = false` in `src/audio.js` (all public methods early-exit).
+- **Audio is enabled** via `AUDIO_ENABLED = true` in `src/audio.ts`. The current implementation is the simplified, dependency-free native HTML5 `<audio>` approach: a single background-music track (`assets/drum_loop_are_you_heaven.wav`), two state variables (`muted`, `initialized`), loaded on first play, with no visibility-change handling (the browser manages it). Howler.js and Three.js Audio were both removed.
+- To disable: set `AUDIO_ENABLED = false` in `src/audio.ts` (all public methods early-exit).
 - The previous Howler.js API surface is kept as no-op/Promise stubs for backward compatibility (`preloadAudio`, `playPreloadedAudio`, `resumeAudioContext`, `changeTrack`, `addAudioListener`, …), so the existing callers in `index.html` keep working without change.
 - **Caveats:** the in-page audio control button CSS is still commented out in `index.html`, and while desktop and the automated suite pass, mobile playback (iOS Safari silent switch, Android Chrome) is **not yet verified on real devices** — test thoroughly there before relying on it.
 - Treat audio changes as high risk: mobile browsers require a user gesture to start audio and can suspend the context.
@@ -119,7 +122,7 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Maintain automatic detection between development and production environments
 
 ## Scoring and Leaderboard Implementation
-- User scoring and leaderboard functionality is managed by the ScoresModule in `scores.js`
+- User scoring and leaderboard functionality is managed by the ScoresModule in `scores.ts`
 - AuthModule delegates to ScoresModule for all score-related operations
 - Both modules maintain backward compatibility with existing code
 - Best times are stored locally in localStorage by default
@@ -130,7 +133,7 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Auth and Scores modules initialize in the correct dependency order
 
 ## Avalanche System Implementation
-- AvalancheSystem class in `avalanche.js` manages snow boulder physics
+- AvalancheSystem class in `avalanche.ts` manages snow boulder physics
 - Uses THREE.InstancedMesh for efficient rendering of 120 snow boulders
 - Triggered when player travels far enough downhill (distance threshold)
 - Boulders spawn behind player (uphill) and tumble downhill following terrain
@@ -138,7 +141,7 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Burial detection: collision between player and boulder = game over
 - Methods: `trigger(playerPos)`, `update(dt)`, `checkBurial(playerPos)`, `hasPassed(playerPos)`, `reset()`
 - Requires terrain height function via `setTerrainFunction(fn)` for terrain-aware physics
-- Browser tests: `index.html?test=avalanche`
+- Browser tests: serve with `npm start`, then `http://localhost:8080/?test=avalanche`
 
 ## Review Guidelines
 - Focus on serious correctness, security, deployment, and user-visible behavior issues.
@@ -151,8 +154,8 @@ SnowGlider is a Three.js animation/game project with HTML/JS implementation feat
 - Prefer concrete bug findings over style-only comments. Avoid broad refactor suggestions unless they directly reduce a clear risk in the changed code.
 
 ## Style Notes
-- Match the existing browser-script style unless a file already uses ES modules.
+- Match the existing ES-module TypeScript style — every `src/` file is `.ts` under `"strict": true` (only the two classic `src/boot/*.js` bootstrap scripts stay JS).
 - Use 2-space indentation and semicolons.
 - Use camelCase for variables/functions and PascalCase for classes.
-- Preserve global module exports such as `window.Mountains`, `window.Controls`, `window.AuthModule`, and `window.ScoresModule` when touching existing modules.
+- Do **not** re-introduce the removed per-module `window.*` namespace bridges (`window.Mountains`, `window.Controls`, `window.Camera`, `THREE`, …) — modules `import` each other directly now. Only `window.AuthModule`/`window.ScoresModule` and the deliberate game↔test handles remain on `window` as boot/test seams (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §3).
 - Use `THREE.Vector3` and existing helper functions for position and terrain calculations instead of duplicating math ad hoc.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SnowGlider is a Three.js-based skiing game featuring a snowman gliding down a pr
 - [`CHANGELOG.md`](docs/CHANGELOG.md) — notable changes, including the skill/structure layer (#56) and the full audio history
 - [`tests/README.md`](tests/README.md) — test types, commands, and the verification harness
 - [`ROADMAP.md`](docs/ROADMAP.md) — feature roadmap and gap analysis
-- [`TYPESCRIPT_MIGRATION.md`](docs/TYPESCRIPT_MIGRATION.md) — incremental `@ts-check`/TypeScript migration plan and phase status
+- [`TYPESCRIPT_MIGRATION.md`](docs/TYPESCRIPT_MIGRATION.md) — TypeScript migration plan and phase status (migration complete)
 - [`THREEJS_UPGRADE.md`](docs/THREEJS_UPGRADE.md) — staged three.js upgrade plan from r160 to latest
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -41,25 +41,25 @@ SnowGlider is a Three.js-based skiing game featuring a snowman gliding down a pr
 - [`THREEJS_UPGRADE.md`](docs/THREEJS_UPGRADE.md) — staged three.js upgrade plan from r160 to latest
 
 ## Project Structure
-- `index.html` - Main entry point and HTML structure (loads boot scripts from `src/boot/`)
+- `index.html` - Main entry point and HTML structure (loads the Vite ES-module bundle entry `src/main.ts` plus the boot/UI module scripts)
 - `auth.html` - Standalone authentication page
 - `styles/` - Page-level CSS for the static site shell
-- `src/` - Application JavaScript modules:
-  - `boot/` - Local auth fallback, Firebase bootstrap, and ordered script loader
-  - `ui/start-menu.js` - Start/about menu behavior
-  - `snowglider.js` - Core game loop and initialization
-  - `snowman.js` - Snowman model creation and physics
-  - `mountains.js` - Terrain generation and mountain features
-  - `trees.js` - Tree creation and placement
-  - `avalanche.js` - Avalanche system with snow boulder physics and burial detection
-  - `course.js` - Course structure: checkpoint gates, split timing, ghost racing, and result screen
-  - `effects.js` - Avalanche warning UI (banner, danger meter, vignette) and camera juice (speed FOV, shake)
-  - `camera.js` - Camera management and tracking
-  - `snow.js` - Utility functions and snow effects
-  - `controls.js` - Keyboard and touch controls
-  - `audio.js` - Background music and sound control system
-  - `auth.js` - Firebase authentication and user management
-  - `scores.js` - User scoring and leaderboard functionality
+- `src/` - Application TypeScript ES modules (bundled by Vite):
+  - `boot/` - Classic-script local-auth fallback + Firebase bootstrap (`.js`), and `script-loader.ts` (the startup driver: sequences auth, the orchestrator import, and audio preload)
+  - `ui/start-menu.ts` - Start/about menu behavior
+  - `snowglider.ts` - Core game loop and initialization
+  - `snowman.ts` - Snowman model creation and physics
+  - `mountains.ts` - Terrain generation and mountain features
+  - `trees.ts` - Tree creation and placement
+  - `avalanche.ts` - Avalanche system with snow boulder physics and burial detection
+  - `course.ts` - Course structure: checkpoint gates, split timing, ghost racing, and result screen
+  - `effects.ts` - Avalanche warning UI (banner, danger meter, vignette) and camera juice (speed FOV, shake)
+  - `camera.ts` - Camera management and tracking
+  - `snow.ts` - Utility functions and snow effects
+  - `controls.ts` - Keyboard and touch controls
+  - `audio.ts` - Background music and sound control system
+  - `auth.ts` - Firebase authentication and user management
+  - `scores.ts` - User scoring and leaderboard functionality
 - `assets/` - Media (audio, video) tracked with Git LFS
 - `tests/` - Testing framework for game components
 - `tests/verification/` - Headless physics-invariant and DOM smoke harnesses (run via `npm run test:verify`)
@@ -107,8 +107,8 @@ files.
 1. Clone the repository
 2. Install dependencies with `npm ci`
 3. Run locally using one of these options:
-   - **Option 1:** Run with Vite: `npm run dev` (full features)
-   - **Option 2:** Run the legacy static server: `npm start` (full features)
+   - **Option 1:** `npm run dev` — Vite dev server (full features)
+   - **Option 2:** `npm start` — the same Vite dev server, pinned to port 8080 (full features)
    - Direct `file://` opens are not supported after the ES-module migration.
 
 #### Local Development Notes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,113 +9,133 @@ subsystem. For the simulation itself see [`PHYSICS.md`](PHYSICS.md); for tests s
 
 ## 1. Big picture
 
-SnowGlider is a **static browser app**. The source remains plain browser
-scripts — the game modules are not bundled together, and each module attaches
-itself to a global on `window`. Vite provides the local dev server and GitHub
-Pages artifact (`dist/`), while the source entry point still runs straight from
-`file://`, at the cost of a hand-maintained load order.
+SnowGlider is a **Vite-bundled browser app written in TypeScript**. Every module
+under `src/` is a `.ts` ES module compiled under `strict: true` (issues #84/#98);
+the game modules link to each other through real ES `import`s, and Vite bundles
+them into the hashed `dist/` artifact deployed to GitHub Pages. `npm start` /
+`npm run dev` serve the raw `.ts` source through the same Vite pipeline.
+`file://` is **no longer a supported run path** for the game — the module graph
+and import map don't load from a `null` origin — so the only scripts that still
+run as classic (non-module) scripts are the two boot scripts in `<head>` (see §2).
 
 Two HTML entry points:
 
-- **`index.html`** — the game. Contains the UI markup, links
-  `styles/main.css`, loads the boot scripts, then loads Three.js.
-- **`auth.html`** — a standalone Firebase auth page that loads `src/auth.js`.
+- **`index.html`** — the game. Contains the UI markup, links `styles/main.css`,
+  loads the two classic boot scripts, then loads the ES-module bundle entry
+  `src/main.ts` (which import-maps/bundles three.js).
+- **`auth.html`** — a standalone Firebase auth page that loads `src/auth.js` (a
+  `.ts` module; Vite resolves the `.js` specifier to `auth.ts`).
 
-All logic lives in `src/*.js`; page styles live in `styles/`; tests in `tests/`.
-`npm run build` emits the deployable Vite artifact to `dist/` and copies the
-static app directories needed by the existing classic-script loader.
+All logic lives in `src/*.ts` (the only `.js` left are the two `src/boot/*`
+classic scripts); page styles live in `styles/`; tests in `tests/`.
+`npm run build` emits the deployable Vite artifact to `dist/`.
 
 ---
 
-## 2. Module loading & order
+## 2. Module loading
 
-`index.html` loads scripts in three groups.
+The game modules no longer have a hand-maintained load order — they are an ES
+module graph rooted at `src/main.ts`, so the bundler/browser resolves
+dependencies. `index.html` loads scripts in two places.
 
-### 2.1 Firebase modules (ES modules, conditional)
+### 2.1 Classic boot scripts (`<head>`, protocol-branching)
 
-In `<head>`, `src/boot/local-auth.js` and `src/boot/firebase-bootstrap.js`
-branch on protocol:
+`src/boot/local-auth.js` and `src/boot/firebase-bootstrap.js` are the only
+remaining **classic** (non-module) scripts. They branch on protocol:
 
 - **`file://`** — Firebase is unavailable, so `local-auth.js` defines mock
-  `ScoresModule` and `AuthModule` implementations (localStorage-only) and loads
-  no module scripts. This is what makes `open index.html` work with no server.
-- **`http(s)://`** — it injects `src/scores.js` and `src/auth.js` as
-  `type="module"` scripts. These are the only true ES modules in the project
-  (`export default` **and** `window.*` assignment, for dual use).
+  `ScoresModule`/`AuthModule` implementations (localStorage-only). The game
+  modules themselves no longer load from `file://`, so this path now matters only
+  as the auth/score fallback, not as a way to run the whole game offline.
+- **`http(s)://`** — `firebase-bootstrap.js` `loadAuthModules()` injects
+  `src/scores.js` then `src/auth.js` as `type="module"` scripts. These two are
+  loaded *conditionally at runtime* (the game runs without Firebase) rather than
+  from the `main.ts` bundle graph, and they fall back to the `local-auth.js`
+  stubs if they don't load in time.
 
 `firebase-bootstrap.js` also sets `window.FIREBASE_MANUAL_INIT = true` and
 intercepts the `/__/firebase/init.json` fetch to stop Firebase's auto-init 404s.
 
-### 2.2 Boot UI and game modules (classic scripts, strict sequence)
+### 2.2 The ES-module bundle (bottom of `<body>`)
 
-At the bottom of `index.html`, after the Three.js CDN script, the page loads:
+After the markup, `index.html` loads three `type="module"` scripts (deferred, run
+in document order before `DOMContentLoaded`):
 
-- `src/boot/script-loader.js` — waits for `AuthModule`, initializes auth, then
-  loads game scripts with `loadScriptsInOrder([...])`.
-- `src/ui/start-menu.js` — owns the start/about menu handlers and forwards game
+- `src/main.ts` — the **bundle entry**. It eagerly `import`s every game module
+  (mountains, trees, snow, camera, snowman, audio, controls, avalanche, effects,
+  course) so they join the graph, and three.js is bundled by Vite (or import-mapped
+  from `node_modules` in raw source). The orchestrator `snowglider.ts` imports them
+  too and drives the game.
+- `src/boot/script-loader.ts` — formerly the ordered classic-script loader; its
+  `GAME_SCRIPT_ORDER` is now **empty** (every game module loads via `main.ts`), so
+  it survives only to append the browser-test suite when a `?test=` parameter is
+  present.
+- `src/ui/start-menu.ts` — owns the start/about menu handlers and forwards game
   start to `window.initializeGameWithAudio()`.
 
-The game-script order still matters because later modules read globals set by
-earlier ones:
+The old fixed chain (`mountains → trees → … → snowglider`) is **obsolete**:
+modules resolve each other through ES imports (e.g. `camera.ts` imports
+`Mountains`; `snow.ts` imports `Mountains`/`Trees`; `snowglider.ts` imports the
+rest), so import order is no longer load-bearing. Test scripts are still appended
+only when a `?test=` parameter is present (see [`tests/README.md`](../tests/README.md)).
 
-```
-mountains → trees → snow → camera → snowman → audio → controls
-          → avalanche → effects → course → snowglider   → (test scripts if ?test=)
-```
-
-`snowglider.js` is last because it is the orchestrator that consumes all the
-others. Test scripts (`tests/*.js`) are appended only when a `?test=` parameter is
-present (see [`tests/README.md`](../tests/README.md)).
-
-> **If you add a module,** insert it at the right point in
-> `src/boot/script-loader.js` (and load it before `snowglider.js` if the game
-> loop uses it).
+> **If you add a module,** `import` it from `src/main.ts` (so it joins the bundle
+> graph) and from whichever module consumes it — not from a script-order list.
 
 ---
 
-## 3. The global namespace
+## 3. Module exports & the global surface
 
-Each module exposes a single top-level symbol. Most attach it to `window`; two are
-**bare globals** (see the note after the table). Two styles coexist; match the file
-you edit.
+Each game module `export`s a single top-level symbol that other modules `import`
+by name. The per-module `window.*` namespace bridges that used to link them were
+**removed in the TypeScript migration** (#84) — `camera.ts` does
+`import { Mountains } from './mountains.js'`, not `window.Mountains`. The exports:
 
-| Symbol | File | Style | Responsibility |
+| Export | File | Style | Responsibility |
 |--------|------|-------|----------------|
-| `window.Mountains` | `mountains.js` | object + fns | Terrain height field, gradient, mesh, rocks / `rockPositions`, `SimplexNoise` |
-| `window.Trees` | `trees.js` | object + fns | Tree meshes + placement; returns `treePositions` |
-| `Snow` (bare global; on `window` only as `window.Utils`) | `snow.js` | object + fns | Snowflakes + ski snow-splash particles |
-| `Camera` (bare global; not on `window`) | `camera.js` | `class Camera` | Chase/orbit camera positioning & look-ahead |
-| `window.Snowman` | `snowman.js` | object + fns | Snowman model, `updateSnowman` physics, test hooks |
-| `window.AudioModule` | `audio.js` | IIFE | Native HTML5 background music (gated by `AUDIO_ENABLED`) |
-| `window.Controls` | `controls.js` | object + fns | Keyboard + touch input → shared `controls` state |
-| `window.Avalanche` | `avalanche.js` | `class AvalancheSystem` | Instanced snow-boulder physics & burial |
-| `window.EffectsModule` | `effects.js` | IIFE | Avalanche warning UI + camera FOV/shake |
-| `window.CourseModule` | `course.js` | IIFE | Gates, split timing, ghost racing, result screen |
-| `window.AuthModule` | `auth.js` | ES module | Firebase auth, user UI, Firestore lifecycle |
-| `window.ScoresModule` | `scores.js` | ES module | Best-time recording, leaderboard, Firestore writes |
-| `window.SnowGliderLocalAuth` | `boot/local-auth.js` | object + fns | `file://` auth and score fallbacks |
-| `window.SnowGliderFirebase` | `boot/firebase-bootstrap.js` | object + fns | Firebase config/init guard and auth-module wait/init helpers |
-| `window.SnowGliderScriptLoader` | `boot/script-loader.js` | object + fns | Ordered classic-script loader and browser-test appender |
-| `window.SnowGliderStartMenu` | `ui/start-menu.js` | object + fns | Start/about menu DOM handlers |
+| `Mountains` | `mountains.ts` | object + fns | Terrain height field, gradient, mesh, rocks / `rockPositions`, `SimplexNoise` |
+| `Trees` | `trees.ts` | object + fns | Tree meshes + placement; returns `treePositions` |
+| `Snow` | `snow.ts` | object + fns | Snowflakes + ski snow-splash particles |
+| `Camera` | `camera.ts` | `class Camera` | Chase/orbit camera positioning & look-ahead |
+| `Snowman` | `snowman.ts` | object + fns | Snowman model, `updateSnowman` physics, test hooks |
+| `Physics` | `physics.ts` | object + fns | Typed per-frame `PlayerState` container over the snowman kernel |
+| `AudioModule` | `audio.ts` | IIFE | Native HTML5 background music (gated by `AUDIO_ENABLED`) |
+| `Controls` | `controls.ts` | object + fns | Keyboard + touch input → shared `controls` state |
+| `AvalancheSystem` | `avalanche.ts` | `class` | Instanced snow-boulder physics & burial |
+| `EffectsModule` | `effects.ts` | IIFE | Avalanche warning UI + camera FOV/shake |
+| `CourseModule` | `course.ts` | IIFE | Gates, split timing, ghost racing, result screen |
+| `AuthModule` | `auth.ts` | ES module | Firebase auth, user UI, Firestore lifecycle (also `window.AuthModule`) |
+| `ScoresModule` | `scores.ts` | ES module | Best-time recording, leaderboard, Firestore writes (also `window.ScoresModule`) |
 
-> **Bare globals vs. `window` properties.** A classic-script top-level `const`/`class`
-> (e.g. `Snow`, `Camera`) is shared across scripts by its bare name but is **not** a
-> property of `window` — `window.Snow` and `window.Camera` are `undefined`. Only the
-> explicit `window.* =` assignments above (plus `window.Utils`, the legacy alias for
-> `Snow`) are real `window` properties. Reference those two as bare `Snow`/`Camera`,
-> the way `snowglider.js` does (`new Camera(scene)`, `Snow.createTerrain(...)`).
+### What still lives on `window`
 
-`snowglider.js` itself exports several functions on `window` for cross-module and
-test use: `resetSnowman`, `restartGame`, `showGameOver`, `toggleCameraView`,
-`initializeGameWithAudio`, plus `window.terrainMesh`, `window.treePositions`,
-`window.rockPositions`,
-`window.isTestMode`.
+The migration kept a small, deliberate global surface:
+
+- **Auth/scores public API** — `window.AuthModule` (`auth.ts`) and
+  `window.ScoresModule` (`scores.ts`), because they're injected conditionally
+  (§2.1), consumed by `auth.html`, and stubbed by `local-auth.js`.
+- **Boot helpers** — `window.SnowGliderLocalAuth` (`boot/local-auth.js`),
+  `window.SnowGliderFirebase` (`boot/firebase-bootstrap.js`),
+  `window.SnowGliderScriptLoader` (`boot/script-loader.ts`),
+  `window.SnowGliderStartMenu` (`ui/start-menu.ts`).
+- **Orchestrator runtime/test hooks** — `snowglider.ts` exposes `resetSnowman`,
+  `restartGame`, `showGameOver`, `toggleCameraView`, `initializeGameWithAudio`,
+  plus `window.terrainMesh`, `window.treePositions`, `window.rockPositions`,
+  `window.isTestMode`, and the `window.testHooks` / `window.testCollisionDetected`
+  collision hooks (shared with `snowman.ts`) that the browser tests read.
+
+> The touch/keyboard handlers in `controls.ts` and the browser tests still key off
+> these symbols (e.g. `window.toggleCameraView`, `window.resetSnowman`). Preserve
+> them until those callers are migrated — this is what the Refactoring Roadmap's
+> R2/R3 stages are gated on.
 
 ---
 
 ## 4. Injection seams (avoid hard coupling)
 
-Rather than importing each other, modules receive their dependencies:
+Modules now `import` each other's exports directly (§3), but the cross-cutting
+*runtime* dependencies are still passed in as parameters rather than hard-wired —
+which is what keeps physics testable and terrain swappable:
 
 - **Terrain into physics.** `getTerrainHeight`, `getTerrainGradient`,
   `getDownhillDirection` are passed into `Snowman.updateSnowman(...)`.
@@ -139,10 +159,12 @@ and a mocked `THREE`.
 
 ---
 
-## 5. The game loop (`snowglider.js`)
+## 5. The game loop (`snowglider.ts`)
 
-`snowglider.js` owns the Three.js `scene`, `renderer`, `camera`/`cameraManager`,
-the shared mutable state (`pos`, `velocity`, `isInAir`, timers, avalanche flags),
+`snowglider.ts` owns the Three.js `scene`, `renderer`, `camera`/`cameraManager`,
+the shared mutable run state (now a typed `GameState` + the `Physics`
+player-state layer in `physics.ts`, see #118–#121: `pos`, `velocity`, `isInAir`,
+timers, avalanche flags),
 and the lifecycle: `initializeGameWithAudio()` (entry from the Start button) →
 `resetSnowman()` → `animate()`; `showGameOver(reason)` / `restartGame()`.
 
@@ -175,7 +197,7 @@ camera.position -= shake                          // revert so smoothing stays c
 
 ## 6. Input
 
-`Controls` (`controls.js`) writes a shared `controls` state object
+`Controls` (`controls.ts`) writes a shared `controls` state object
 (`left/right/up/down/jump`) from both keyboard (Arrows/WASD, Space, `V`) and touch
 (screen quadrants), using `{ passive: false }` handlers. Physics reads only that
 state, so keyboard and touch are interchangeable. Button touch handlers wire
@@ -190,10 +212,15 @@ Three runtime modes, auto-detected:
 | Mode | Trigger | Auth | Firestore | Source |
 |------|---------|------|-----------|--------|
 | **File** | `file://` | mock (Local Mode banner) | no | `src/boot/local-auth.js` |
-| **Local dev** | `localhost`/`127.0.0.1` | real | disabled (avoids 400s) | `auth.js` / `scores.js` |
-| **Production** | GitHub Pages (https) | real | enabled | `auth.js` / `scores.js` |
+| **Local dev** | `localhost`/`127.0.0.1` | real | disabled (avoids 400s) | `auth.ts` / `scores.ts` |
+| **Production** | GitHub Pages (https) | real | enabled | `auth.ts` / `scores.ts` |
 
-Scoring flow (`scores.js` `recordScore(time)`): always writes a new local best to
+> The **File** row is now only the auth/score fallback: the game's ES-module
+> graph won't load from `file://`, so you serve the game through Vite
+> (`npm start`) even in "local" development. The mock still matters for
+> graceful degradation when Firebase is unreachable on a real origin.
+
+Scoring flow (`scores.ts` `recordScore(time)`): always writes a new local best to
 `localStorage` first; then, only when the user is signed in, Firestore is
 available, **and** this run matches or beats the local best
 (`shouldSyncBestTime`), it syncs the run's `time` via `updateUserBestTime` (which
@@ -212,14 +239,18 @@ fallbacks** — they are what keep the game runnable without a Firebase project.
 
 ## 8. Testing & deployment seams
 
-- **Node suites** (`tests/*-tests.js`) import the physics/terrain modules directly
-  and run headless. The **verification harness** (`tests/verification/`) compares
-  live physics against a frozen baseline and smoke-tests the DOM modules.
-- **Browser suites** load inside the real game via `?test=…` and are appended by
-  the loader after `snowglider.js`.
+- **Node suites** (`tests/*-tests.js`) import the physics/terrain `.ts` modules
+  directly (transpiled for Node) and run headless. The **verification harness**
+  (`tests/verification/`) compares live physics against a frozen baseline and
+  smoke-tests the DOM modules.
+- **Browser suites** load inside the real game via `?test=…`, served through Vite
+  so the `.ts` modules resolve, and are appended by the loader after the bundle
+  (`main.ts`).
+- **End-to-end** Playwright specs (`tests/e2e/`) run cross-browser + mobile
+  viewports alongside the Puppeteer suite.
 - **Deployment** is GitHub Pages, gated so Pages publishes only after the test job
-  passes. Vite builds the Pages artifact into `dist/`; workflows must stay
-  least-privileged and must not publish `node_modules/`, `coverage/`, or test
-  artifacts.
+  passes. Vite builds the Pages artifact into `dist/`; a CI guard rejects raw
+  TypeScript in the artifact. Workflows must stay least-privileged and must not
+  publish `node_modules/`, `coverage/`, or test artifacts.
 
 See [`tests/README.md`](../tests/README.md) for the full matrix and commands.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,10 +66,18 @@ in document order before `DOMContentLoaded`):
   course) so they join the graph, and three.js is bundled by Vite (or import-mapped
   from `node_modules` in raw source). The orchestrator `snowglider.ts` imports them
   too and drives the game.
-- `src/boot/script-loader.ts` — formerly the ordered classic-script loader; its
-  `GAME_SCRIPT_ORDER` is now **empty** (every game module loads via `main.ts`), so
-  it survives only to append the browser-test suite when a `?test=` parameter is
-  present.
+- `src/boot/script-loader.ts` — the **startup driver**, and still load-bearing for
+  normal play. Its `DOMContentLoaded` handler `initializeGameScripts()` sequences
+  boot: it waits for the auth fallback (`SnowGliderFirebase.waitForAuthModule()`),
+  initializes Auth (`initializeAuthModule()`), then dynamically imports and runs the
+  `snowglider.ts` orchestrator through `window.__loadSnowGliderOrchestrator` (set by
+  `main.ts`; if the hook is missing the chain rejects rather than hanging), and
+  finally announces readiness (`window.SnowGliderGameScriptsReady` + the
+  `snowglider:game-scripts-ready` event) and pre-loads audio. Its
+  `GAME_SCRIPT_ORDER` is now **empty** (every game module loads via `main.ts`) and
+  it appends the browser-test suite only when a `?test=` parameter is present — but
+  **do not mistake it for a test-only shim**: bypass or remove it outside `?test=`
+  and the orchestrator never runs, so the game never starts.
 - `src/ui/start-menu.ts` — owns the start/about menu handlers and forwards game
   start to `window.initializeGameWithAudio()`.
 

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -29,7 +29,7 @@ Companion docs: [`ARCHITECTURE.md`](ARCHITECTURE.md) (how the modules fit togeth
 
 Terrain is the foundation of every other system: skiing forces, tree/rock
 placement, gates, and the avalanche all sample terrain height. Implemented in
-[`src/mountains.js`](src/mountains.js).
+[`src/mountains.ts`](src/mountains.ts).
 
 ### 2.1 Height field
 
@@ -84,7 +84,7 @@ sample (`sampleDist = 0.4`) for stability.
 
 ## 3. Skiing model
 
-Implemented in [`src/snowman.js`](src/snowman.js) `updateSnowman()`. Each frame,
+Implemented in [`src/snowman.ts`](src/snowman.ts) `updateSnowman()`. Each frame,
 grounded, the order is: detect landing → compute slope forces → apply ski
 technique → friction → integrate → orient/tilt → collision & bounds.
 
@@ -223,7 +223,7 @@ trigger a proportional camera shake on touchdown.
 `treeCollisionRadius = 2.5`. A collision ends the run **unless** the snowman is
 genuinely clearing the tree: `isInAir && verticalVelocity > 0 && pos.y > treeY + 5`
 allows jumping over. (Test modes widen the epsilon and add force-collision hooks —
-see [`src/snowman.js`](src/snowman.js) `addTestHooks`.)
+see [`src/snowman.ts`](src/snowman.ts) `addTestHooks`.)
 
 ### 5.2 Rocks
 
@@ -286,15 +286,15 @@ compares trajectories against a frozen baseline. Two properties make this work:
    input gate or the invariant harness will (correctly) fail.
 
 Regenerate the baseline only on a **deliberate** physics change:
-`git show <ref>:src/snowman.js > tests/verification/snowman_baseline.js`
+`git show <ref>:src/snowman.ts > tests/verification/snowman_baseline.js`
 (re-add the header), then re-run `npm run test:verify`.
 
 ---
 
 ## 7. Avalanche
 
-Implemented in [`src/avalanche.js`](src/avalanche.js) (`AvalancheSystem`), driven
-from the main loop in [`src/snowglider.js`](src/snowglider.js).
+Implemented in [`src/avalanche.ts`](src/avalanche.ts) (`AvalancheSystem`), driven
+from the main loop in [`src/snowglider.ts`](src/snowglider.ts).
 
 ### 7.1 Trigger
 
@@ -340,7 +340,7 @@ if (pos.y < floorY + radius):                  // ground contact
 
 ## 8. Course timing & ghost
 
-Implemented in [`src/course.js`](src/course.js). Physics-adjacent: it reads the
+Implemented in [`src/course.ts`](src/course.ts). Physics-adjacent: it reads the
 snowman's position but applies no forces (gates are decorative and never collide).
 
 - Geometry: `START_Z = -15`, `FINISH_Z = -195`, checkpoints at `-60, -105, -150`,
@@ -357,7 +357,7 @@ snowman's position but applies no forces (gates are decorative and never collide
 
 ## 9. Camera "juice"
 
-Implemented in [`src/effects.js`](src/effects.js); applied in the render step and
+Implemented in [`src/effects.ts`](src/effects.ts); applied in the render step and
 then reverted so the camera manager's smoothing never re-ingests its own shake.
 
 - **Speed FOV.** `BASE_FOV = 75` widens toward `MAX_FOV = 88` as speed approaches

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -285,9 +285,19 @@ compares trajectories against a frozen baseline. Two properties make this work:
    are reproducible. If you add randomness to the grounded path, keep it behind an
    input gate or the invariant harness will (correctly) fail.
 
-Regenerate the baseline only on a **deliberate** physics change:
-`git show <ref>:src/snowman.ts > tests/verification/snowman_baseline.js`
-(re-add the header), then re-run `npm run test:verify`.
+Regenerate the baseline only on a **deliberate** physics change — and note it is
+**not** a verbatim copy of `src/snowman.ts`. The harness loads the baseline as a
+*classic script* through `vm.runInContext` and reads `window.Snowman.updateSnowman`,
+whereas `src/snowman.ts` is an ES module (`import * as THREE from 'three'`,
+`export const Snowman`). A raw `git show <ref>:src/snowman.ts > …snowman_baseline.js`
+would therefore write ESM `import`/`export` with no `window.Snowman`, and the next
+`npm run test:verify` would fail. Instead, port the changed `updateSnowman` (plus the
+helpers it calls) into the existing classic-wrapper shape: drop the
+`import * as THREE from 'three'` line (the harness supplies a global `THREE` stub) and
+the `export`s, and keep the trailing
+`const Snowman = { … }; if (typeof window !== 'undefined') window.Snowman = Snowman;`
+block. Re-add the header, then re-run `npm run test:verify`. (`tests/README.md` carries
+the same note.)
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,8 @@
 
 This roadmap began as a feature-gap analysis. Its **top recommendation — the "skill & structure" layer — shipped in [#56](https://github.com/den-run-ai/snowglider/pull/56)**: checkpoint gates + finish line, live split timing and a result screen, ghost racing, an avalanche warning UI, and a first snowplow/carve/tuck ski-technique pass. See [`CHANGELOG.md`](CHANGELOG.md) for that work in detail.
 
+**Since this roadmap was written (snapshot 2026-06-18):** a large *infrastructure* wave landed — the TypeScript/ES-module migration completed (issues [#35](https://github.com/den-run-ai/snowglider/issues/35), [#84](https://github.com/den-run-ai/snowglider/issues/84), [#98](https://github.com/den-run-ai/snowglider/issues/98), now closed; all of `src/` is `.ts` under `strict: true`, bundled by Vite), plus CI hardening (production-build validation, raw-TS Pages guard, honest merged Node+browser coverage) and new test layers (Playwright cross-browser/mobile E2E, Firestore-rules harness, c8 coverage harnesses). **None of this changed gameplay**, so the Priority Findings below are unchanged — but it did invalidate the premises of the [Refactoring Roadmap](#refactoring-roadmap), which has been updated accordingly.
+
 Status legend used below: **✅ shipped** · **◐ partial** (started, more to do) · **○ open**.
 
 > The [**GitHub issue tracker**](https://github.com/den-run-ai/snowglider/issues) is the living source of truth for the backlog. This document is a higher-level synthesis and will drift as issues open and close — treat the issue references here as pointers, not a status board.
@@ -87,7 +89,7 @@ The avalanche existed but wasn't well communicated, especially when it came from
 Jump is a listed control but currently does little for the player.
 
 - **Add:** airtime scoring, landing-quality grading, obstacle clears, shortcuts, avalanche-dodge windows, speed boost on clean landings, and style/combo bonuses.
-- **Open issue:** jumping should help avoid obstacles and maybe avalanches (**#47**).
+- **Open issues:** jumping should help avoid obstacles and maybe avalanches (**#47**), freestyle ski tricks (**#32**).
 
 ### 5. Dynamic hazards and a living world — ○ open
 
@@ -132,7 +134,7 @@ Touch controls exist, but this game is a natural fit for richer mobile input.
 
 - **Add:** gyro/tilt steering, haptics, swipe-to-jump, a simpler mobile HUD, and **performance scaling** (toggle shadows / reduce particle counts when framerate drops below ~30 FPS).
 - **UI:** keep the game-over screen, score counter, and menus as responsive HTML/CSS overlaying the `<canvas>` for crisp mobile readability, rather than baked into the 3D scene.
-- **Open issue:** gyro/tilt controls (open).
+- **Open issues:** gyro/tilt controls (**#24**), more visible touchscreen controls (**#25**), make all buttons (about-game, music selection) mobile-friendly (**#37**).
 
 ### 11. Personality and fail-state fun — ○ open
 
@@ -170,52 +172,78 @@ A phased plan that several of the review passes converge on:
 
 ## Refactoring Roadmap
 
+> **Premises updated (2026-06-18).** This section originally assumed a
+> "classic browser-script" / `file://` architecture with a load-bearing script
+> order. That is no longer the project: the TypeScript migration (**#84**,
+> **#98**) converted every `src/*` module to a `.ts` ES module bundled by Vite,
+> removed the per-module `window.*` namespace bridges, single-sourced three.js
+> from npm, and retired the explicit script order (`src/main.ts` is the bundle
+> entry and modules now resolve each other through real ES imports — see
+> `src/main.ts`: *"the import order below is no longer load-bearing"*). `file://`
+> is no longer a supported run path for the game graph; only the boot scripts
+> (`src/boot/local-auth.js`, `src/boot/firebase-bootstrap.js`) stay as classic
+> non-module scripts so the Local Mode auth/score fallback still loads. The
+> staged plan below survives the migration, but **Stage R1 has effectively
+> shipped** and the remaining stages should be read as ES-module extractions,
+> not classic-script ones.
+
 The feature roadmap above is increasingly constrained by three large files:
 `index.html` owns markup, CSS, bootstrapping, local-mode mocks, script loading,
-and start-menu behavior; `src/snowglider.js` owns scene setup, shared game state,
+and start-menu behavior; `src/snowglider.ts` owns scene setup, shared game state,
 the render loop, lifecycle, HUD updates, scoring, overlays, and test globals; and
-`src/snowman.js` owns model construction, skiing physics, pose animation,
+`src/snowman.ts` owns model construction, skiing physics, pose animation,
 collision checks, finish/crash reason selection, and browser test hooks.
 
-The best structural move is a staged, behavior-preserving extraction that keeps
-the current classic browser-script architecture intact. Do **not** use this as a
-bundler/framework rewrite. Preserve the `file://` fallback, Vite/GitHub Pages
-deployment path, explicit script order, and existing `window.*` compatibility
-exports until tests and callers have been migrated.
+The best structural move is a staged, behavior-preserving extraction. Do **not**
+turn this into a *framework* rewrite (React Three Fiber **#36** and alternative
+engines like rapier **#38** / Needle **#41** remain exploratory "consider" issues,
+not committed direction). Preserve the Vite/GitHub Pages deployment path, the
+Local Mode boot fallback, and the remaining test/runtime `window.*` hooks
+(`window.resetSnowman`, `window.restartGame`, …) until tests and callers have been
+migrated. **Tracking issues:** refactor `index.html` into CSS + main (**#33**),
+refactor `snowglider` into a thinner UI/game module (**#34**).
 
-### Stage R1 — Split the page shell first
+### Stage R1 — Split the page shell first — ✅ shipped
 
-Lowest-risk extraction from `index.html`:
+Lowest-risk extraction from `index.html`; this stage has landed (file names
+reflect what exists today):
 
-- Move page styles to `styles/main.css`.
-- Move `file://` auth/score mocks to `src/boot/local-auth.js`.
-- Move Firebase defaults/init-json handling to `src/boot/firebase-bootstrap.js`.
-- Replace the nested script `onload` pyramid with `src/boot/script-loader.js`
-  using a small `loadScriptsInOrder([...])` helper.
-- Move start/about menu behavior to `src/ui/start-menu.js`.
+- ✅ Page styles moved to `styles/main.css` (no inline `<style>` left in `index.html`).
+- ✅ `file://`/Local Mode auth/score mocks in `src/boot/local-auth.js`.
+- ✅ Firebase defaults/init-json handling in `src/boot/firebase-bootstrap.js`.
+- ✅ Script loading replaced — the nested `onload` pyramid is gone; the bundle
+  entry `src/main.ts` (Vite) eagerly imports the game modules, and
+  `src/boot/script-loader.ts` survives only to append the optional browser-test
+  suite (its `GAME_SCRIPT_ORDER` is now empty).
+- ✅ Start/about menu behavior moved to `src/ui/start-menu.ts`.
 
-The script order must remain:
+The old fixed script order is **obsolete** — modules resolve each other through
+ES imports, so this chain is no longer load-bearing:
 
 ```text
 mountains -> trees -> snow -> camera -> snowman -> audio -> controls
           -> avalanche -> effects -> course -> snowglider -> tests
 ```
 
-### Stage R2 — Thin the game orchestrator
+### Stage R2 — Thin the game orchestrator — ◐ partial
 
-`src/snowglider.js` should become a small coordinator instead of the owner of
-every runtime concern. Extract:
+`src/snowglider.ts` should become a small coordinator instead of the owner of
+every runtime concern. The TS migration already did the *state* slice of this:
+the mutable run/lifecycle state was folded into a typed `GameState`
+(**#118**/**#119**/**#121**) and the player physics state was extracted into
+`src/physics.ts` (**#120**). The *scene / loop / UI* extractions below are still
+open (no `src/game/` dir yet; `src/ui/` currently holds only `start-menu.ts`):
 
-- `src/game/scene-setup.js` for scene, renderer, lights, terrain, trees, snowman,
+- ◐ `game-state` — done as typed `GameState` (`pos`, `velocity`, air state, timers,
+  avalanche trigger state, technique) + `src/physics.ts` player-state layer.
+- ○ `src/game/scene-setup.ts` for scene, renderer, lights, terrain, trees, snowman,
   snow particles, avalanche construction, and course/effects init.
-- `src/game/game-state.js` for mutable run state (`pos`, `velocity`, air state,
-  timers, avalanche trigger state, technique).
-- `src/game/main-loop.js` for the current `animate()` ordering.
-- `src/game/lifecycle.js` for start, reset, restart, and game-active transitions.
-- `src/ui/hud.js` for stats, timer, speed color, position, and technique display.
-- `src/ui/result-overlay.js` for game-over/finish overlay, local best display,
+- ○ `src/game/main-loop.ts` for the current `animate()` ordering.
+- ○ `src/game/lifecycle.ts` for start, reset, restart, and game-active transitions.
+- ○ `src/ui/hud.ts` for stats, timer, speed color, position, and technique display.
+- ○ `src/ui/result-overlay.ts` for game-over/finish overlay, local best display,
   login prompt, leaderboard insertion, and `CourseModule.onFinish(...)`.
-- `src/ui/collapsible-panel.js` for shared Game Stats / Game Controls
+- ○ `src/ui/collapsible-panel.ts` for shared Game Stats / Game Controls
   collapse, resize, and swipe behavior.
 
 Keep these globals stable during the first pass because controls and browser
@@ -223,20 +251,23 @@ tests still use them: `window.resetSnowman`, `window.restartGame`,
 `window.showGameOver`, `window.toggleCameraView`, and
 `window.initializeGameWithAudio`.
 
-### Stage R3 — Split snowman only after R1/R2
+### Stage R3 — Split snowman only after R1/R2 — ○ mostly open
 
-`src/snowman.js` is the highest-risk file because it contains the physics model
-and the deterministic verification seam. Split it only after the boot and
-orchestrator work has landed:
+`src/snowman.ts` is the highest-risk file because it contains the physics model
+and the deterministic verification seam. Note the typed `src/physics.ts`
+extracted in R2 is only the per-frame *state* container — the physics *math*
+(`Snowman.updateSnowman` / `Snowman.resetSnowman`) deliberately still lives in
+`snowman.ts` so the physics-invariant harness stays byte-identical. Split the
+rest only after the boot and orchestrator work has landed:
 
-- `src/snowman/model.js` for geometry, materials, arms, hat, skis, and scene add.
-- `src/snowman/physics.js` for gravity, friction, jumping, air control, ski
+- `src/snowman/model.ts` for geometry, materials, arms, hat, skis, and scene add.
+- `src/snowman/physics.ts` for gravity, friction, jumping, air control, ski
   technique, snowplow braking, skid/carve classification, and idle turning.
-- `src/snowman/pose.js` for heading, terrain tilt, jump tilt, turn lean, and ski
+- `src/snowman/pose.ts` for heading, terrain tilt, jump tilt, turn lean, and ski
   wedge animation.
-- `src/snowman/collision.js` for tree collision, boundary checks, finish
+- `src/snowman/collision.ts` for tree collision, boundary checks, finish
   detection, and crash/finish reason strings.
-- `src/snowman/test-hooks.js` for browser collision hooks.
+- `src/snowman/test-hooks.ts` for browser collision hooks.
 
 Keep `window.Snowman.updateSnowman(...)`, `window.Snowman.resetSnowman(...)`,
 and `window.Snowman.addTestHooks(...)` as compatibility wrappers at first.
@@ -252,8 +283,8 @@ Internally delegate to smaller modules without changing the public signatures.
 - Re-run `npm test` and `npm run test:verify` after each stage. Any change to the
   no-input physics path must be deliberate and reflected in
   `docs/PHYSICS.md` plus the verification baseline.
-- Update `docs/ARCHITECTURE.md` in the same PR as each extraction so the script
-  order, globals, and ownership boundaries stay accurate.
+- Update `docs/ARCHITECTURE.md` in the same PR as each extraction so the module
+  graph, globals, and ownership boundaries stay accurate.
 
 ---
 
@@ -280,8 +311,30 @@ Many recommendations align with the maintainer's backlog, which is a good sign t
 | Intro fly-over of the mountain | #51 | ○ open |
 | Mobile music-disable button broken *(bug)* | #50 | ○ open |
 | Jumping should help avoid obstacles/avalanches | #47 | ○ open |
-| Integrate a realistic 3D map | #40 | ○ open |
+| Freestyle ski tricks | #32 | ○ open |
 | Pause/save game state | #39 | ○ open |
-| Gyro/tilt controls; lighting/shadows; textures; visible sky | (open) | ○ open |
+| Social media sharing | #31 | ○ open |
+| Gameplay tuning (steeper slope, fewer bumps, drop the "forward" button) | #27 | ○ open |
+| More visible touchscreen controls; mobile-friendly buttons | #25, #37 | ○ open |
+| Gyro/tilt controls | #24 | ○ open |
+| Lighting and shadows | #18 | ○ open |
+| Textures (snow, trees, rocks, snowman) | #17 | ○ open |
+| Visible sky | #2 | ○ open |
+
+### Infrastructure, tooling & exploratory
+
+These don't map to a Priority Finding above but are part of the live backlog (and
+several landed after this roadmap was first written):
+
+| Theme | Issue(s) | Status |
+|-------|----------|--------|
+| TypeScript / ES-module migration | #35, #84, #98 | ✅ shipped — closed (all `src/` is `.ts`, `strict: true`, Vite bundle) |
+| Refactor `index.html` into CSS + main | #33 | ✅ Stage R1 shipped (`styles/main.css` + `src/boot/*` + `src/ui/start-menu.ts`) |
+| Refactor `snowglider` into a thinner UI/game module | #34 | ◐ partial — typed `GameState` + `src/physics.ts`; scene/loop/UI extraction still open |
+| Improve test coverage for RED files (scores, auth, controls, start-menu) | #126 | ◐ in progress (#128–#131) |
+| Update three.js + validate testing/audio | #29 | ✅ likely addressed by the r160 upgrade (#75/#76) + native-audio rewrite — candidate to close |
+| Leaderboard unavailable / sign-in dropout + testing | #28 | ◐ scores/auth hardening + tests (#67, #73, #128/#129); the specific dropout report not separately re-verified |
+| Performance monitoring via Firebase | #30 | ○ open |
+| Engine/framework explorations (not committed direction) | #40 (3D map), #36 (React Three Fiber), #38 (rapier physics), #41 (Needle tools) | ○ exploratory |
 
 *The higher-level structural gaps — a finish line and objective feedback, scoring depth, progression/replay hooks, and the AI features — were the items the tracker was quieter on; #56 delivered the first of these (course + result + ghost), and the rest (daily/per-course leaderboards, AI coach) remain the biggest open wins.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -212,9 +212,11 @@ reflect what exists today):
 - ✅ `file://`/Local Mode auth/score mocks in `src/boot/local-auth.js`.
 - ✅ Firebase defaults/init-json handling in `src/boot/firebase-bootstrap.js`.
 - ✅ Script loading replaced — the nested `onload` pyramid is gone; the bundle
-  entry `src/main.ts` (Vite) eagerly imports the game modules, and
-  `src/boot/script-loader.ts` survives only to append the optional browser-test
-  suite (its `GAME_SCRIPT_ORDER` is now empty).
+  entry `src/main.ts` (Vite) eagerly imports the game modules. `src/boot/script-loader.ts`
+  remains the **startup driver**: its `DOMContentLoaded` handler still sequences auth,
+  the `window.__loadSnowGliderOrchestrator` import, readiness, and audio preload (see
+  `ARCHITECTURE.md` §2.2). Its `GAME_SCRIPT_ORDER` is now empty and it only *additionally*
+  appends the browser-test suite when `?test=` is present — it is **not** a test-only shim.
 - ✅ Start/about menu behavior moved to `src/ui/start-menu.ts`.
 
 The old fixed script order is **obsolete** — modules resolve each other through

--- a/docs/THREEJS_UPGRADE.md
+++ b/docs/THREEJS_UPGRADE.md
@@ -13,6 +13,11 @@
   `require('three')`). No bundler, no build step.
 - **After PR #76:** three.js **0.160.0** in both the CDN tag and npm, with
   `@types/three@0.160.0` checked by the TypeScript Phase 1 gate from main.
+- **Since then (TypeScript migration #84/#98 complete):** the CDN `<script>` global was
+  removed (TS PR 2.10) and the codebase went full ESM + Vite. three.js **0.160.0** is now
+  single-sourced from **npm** — bundled by Vite for the deploy, and import-mapped from
+  `node_modules` on the raw-source path (`npm start`, puppeteer). **This unblocks Stage B**:
+  its only blocker (ES modules / TS Phase 2) has landed. See Phase B below.
 - **Latest:** three.js **0.184.0** / `@types/three` **0.184.1** (npm, at time of writing).
 - **Guardrail:** `npm test`, `npm run lint`, `npm run typecheck`, the verification harness,
   and the puppeteer browser smoke must stay green after every step. No step may leave `main`
@@ -40,10 +45,9 @@ TypeScript migration**. Therefore:
    global. This is where the *real* work and visual risk live: it crosses the **color-management
    default (r152)** and the **physically-correct-lights default (r155)**. Independently
    shippable in PR #76, with the TypeScript checker already active. **High value, self-contained.**
-2. **Stage B — r160 → latest, after ES modules exist.** Sequenced **after** TS-migration
-   Phase 2. `THREE` comes from npm via `import * as THREE from 'three'` (bundler) or an
-   **import map** (keeps the no-build static-site model). Mostly mechanical once Stage A's
-   color/lighting tuning is already done.
+2. **Stage B — r160 → latest.** Was sequenced **after** TS-migration Phase 2; **that has since
+   landed** (along with Phase 3), so `THREE` now comes from npm via `import * as THREE from 'three'`
+   and the Vite bundle. Mostly mechanical once Stage A's color/lighting tuning is already done.
 
 > This **refines** the note in [`TYPESCRIPT_MIGRATION.md`](TYPESCRIPT_MIGRATION.md)
 > ("upgrade three.js off r134 … sequence it after Phase 2"). True for *latest*, but you don't
@@ -190,25 +194,26 @@ Shippable as its own PR; after PR #74, the Phase 1 TypeScript checker is an addi
 
 ## Phase B — r160 → latest (≈0.184), after ES modules
 
-**Blocked on TypeScript-migration Phase 2** (ES modules + bundler/import-map). r161+ ship no
-global build, so `THREE` must be imported, not read off `window`. Do **not** start Phase B until
-`index.html` loads modules instead of the `<script>`-chain in [`ARCHITECTURE.md`](ARCHITECTURE.md) §2.2.
+**Now unblocked.** This stage was gated on TypeScript-migration Phase 2 (ES modules + bundler);
+that has since shipped, along with Phase 3 — all of `src/` is `.ts`, Vite-bundled (see
+[`TYPESCRIPT_MIGRATION.md`](TYPESCRIPT_MIGRATION.md) and [`ARCHITECTURE.md`](ARCHITECTURE.md) §2.2).
+`index.html` already loads ES modules and `THREE` is imported from npm, not read off `window`, so
+the r161+ ESM-only requirement is satisfied. Phase B is just a version bump on the existing model,
+to schedule whenever the visual-gate work below is done.
 
 ### B.1 Source `THREE` as a module
 
-Once modules exist, two ways to get latest three while keeping deploys sane:
+The path is already chosen: modules `import * as THREE from 'three'` and the app is Vite-bundled,
+so Stage B reduces to bumping the npm dependency.
 
-- **Import map (keeps the no-build static-site model — preferred if staying build-less):**
-  ```html
-  <script type="importmap">
-  { "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js" } }
-  </script>
-  ```
-  Modules then `import * as THREE from 'three'`. No bundler, still copy-deploys to Pages, but
-  **note `file://` import maps are blocked by CORS** — `open index.html` would need the dev
-  server (`npm start`). Weigh against the `file://`-fallback design in `ARCHITECTURE.md` §7.
-- **Bundler (Vite):** per `TYPESCRIPT_MIGRATION.md` §2.1; `import * as THREE from 'three'`,
-  `npm i three@0.184`, build to `dist/`, deploy `dist/`.
+- **Bundler (Vite) — the current model:** per `TYPESCRIPT_MIGRATION.md` §2.1. Modules already do
+  `import * as THREE from 'three'`; `npm i three@0.184` (+ matching `@types/three`), Vite bundles
+  it, deploy `dist/`. The raw-source/puppeteer path resolves bare `three` through the `index.html`
+  import map pointed at `node_modules`, so bump that map's target in lockstep.
+- **Import map to a CDN (historical alternative, no longer the project's model):** before Vite
+  landed, the plan was to keep the no-build static site by import-mapping `three` to a CDN
+  `three.module.js`. Moot now that the build step exists — noted only for context. (`file://`
+  import maps are blocked by CORS anyway, and `open index.html` is no longer a supported run mode.)
 
 ### B.2 Bump and clear the r160→r184 deltas
 

--- a/docs/TYPESCRIPT_MIGRATION.md
+++ b/docs/TYPESCRIPT_MIGRATION.md
@@ -4,10 +4,13 @@
 
 ## Status
 
-- **Current:** Phase 1 hardened **and Phase 2 (the conversion phase) complete** (see issue #84 for
-  the per-PR plan). Every `src/**/*.js` carries `// @ts-check`, `tsc --noEmit` is green and **blocking
-  in CI**, and `tsconfig` sets `"checkJs": true` so any *new* source file is type-checked by default.
-  **Every game module is now an ES module** that `import * as THREE from 'three'` (the npm package —
+- **Current:** Migration complete — **Phases 1, 2, and 3 have all shipped to `main`** (issues
+  #35/#84/#98, all closed). Every `src/**` module is now **`.ts`** (only the two classic `boot/*.js`
+  bootstrap scripts stay JS by design); `tsconfig` is fully **`"strict": true`**, `tsc --noEmit` is
+  green and **blocking in CI**, and `typescript-eslint` lints the `.ts` sources (PR 3.18). The only
+  remaining work is the **optional, non-exit-blocking** typed-`GameState` consolidation (Phase 3,
+  item marked `[~]`) and the separately-tracked three.js r160→latest upgrade. **Every game module is
+  now an ES module** that `import * as THREE from 'three'` (the npm package —
   the CDN UMD global is gone) and imports the others directly. `auth.js` / `scores.js` were already
   ES modules for Firebase, and the final classic module **`audio.js`** plus the boot/UI scripts
   (**`src/boot/script-loader.js`**, **`src/ui/start-menu.js`**) and all seven browser test suites are
@@ -68,9 +71,9 @@ Highest ROI is **typed game-state + the pure-logic modules you already test** (p
 
 Goal: lock in a known-good state so every later phase is measurable.
 
-- [ ] Confirm `npm test` and `npm run lint` are green on a clean checkout. Record current `c8` coverage as the baseline.
-- [ ] Tag the pre-migration commit (e.g. `pre-ts-baseline`) so any phase can be bisected against it.
-- [ ] Skim `ARCHITECTURE.md` §3 (global namespace) and §4 (injection seams) — the seams (`setTerrainFunction`, etc.) are your future typed boundaries.
+- [x] Confirm `npm test` and `npm run lint` are green on a clean checkout. Record current `c8` coverage as the baseline.
+- [x] Tag the pre-migration commit (e.g. `pre-ts-baseline`) so any phase can be bisected against it.
+- [x] Skim `ARCHITECTURE.md` §3 (global namespace) and §4 (injection seams) — the seams (`setTerrainFunction`, etc.) are your future typed boundaries.
 
 **No code changes. Nothing to revert.**
 
@@ -153,9 +156,9 @@ Treat `globals.d.ts` and the eslint globals list as **one logical thing kept in 
 
 You already standardize on "JSDoc-style comments for public functions" (`CLAUDE.md`). Now make those JSDoc comments *typed*, and flip files on one at a time:
 
-- [ ] Add `// @ts-check` to the top of a file, run `npx tsc --noEmit`, fix what it flags, commit.
-- [ ] Recommended order (pure logic first — highest value, already test-protected): **`avalanche.js` → `course.js` → `camera.js` → `trees.js` → `controls.js` → `effects.js` → `snow.js` → `mountains.js` → `snowman.js` → `snowglider.js`**. (`auth.js` / `scores.js` can go in parallel — they're already modules and Firebase ships its own types.)
-- [ ] Define **domain typedefs** early (in JSDoc or `types/`), since they pay off immediately:
+- [x] Add `// @ts-check` to the top of a file, run `npx tsc --noEmit`, fix what it flags, commit.
+- [x] Recommended order (pure logic first — highest value, already test-protected): **`avalanche.js` → `course.js` → `camera.js` → `trees.js` → `controls.js` → `effects.js` → `snow.js` → `mountains.js` → `snowman.js` → `snowglider.js`**. (`auth.js` / `scores.js` can go in parallel — they're already modules and Firebase ships its own types.)
+- [x] Define **domain typedefs** early (in JSDoc or `types/`), since they pay off immediately:
 
 ```ts
 /** @typedef {'start'|'racing'|'finished'|'crashed'} GamePhase */
@@ -189,8 +192,8 @@ These map straight onto state you already track (`velocity`, `verticalVelocity`,
 "typecheck": "tsc --noEmit"
 ```
 
-- [ ] Add a `typecheck` step to your existing `.github/` workflow (run it alongside `lint` and `test`).
-- [ ] Optionally gate it as `"warn"`-equivalent first (don't fail the build) until `src/` is clean, then make it blocking.
+- [x] Add a `typecheck` step to your existing `.github/` workflow (run it alongside `lint` and `test`).
+- [x] Optionally gate it as `"warn"`-equivalent first (don't fail the build) until `src/` is clean, then make it blocking.
 
 **Exit criteria for Phase 1:** every `src/*.js` has `// @ts-check`, `tsc --noEmit` is green and blocking in CI, `npm test` still green, deploy untouched. **At this point you can keep shipping features in JS indefinitely with a real safety net.** Phases 2–3 are optional and only worth it if you're committing to long-term growth.
 
@@ -219,8 +222,8 @@ export default defineConfig({
 });
 ```
 
-- [ ] Replace the CDN `<script src=".../0.160.0/three.min.js">` and the nested `src/*.js` injection in `index.html` with a single module entry: `<script type="module" src="/src/snowglider.js"></script>`. Vite resolves the import graph and ordering for you.
-- [ ] Update the GitHub Pages workflow to `npm run build` and deploy `dist/` (e.g. via `actions/deploy-pages`), keeping the `CNAME` file in the published output.
+- [x] Replace the CDN `<script src=".../0.160.0/three.min.js">` and the nested `src/*.js` injection in `index.html` with a single module entry: `<script type="module" src="/src/snowglider.js"></script>`. Vite resolves the import graph and ordering for you.
+- [x] Update the GitHub Pages workflow to `npm run build` and deploy `dist/` (e.g. via `actions/deploy-pages`), keeping the `CNAME` file in the published output.
 
 > ⚠️ **Vite does not type-check** — it strips types and bundles. Keep `tsc --noEmit` in CI as the *real* type gate. Optionally add `vite-plugin-checker` for in-editor/dev feedback.
 
@@ -275,7 +278,7 @@ The first `.ts` rename, done as a standalone PR to prove the end-to-end pipeline
   - **Array state** that inferred `never[]` is now explicitly typed (`treePositions: TreePosition[]`, scores' `LeaderboardScore[]`; `getLeaderboard()` got an explicit `Promise<LeaderboardScore[]>` return so its empty-array fallbacks stop poisoning the resolved type).
   - **Lazily-built UI handles** (`EffectsModule`'s `ui`, the course HUD) are atomic, so members became required behind a single nullable/guarded reference.
   - **Canvas + DOM lookups:** `getContext('2d')` and known-present `getElementById` results use `!` (behavior-identical — still throws if genuinely absent); optional/best-effort lookups use guards or `?.`.
-- [ ] Then ratchet the rest: `noImplicitAny` → `strictFunctionTypes` → full `"strict": true`. One flag per PR; never big-bang `strict`.
+- [x] Then ratchet the rest: `noImplicitAny` → `strictFunctionTypes` → full `"strict": true`. One flag per PR; never big-bang `strict`.
   - [x] **`noImplicitAny`** — done (`noImplicitAny: true` in `tsconfig.json`). Fixed 91 implicit-`any` spots across 7 files, behavior-preserving: the Firebase modules carried the bulk (their `let auth/firestore/analytics/currentUser` module state was untyped, poisoning every read) and are now typed with the Firebase-provided `Auth`/`Firestore`/`Analytics`/`User`/`FirebaseOptions` types; remaining params got concrete types (`number`/`string`/`THREE.Scene`/`Event`/`TerrainHeightFn`). Two index maps (`script-loader`'s `TEST_SCRIPTS`, snowglider's `techMap`) became `Record<string, …>`, and snowglider's `live` accessor object — whose `/** @type {Record<string, PropertyDescriptor>} */` JSDoc went **inert** when the file was renamed `.js`→`.ts` — got a real TS annotation (JSDoc `@type` is ignored in `.ts` files; watch for this on other renamed modules). `src/boot/local-auth.js` stays `.js`, so its `time` params use JSDoc `@param`.
   - [x] **`strictFunctionTypes`** — done (`strictFunctionTypes: true`). Zero code changes: the codebase already passes contravariant function-parameter checks. Type-only/runtime-inert flag (tsc `noEmit`; Vite strips types regardless), verified green via typecheck + lint + build.
   - [x] **`strictBindCallApply`** — done (`strictBindCallApply: true`). One fix: `firebase-bootstrap.js`'s `fetch` interceptor called `originalFetch.apply(this, arguments)` (untyped `IArguments`); now `originalFetch.call(this, url, options)` using the wrapper's already-typed params — behavior-identical. Full gate set green (incl. firebase-bootstrap 5/5, browser 87/0).

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,7 +136,10 @@ from `npm test` because the emulator requires a local Java runtime.
 ### Browser Tests
 
 Append a `?test=` parameter to the game URL to load a suite in-browser; results
-display on-screen. Available parameters:
+display on-screen. The game must be **served** (`npm start` or `npm run dev` — Vite
+on port 8080); after the ES-module migration the suites can no longer load from a
+`file://` / `open index.html` null origin (see
+[`ARCHITECTURE.md`](../docs/ARCHITECTURE.md) §2.2). Available parameters:
 
 | Parameter | Suite |
 |-----------|-------|
@@ -149,59 +152,59 @@ display on-screen. Available parameters:
 | `?test=regression` | Regression tests |
 | `?test=unified` | All suites (controls, camera, audio, gameplay, tree, avalanche, regression) |
 
-1. Open the game with the test parameter:
+1. Serve the game, then open the test URL:
 ```
-open index.html?test=true
+http://localhost:8080/?test=true
 ```
-   Or load the game in a browser with `?test=true` appended to the URL
+   (run `npm start` first; the suites need the Vite-served origin, not `file://`)
 
 2. The tests will run automatically and display results in the top-left corner of the screen
 
 ### Browser Regression Tests
 
-1. Open the game with the regression test parameter:
+1. Serve the game, then open the regression test URL:
 ```
-open index.html?test=regression
+http://localhost:8080/?test=regression
 ```
-   Or load the game in a browser with `?test=regression` appended to the URL
+   (run `npm start` first; the suites need the Vite-served origin, not `file://`)
 
 2. The regression tests will run automatically and display results in the top-left corner of the screen
 
 ### Browser Tree Collision Tests
 
-1. Open the game with the tree tests parameter:
+1. Serve the game, then open the tree tests URL:
 ```
-open index.html?test=trees
+http://localhost:8080/?test=trees
 ```
-   Or load the game in a browser with `?test=trees` appended to the URL
+   (run `npm start` first; the suites need the Vite-served origin, not `file://`)
 
 2. The tree collision tests will run automatically and display results in the top-left corner of the screen
 
 ### Browser Audio Tests
 
-1. Open the game with the audio tests parameter:
+1. Serve the game, then open the audio tests URL:
 ```
-open index.html?test=audio
+http://localhost:8080/?test=audio
 ```
-   Or load the game in a browser with `?test=audio` appended to the URL
+   (run `npm start` first; the suites need the Vite-served origin, not `file://`)
 
 2. The audio tests will run automatically and display results on the screen
 
 ### Browser Avalanche Tests
 
-1. Open the game with the avalanche tests parameter:
+1. Serve the game, then open the avalanche tests URL:
 ```
-open index.html?test=avalanche
+http://localhost:8080/?test=avalanche
 ```
-   Or load the game in a browser with `?test=avalanche` appended to the URL
+   (run `npm start` first; the suites need the Vite-served origin, not `file://`)
 
 2. The avalanche tests will run automatically and display results on the screen
 
 ### Unified Test Runner
 
-Run all tests in sequence:
+Run all tests in sequence (serve first with `npm start`):
 ```
-open index.html?test=unified
+http://localhost:8080/?test=unified
 ```
    This will run all test suites (controls, camera, audio, gameplay, tree, avalanche, regression) in sequence with a unified results display
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -223,7 +223,7 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   [`PHYSICS.md` §6](../docs/PHYSICS.md) for the seam this protects.
 - **`snowman_baseline.js`** — the frozen pre-feature snapshot of `updateSnowman`.
   Regenerate it **only** on a deliberate physics change:
-  `git show <ref>:src/snowman.js > tests/verification/snowman_baseline.js`
+  `git show <ref>:src/snowman.ts > tests/verification/snowman_baseline.js`
   (re-add the file header), then re-run `npm run test:verify`.
 - **`dom_smoke_test.js`** — boots `effects.ts` + `course.ts` under jsdom with a
   mocked THREE: both modules build their DOM/gates, the per-frame loop runs, every

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,8 +136,9 @@ from `npm test` because the emulator requires a local Java runtime.
 ### Browser Tests
 
 Append a `?test=` parameter to the game URL to load a suite in-browser; results
-display on-screen. The game must be **served** (`npm start` or `npm run dev` — Vite
-on port 8080); after the ES-module migration the suites can no longer load from a
+display on-screen. The game must be **served** — `npm start` runs Vite on port 8080
+(the `?test=` URLs below assume that port); `npm run dev` also works but uses the
+port Vite prints. After the ES-module migration the suites can no longer load from a
 `file://` / `open index.html` null origin (see
 [`ARCHITECTURE.md`](../docs/ARCHITECTURE.md) §2.2). Available parameters:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -222,10 +222,18 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   to the baseline (max abs difference `0`); the harness's exit code gates on it.
   It also confirms the snowplow brake and edge-skid scrub behave as designed. See
   [`PHYSICS.md` §6](../docs/PHYSICS.md) for the seam this protects.
-- **`snowman_baseline.js`** — the frozen pre-feature snapshot of `updateSnowman`.
-  Regenerate it **only** on a deliberate physics change:
-  `git show <ref>:src/snowman.ts > tests/verification/snowman_baseline.js`
-  (re-add the file header), then re-run `npm run test:verify`.
+- **`snowman_baseline.js`** — the frozen pre-feature snapshot of `updateSnowman`,
+  kept as a **classic script** (global `THREE`, ends in
+  `window.Snowman = { … }`, no ESM `import`/`export`) because the harness loads it via
+  `vm.runInContext` and reads `window.Snowman.updateSnowman`. Regenerate it **only** on a
+  deliberate physics change, and **not** by copying `src/snowman.ts` verbatim — that file
+  is an ES module, so a raw `git show <ref>:src/snowman.ts > …snowman_baseline.js` would
+  write `import`/`export` with no `window.Snowman` and break `npm run test:verify`. Instead
+  port the changed `updateSnowman` (and the helpers it calls) into the classic-wrapper shape
+  above: drop the `import * as THREE from 'three'` line (the harness supplies a global
+  `THREE` stub) and the `export`s, keep the trailing
+  `const Snowman = { … }; if (typeof window !== 'undefined') window.Snowman = Snowman;`
+  block, re-add the file header, then re-run `npm run test:verify`.
 - **`dom_smoke_test.js`** — boots `effects.ts` + `course.ts` under jsdom with a
   mocked THREE: both modules build their DOM/gates, the per-frame loop runs, every
   checkpoint and the finish are reached, the ghost trajectory and best splits


### PR DESCRIPTION
## What

Sweeps the GitHub issue tracker **and** the post-roadmap PR/commit history, then syncs the two docs that had drifted away from reality after the TypeScript/ESM/Vite migration (#84/#98). Rebased onto latest `main`.

### `docs/ROADMAP.md`
Everything merged since the roadmap was written is **infrastructure** (TS migration, CI hardening, test/coverage + E2E layers) — no gameplay PRs — so the Priority Findings are unchanged. Updated:
- Added a dated "since this roadmap was written" status note.
- **Refactoring Roadmap**: corrected the stale "classic browser-script / `file://` / load-bearing script order" premises; marked **Stage R1 ✅ shipped**, **R2 ◐ partial** (typed `GameState` + `src/physics.ts`); fixed `.js`→`.ts`; cited #33/#34.
- **Appendix mapping**: filled `(open)` placeholders with real issue numbers (#24/#18/#17/#2), added previously-unreferenced issues (#32/#31/#27/#25/#37), and added an Infrastructure/tooling/exploratory table (#35/#84/#98, #33, #34, #126, #29, #28, #30, #40/#36/#38/#41).

### `docs/ARCHITECTURE.md`
It still described the pre-migration design. Verified every claim against the current `src/` tree and rewrote:
- **§1/§2** — Vite-bundled TS app; ES-import graph rooted at `src/main.ts`; `file://` no longer runs the game (only the two `boot/*.js` classic scripts remain); the fixed module order is obsolete (`GAME_SCRIPT_ORDER` empty); auth/scores still injected conditionally.
- **§3** — replaced the `window.<Namespace>` table with the real ES exports and a precise "what still lives on `window`" list.
- **§4–§8** — modules import each other (only runtime deps are param-injected); typed `GameState`/`physics.ts`; `file://` is auth-fallback-only; Vite-served browser suites + Playwright e2e + raw-TS Pages guard.

### Rebase note
Rebased onto `main` after #123 (rocks) and #111 (onboarding) merged. The rocks PR had edited the *old* ARCHITECTURE.md, so I folded its notes into the rewrite: `rockPositions` in the `Mountains` row + the orchestrator-globals list, and the "Obstacle positions into physics" injection-seam bullet.

Docs-only; no `src/` changes. Statuses hedged where not fully verifiable (#29/#28); the issue tracker stays authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)