### PR TITLE
ci: don't cancel in-progress runs on main (let Pages deploys finish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ permissions:
 
 concurrency:
   group: ci-cd-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR pushes to save CI minutes, but never cancel a run on
+  # main: a push to main ends in the Pages deploy, and cancelling it mid-flight
+  # surfaces as a red "Failed to deploy" on the Deployments page (and, if it
+  # were the last successful run, could leave the site on stale content). Two
+  # merges landing seconds apart used to cancel the earlier deploy this way;
+  # letting main runs finish lets their deploys queue instead.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Problem

The github-pages deployment for PR #132 showed a red **"Failed to deploy"** even though all CI was green. It was not a real failure: the `deploy-pages` job was **cancelled** mid-flight.

Root cause is the workflow-level concurrency:

```yaml
concurrency:
  group: ci-cd-${{ github.ref }}
  cancel-in-progress: true
```

PR #132 and PR #136 merged to `main` ~3 seconds apart, so both runs shared the `ci-cd-refs/heads/main` group. Run #236 (PR #136) started while run #235 (PR #132) was still in its `deploy-pages` job, and `cancel-in-progress: true` cancelled it. Job results for run #235:

| Job | Result |
|-----|--------|
| Test | ✅ success |
| Playwright E2E | ✅ success |
| Build GitHub Pages artifact | ✅ success |
| Deploy GitHub Pages | ⛔ cancelled |

The site itself was never broken — the next merge redeployed cleanly — but a cancelled deploy renders as a scary red ❌ on the Deployments page.

## Fix

Scope `cancel-in-progress` to `pull_request` events only:

```yaml
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- PR pushes still cancel their superseded runs (saves CI minutes).
- Pushes to `main` now run to completion, so back-to-back merges **queue** their Pages deploys instead of cancelling each other — no more spurious red deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)