### PR TITLE
feat(auth): GitHub, Apple, and anonymous "Play as Guest" sign-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,22 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 
 ## Authentication Implementation
 - Use popup-only authentication flow for all devices (mobile and desktop)
+- Multiple sign-in providers wired in `auth.ts` from a `PROVIDER_BUTTONS` table:
+  Google, GitHub (`GithubAuthProvider`), Apple (`OAuthProvider('apple.com')`), plus
+  anonymous "Play as Guest" (`signInAnonymously`). Add a provider by extending that
+  table and adding a button with the matching id; a button absent from the DOM is skipped.
+- Anonymous guests are kept OUT of Firestore and the global leaderboard: `auth.ts`
+  passes `null` to `ScoresModule.setCurrentUser` and `scores.ts` `getActiveUser()`
+  skips `isAnonymous` users. A guest who later signs in with a real provider is
+  upgraded in place via `linkWithPopup` (same uid), and `syncUserData` backfills
+  their local best time to the leaderboard. Preserve this guard when touching auth/scores.
 - Set `window.FIREBASE_MANUAL_INIT = true` to prevent 404 errors 
 - Implement specialized handling for popup-blocked and popup-closed-by-user errors
 - Provide graceful degradation to localStorage when Firebase is unavailable
 - Include visual state indicators during the authentication process
 - Maintain automatic detection between development and production environments
+- GitHub/Apple require server-side Firebase console config (OAuth app; Apple Service ID);
+  the buttons exist but only succeed once those providers are enabled.
 
 ## Scoring and Leaderboard Implementation
 - User scoring and leaderboard functionality is managed by the ScoresModule in `scores.ts`

--- a/README.md
+++ b/README.md
@@ -126,7 +126,15 @@ files.
 
 #### Firebase Configuration
 1. Create a Firebase project at [console.firebase.google.com](https://console.firebase.google.com/)
-2. Enable Google Authentication in the Firebase console
+2. Enable the sign-in providers you want in the Firebase console. SnowGlider wires
+   buttons for Google, GitHub, Apple, and Anonymous ("Play as Guest"):
+   - **Google** / **Anonymous** — enable in Authentication → Sign-in method (no extra setup).
+   - **GitHub** — register a GitHub OAuth app and paste its client ID/secret into Firebase.
+   - **Apple** — requires a paid Apple Developer account and an Apple Service ID.
+   A provider button whose backend isn't enabled simply errors on click; `auth.ts`
+   skips any button absent from the DOM, so you can ship buttons incrementally. Guests
+   are anonymous: their best time stays local and is backfilled to the leaderboard only
+   if they later upgrade to a real provider (same uid, via account linking).
 3. Create a Firestore database in the Firebase console
 4. Register your web app in Firebase to get configuration keys
 5. Update the Firebase configuration in `src/boot/firebase-bootstrap.js`:

--- a/auth.html
+++ b/auth.html
@@ -95,6 +95,9 @@
         <h2>Authentication Status</h2>
         <div id="authUI">
             <button id="loginBtn">Login with Google</button>
+            <button id="githubLoginBtn">Login with GitHub</button>
+            <button id="appleLoginBtn">Sign in with Apple</button>
+            <button id="guestLoginBtn">Play as Guest</button>
         </div>
         <div id="profileUI">
             <img id="profileAvatar" src="" alt="Profile">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,7 +112,7 @@ by name. The per-module `window.*` namespace bridges that used to link them were
 | `AvalancheSystem` | `avalanche.ts` | `class` | Instanced snow-boulder physics & burial |
 | `EffectsModule` | `effects.ts` | IIFE | Avalanche warning UI + camera FOV/shake |
 | `CourseModule` | `course.ts` | IIFE | Gates, split timing, ghost racing, result screen |
-| `AuthModule` | `auth.ts` | ES module | Firebase auth, user UI, Firestore lifecycle (also `window.AuthModule`) |
+| `AuthModule` | `auth.ts` | ES module | Multi-provider Firebase auth (Google/GitHub/Apple/anonymous), user UI, Firestore lifecycle (also `window.AuthModule`) |
 | `ScoresModule` | `scores.ts` | ES module | Best-time recording, leaderboard, Firestore writes (also `window.ScoresModule`) |
 
 ### What still lives on `window`
@@ -214,6 +214,19 @@ state, so keyboard and touch are interchangeable. Button touch handlers wire
 ---
 
 ## 7. Auth, scoring & persistence
+
+**Sign-in providers.** `auth.ts` offers popup-based **Google, GitHub, and Apple**
+sign-in plus an **anonymous "Play as Guest"** option. Each `#authUI` button is wired
+by id from a `PROVIDER_BUTTONS` table (Google `signInWithPopup`, GitHub
+`GithubAuthProvider`, Apple `OAuthProvider('apple.com')`) with `signInAsGuest`
+calling `signInAnonymously`; a button absent from the DOM is skipped, so markup can
+ship ahead of the server-side provider config. A signed-in **anonymous guest who
+picks a real provider is upgraded in place via `linkWithPopup`** (same uid, progress
+carries over); if that provider account already exists it falls back to a normal
+`signInWithPopup`. Anonymous guests are deliberately kept **out of Firestore and the
+global leaderboard** — `auth.ts` passes `null` to `ScoresModule.setCurrentUser` and
+`scores.ts` `getActiveUser()` skips `isAnonymous` users — so a guest's best time
+stays in `localStorage` until they upgrade, at which point `syncUserData` backfills it.
 
 Three runtime modes, auto-detected:
 

--- a/index.html
+++ b/index.html
@@ -161,8 +161,23 @@
   <!-- Auth Container -->
   <div id="authContainer">
     <div id="authUI">
-      <button id="loginBtn">
+      <!--
+        Provider buttons. GitHub/Apple only work once their providers are enabled
+        in the Firebase console (GitHub OAuth app; Apple Service ID). auth.ts wires
+        each by id and skips any that are absent, so buttons can ship ahead of the
+        server-side config without breaking sign-in.
+      -->
+      <button id="loginBtn" class="provider-btn provider-google">
         <span>Login with Google</span>
+      </button>
+      <button id="githubLoginBtn" class="provider-btn provider-github">
+        <span>Login with GitHub</span>
+      </button>
+      <button id="appleLoginBtn" class="provider-btn provider-apple">
+        <span>Sign in with Apple</span>
+      </button>
+      <button id="guestLoginBtn" class="provider-btn provider-guest">
+        <span>Play as Guest</span>
       </button>
     </div>
     <div id="profileUI">

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -188,7 +188,6 @@ function handleSignedInUser(user: User) {
   console.log("Auth state changed: User IS signed in", user.uid, user.email,
     user.isAnonymous ? '(anonymous guest)' : '');
   currentUser = user;
-  updateUIForLoggedInUser(user);
 
   // Anonymous guests are intentionally kept OUT of Firestore and the global
   // leaderboard: they have no displayName/email and would show up as "Anonymous".
@@ -197,8 +196,14 @@ function handleSignedInUser(user: User) {
   // provider (linkWithPopup, same uid), this runs again with isAnonymous === false
   // and syncUserData backfills that local best to the leaderboard.
   if (user.isAnonymous) {
+    // Keep the provider buttons (#authUI) visible so the guest can upgrade IN
+    // PLACE via linkWithPopup — those buttons are the only entry point to the
+    // upgrade flow, so the full logged-in chrome (which hides #authUI) would make
+    // it unreachable. Show a lightweight "Guest" indicator + logout alongside.
+    updateUIForGuestUser();
     ScoresModule.setCurrentUser(null);
   } else {
+    updateUIForLoggedInUser(user);
     // Update user in ScoresModule AFTER UI updates to ensure proper sequence
     ScoresModule.setCurrentUser(user);
     if (firestore) {
@@ -271,11 +276,33 @@ function updateUIForLoggedInUser(user: User) {
 function updateUIForLoggedOutUser() {
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
-  
+
   if (!authUI || !profileUI) return;
-  
+
   authUI.style.display = 'flex';
   profileUI.style.display = 'none';
+}
+
+// Update UI for an anonymous "guest" session. Unlike a fully logged-in user, we
+// keep the provider buttons (#authUI) visible so the guest can upgrade in place
+// (a provider click becomes a linkWithPopup on the same uid). We also show a small
+// "Guest" profile + logout so they can see they're playing as a guest and can end
+// the session. The provider button labels double as the "sign in to save" affordance.
+function updateUIForGuestUser() {
+  const authUI = document.getElementById('authUI');
+  const profileUI = document.getElementById('profileUI');
+  const profileName = document.getElementById('profileName');
+  const profileAvatar = document.getElementById('profileAvatar') as HTMLImageElement;
+
+  if (!authUI || !profileUI) {
+    console.error("updateUIForGuestUser: Could not find authUI or profileUI elements!");
+    return;
+  }
+
+  authUI.style.display = 'flex';     // keep provider buttons available for upgrade
+  profileUI.style.display = 'flex';  // show the guest indicator + logout
+  if (profileName) profileName.textContent = 'Guest';
+  if (profileAvatar) profileAvatar.style.display = 'none';
 }
 
 // Provider metadata for the buttons in #authUI. Each federated provider maps a

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
 // auth.ts - Firebase Authentication module for SnowGlider
-// Uses Firebase modular SDK (Popup-only Google Sign-In)
+// Uses Firebase modular SDK (popup-based federated sign-in + anonymous guest)
 //
 // Phase 3.8 (issue #84): renamed `.js` -> `.ts`. The `@ts-check` pragma is gone
 // (implied for a real `.ts` file). The module keeps its existing Firebase-typed
@@ -17,11 +17,21 @@ window.__FIREBASE_DEFAULTS__ = {}; // Ensure this exists early
 /**
  * Firebase Authentication Module for SnowGlider
  *
- * This module handles user authentication (Google Popup) and profile management.
- * Score tracking and leaderboard functionality have been moved to scores.js.
+ * This module handles user authentication and profile management. Score tracking
+ * and leaderboard functionality have been moved to scores.js.
+ *
+ * Sign-in methods (all popup-based; see PROVIDER_BUTTONS + signInAsGuest):
+ * - Google, GitHub, and Apple via signInWithPopup
+ * - Anonymous "play as guest" via signInAnonymously
+ * - Guests upgrade in place via linkWithPopup so their uid/best-time carries over
+ *
+ * Provider availability is gated by the Firebase console: GitHub needs an OAuth
+ * app, Apple needs an Apple Service ID (paid Apple Developer Program). A button
+ * absent from the DOM is simply skipped, so the markup can ship a provider before
+ * it is enabled server-side without breaking sign-in.
  *
  * Features:
- * - Google authentication with signInWithPopup
+ * - Multi-provider authentication with signInWithPopup / signInAnonymously
  * - User profile management
  * - Integration with ScoresModule for best time tracking
  */
@@ -37,13 +47,19 @@ let firebaseApp: FirebaseApp | null = null; // Keep track of the app instance
 import {
   getAuth,
   GoogleAuthProvider,
-  signInWithPopup, // Using popup exclusively
+  GithubAuthProvider,
+  OAuthProvider, // Apple (and other generic OAuth) via OAuthProvider('apple.com')
+  signInWithPopup, // Popup flow for every federated provider
+  signInAnonymously, // "Play as guest" — no account required
+  linkWithPopup, // Upgrade a guest in place so their uid + progress carries over
   signOut as firebaseSignOut,
   onAuthStateChanged,
   setPersistence,
   browserLocalPersistence,
   type User,
   type Auth,
+  type AuthProvider,
+  type UserCredential,
 } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-auth.js";
 import {
   getFirestore,
@@ -125,53 +141,19 @@ function initializeAuth(firebaseConfig: FirebaseOptions) {
       // Set up auth state observer - This handles UI updates after login/logout
       console.log("Attaching onAuthStateChanged listener..."); // Log before attaching
       onAuthStateChanged(auth, user => {
-        // --- Edit 1: Add detailed logging inside the callback ---
         console.log(">>> onAuthStateChanged triggered <<<"); // Log entry into the callback
         if (user) {
-          // User is signed in
-          console.log("Auth state changed: User IS signed in", user.uid, user.email);
-          currentUser = user;
-          console.log("Calling updateUIForLoggedInUser..."); // Log before UI update
-          updateUIForLoggedInUser(user);
-          
-          // Update user in ScoresModule AFTER UI updates to ensure proper sequence
-          console.log("Updating ScoresModule with current user..."); // Log before update
-          ScoresModule.setCurrentUser(user);
-          
-          if (firestore) {
-            // Use setTimeout to ensure auth state is fully stabilized before syncing
-            setTimeout(() => {
-              console.log("Calling syncUserData with delay..."); // Log before sync
-              syncUserData(user); // Sync data if firestore is available
-            }, 100); // Small delay to ensure auth state stabilizes
-          }
-          console.log("Calling resetLoginButton..."); // Log before reset
-          resetLoginButton(); // Ensure button is in default state after successful login
-          notifyAuthChanged(); // Let read-only consumers (e.g. start screen) refresh
-          console.log("Finished processing signed-in state in onAuthStateChanged."); // Log completion
+          handleSignedInUser(user);
         } else {
-          // User is signed out
-          console.log("Auth state changed: User IS signed out");
-          currentUser = null;
-          
-          // Clear user in ScoresModule
-          ScoresModule.setCurrentUser(null);
-          
-          console.log("Calling updateUIForLoggedOutUser..."); // Log before UI update
-          updateUIForLoggedOutUser();
-          console.log("Calling resetLoginButton..."); // Log before reset
-          resetLoginButton(); // Ensure button is in default state after logout
-          notifyAuthChanged(); // Let read-only consumers (e.g. start screen) refresh
-          console.log("Finished processing signed-out state in onAuthStateChanged."); // Log completion
+          handleSignedOutUser();
         }
-        // --- End Edit 1 ---
       });
       console.log("onAuthStateChanged listener attached successfully."); // Confirm attachment
     } else {
       // Handle case where auth failed to initialize
       console.error("Auth service failed to initialize. Auth features disabled.");
       updateUIForLoggedOutUser(); // Show logged-out state
-      resetLoginButton(); // Ensure button is usable (though login will fail)
+      resetAuthButtons(); // Ensure buttons are usable (though login will fail)
     }
   } catch (e) {
     // Catch errors during initializeApp or other setup steps
@@ -179,7 +161,7 @@ function initializeAuth(firebaseConfig: FirebaseOptions) {
     console.error("Firebase setup failed:", err.message, err.stack);
     auth = firestore = analytics = null; // Ensure services are null on failure
     updateUIForLoggedOutUser();
-    resetLoginButton();
+    resetAuthButtons();
   }
 
   // Set up login/logout buttons (even if auth failed, to avoid errors)
@@ -197,6 +179,48 @@ function notifyAuthChanged() {
   } catch (e) {
     console.warn("Could not dispatch snowglider:auth-changed event:", e);
   }
+}
+
+// Apply the signed-in state. Shared by the onAuthStateChanged listener and the
+// guest-upgrade path (linkWithPopup keeps the same uid and may not re-fire the
+// observer), so both routes drive identical UI + scoring updates.
+function handleSignedInUser(user: User) {
+  console.log("Auth state changed: User IS signed in", user.uid, user.email,
+    user.isAnonymous ? '(anonymous guest)' : '');
+  currentUser = user;
+  updateUIForLoggedInUser(user);
+
+  // Anonymous guests are intentionally kept OUT of Firestore and the global
+  // leaderboard: they have no displayName/email and would show up as "Anonymous".
+  // We tell ScoresModule there is no signed-in user, so a guest's best time is
+  // tracked locally (localStorage) only. When they later upgrade to a real
+  // provider (linkWithPopup, same uid), this runs again with isAnonymous === false
+  // and syncUserData backfills that local best to the leaderboard.
+  if (user.isAnonymous) {
+    ScoresModule.setCurrentUser(null);
+  } else {
+    // Update user in ScoresModule AFTER UI updates to ensure proper sequence
+    ScoresModule.setCurrentUser(user);
+    if (firestore) {
+      // Small delay to ensure auth state is fully stabilized before syncing
+      setTimeout(() => syncUserData(user), 100);
+    }
+  }
+
+  resetAuthButtons(); // Ensure buttons are in default state after successful login
+  notifyAuthChanged(); // Let read-only consumers (e.g. start screen) refresh
+  console.log("Finished processing signed-in state.");
+}
+
+// Apply the signed-out state (also covers a failed/cleared session).
+function handleSignedOutUser() {
+  console.log("Auth state changed: User IS signed out");
+  currentUser = null;
+  ScoresModule.setCurrentUser(null); // Clear user in ScoresModule
+  updateUIForLoggedOutUser();
+  resetAuthButtons(); // Ensure buttons are in default state after logout
+  notifyAuthChanged(); // Let read-only consumers (e.g. start screen) refresh
+  console.log("Finished processing signed-out state.");
 }
 
 // Update UI when user is logged in
@@ -254,97 +278,211 @@ function updateUIForLoggedOutUser() {
   profileUI.style.display = 'none';
 }
 
-// Reset login button to default state
-function resetLoginButton() {
-  const loginBtn = document.getElementById('loginBtn') as HTMLButtonElement;
-  if (loginBtn) {
-    loginBtn.textContent = 'Login with Google';
-    loginBtn.disabled = false;
-    loginBtn.classList.remove('signing-in');
-    // No longer need 'retry-auth' class related to redirect failures
-    loginBtn.classList.remove('retry-auth');
+// Provider metadata for the buttons in #authUI. Each federated provider maps a
+// button id -> default label + analytics method + a factory that builds a fresh
+// Firebase auth provider (providers are single-use, so we build one per sign-in).
+// The anonymous `guestLoginBtn` has no provider and is wired separately.
+type ProviderButton = {
+  id: string;
+  label: string;
+  method: string;
+  makeProvider: () => AuthProvider;
+};
+
+const PROVIDER_BUTTONS: ProviderButton[] = [
+  {
+    id: 'loginBtn',
+    label: 'Login with Google',
+    method: 'GooglePopup',
+    makeProvider: () => {
+      const provider = new GoogleAuthProvider();
+      provider.addScope('profile');
+      provider.addScope('email');
+      provider.setCustomParameters({ prompt: 'select_account' }); // Prompt account picker
+      return provider;
+    }
+  },
+  {
+    id: 'githubLoginBtn',
+    label: 'Login with GitHub',
+    method: 'GitHubPopup',
+    makeProvider: () => {
+      const provider = new GithubAuthProvider();
+      provider.addScope('read:user'); // Public profile only; no repo scopes
+      return provider;
+    }
+  },
+  {
+    id: 'appleLoginBtn',
+    label: 'Sign in with Apple',
+    method: 'ApplePopup',
+    makeProvider: () => {
+      const provider = new OAuthProvider('apple.com');
+      provider.addScope('email');
+      provider.addScope('name');
+      return provider;
+    }
   }
+];
+
+const GUEST_BUTTON = { id: 'guestLoginBtn', label: 'Play as Guest' };
+
+// Every auth button that should be enabled/disabled/reset together.
+function allAuthButtonMeta() {
+  return [...PROVIDER_BUTTONS, GUEST_BUTTON];
+}
+
+// Reset all present auth buttons to their default, enabled state. (Replaces the
+// old single-button resetLoginButton; a missing button id is simply skipped.)
+function resetAuthButtons() {
+  allAuthButtonMeta().forEach(({ id, label }) => {
+    const btn = document.getElementById(id) as HTMLButtonElement | null;
+    if (!btn) return;
+    btn.textContent = label;
+    btn.disabled = false;
+    btn.classList.remove('signing-in');
+    btn.classList.remove('retry-auth'); // legacy redirect-retry class
+  });
+}
+
+// Mark a sign-in as in flight: disable every auth button (so a second provider
+// can't open a competing popup) and show the active one as "Signing In...".
+function setAuthButtonsBusy(activeBtn: HTMLButtonElement) {
+  allAuthButtonMeta().forEach(({ id }) => {
+    const btn = document.getElementById(id) as HTMLButtonElement | null;
+    if (!btn) return;
+    btn.disabled = true;
+    if (btn === activeBtn) {
+      btn.textContent = 'Signing In...';
+      btn.classList.add('signing-in');
+    }
+  });
+}
+
+// Shared sign-in error handling for every provider and the guest path.
+function handleSignInError(error: { code?: string; message?: string }) {
+  console.error("Sign-in error:", error.code, error.message);
+  if (error.code === 'auth/popup-blocked') {
+    alert('Popup blocked by browser. Please allow popups for this site and try again.');
+  } else if (error.code === 'auth/popup-closed-by-user' ||
+             error.code === 'auth/cancelled-popup-request') {
+    // Benign: the user closed the popup, or a second sign-in superseded this one
+    // (rapid double-tap). Don't alert — just allow a retry.
+    console.log('Sign-in cancelled (popup closed or superseded):', error.code);
+  } else if (error.code === 'auth/account-exists-with-different-credential') {
+    // The email is already linked to a different provider.
+    alert('An account already exists with this email using a different sign-in method. ' +
+          'Please sign in with that method instead.');
+  } else {
+    alert(`Error during sign-in: ${error.message}`);
+  }
+  resetAuthButtons(); // Re-enable buttons on any error to allow a retry
+}
+
+// Federated (Google/GitHub/Apple) popup sign-in. If the current user is an
+// anonymous guest we LINK the credential to their uid (upgrade in place) so their
+// session and best time carry over; if that provider account already exists we
+// fall back to a normal sign-in (the local best time still reconciles through
+// syncUserData on the resulting auth-state change).
+function runProviderSignIn(meta: ProviderButton, btn: HTMLButtonElement) {
+  if (btn.disabled) return; // already in flight
+
+  if (!auth) {
+    console.error("Auth service not available. Cannot sign in.");
+    alert("Authentication service is currently unavailable. Please try again later.");
+    resetAuthButtons();
+    return;
+  }
+
+  setAuthButtonsBusy(btn);
+  const provider = meta.makeProvider();
+  const guest = auth.currentUser;
+  const upgrading = !!guest && guest.isAnonymous;
+  console.log(`Sign-in initiated (${meta.method})${upgrading ? ' as guest upgrade' : ''}.`);
+
+  // Tracks whether we upgraded the guest IN PLACE (linkWithPopup kept the same
+  // uid). Only that path applies the user directly, because it may not re-fire
+  // onAuthStateChanged. The credential-already-in-use fallback below is a real new
+  // sign-in (different uid), which the observer DOES fire for — so we leave it off.
+  let linkedInPlace = false;
+
+  const flow: Promise<UserCredential> = upgrading
+    ? linkWithPopup(guest!, provider)
+        .then(result => { linkedInPlace = true; return result; })
+        .catch(error => {
+          if (error.code === 'auth/credential-already-in-use' ||
+              error.code === 'auth/email-already-in-use') {
+            console.log('Guest upgrade: provider account already exists, signing in instead.');
+            return signInWithPopup(auth!, provider);
+          }
+          throw error;
+        })
+    : signInWithPopup(auth, provider);
+
+  flow
+    .then(result => {
+      console.log(`Popup sign-in successful (${meta.method}) for:`, result.user.email);
+      if (analytics) {
+        logEvent(analytics, 'login', { method: meta.method });
+      }
+      if (linkedInPlace) {
+        handleSignedInUser(result.user);
+      }
+    })
+    .catch(handleSignInError);
+}
+
+// Anonymous "play as guest" — no account, no popup. onAuthStateChanged then runs
+// with isAnonymous === true, which keeps the guest out of the global leaderboard.
+function signInAsGuest(btn: HTMLButtonElement) {
+  if (btn.disabled) return;
+
+  if (!auth) {
+    console.error("Auth service not available. Cannot start guest session.");
+    alert("Authentication service is currently unavailable. Please try again later.");
+    resetAuthButtons();
+    return;
+  }
+
+  setAuthButtonsBusy(btn);
+  console.log("Guest sign-in initiated (anonymous).");
+  signInAnonymously(auth)
+    .then(result => {
+      console.log("Guest (anonymous) sign-in successful:", result.user.uid);
+      if (analytics) {
+        logEvent(analytics, 'login', { method: 'Anonymous' });
+      }
+    })
+    .catch(handleSignInError);
+}
+
+// Bind click + touchend for an auth button. We bind both because, on the game
+// page, controls.js installs a document-level touchstart preventDefault that
+// suppresses the synthetic click — so touch sign-in must also fire from 'touchend',
+// which is still a valid popup user-activation gesture. onActivate preventDefaults
+// (so a tap won't also emit a click) and each sign-in path bails while the button
+// is disabled, so the pair can't open two popups. 'touchend' (not 'touchstart') is
+// deliberate: touchstart fires before the tap completes and is a weaker popup
+// gesture on iOS.
+function bindAuthButton(id: string, handler: (btn: HTMLButtonElement) => void) {
+  const btn = document.getElementById(id) as HTMLButtonElement | null;
+  if (!btn) return;
+  const onActivate = (e: Event) => {
+    if (e) e.preventDefault();
+    handler(btn);
+  };
+  btn.addEventListener('click', onActivate);
+  btn.addEventListener('touchend', onActivate, { passive: false });
 }
 
 // Set up login/logout button handlers
 function setupAuthButtons() {
-  // Login button
-  const loginBtn = document.getElementById('loginBtn') as HTMLButtonElement;
-  if (loginBtn) {
-    // Function to handle sign-in process using Popup
-    const handleSignIn = (e: Event) => {
-      if (e) e.preventDefault(); // Prevent default button action
-
-      // Ignore repeat taps while a sign-in is already in flight. The button is
-      // disabled below, but this also guards against any environment that fires
-      // a second activation before the disabled state takes effect.
-      if (loginBtn.disabled) {
-        return;
-      }
-
-      // Check if auth is available before attempting login
-      if (!auth) {
-          console.error("Auth service not available. Cannot sign in.");
-          alert("Authentication service is currently unavailable. Please try again later.");
-          resetLoginButton(); // Reset button state
-          return;
-      }
-
-      // Update button state
-      loginBtn.textContent = 'Signing In...';
-      loginBtn.disabled = true;
-      loginBtn.classList.add('signing-in');
-
-      console.log("Sign-in initiated via", e ? e.type : 'programmatic');
-
-      const provider = new GoogleAuthProvider();
-      provider.addScope('profile');
-      provider.addScope('email');
-      provider.setCustomParameters({ 'prompt': 'select_account' }); // Prompt user to select account
-
-      console.log("Using signInWithPopup for authentication.");
-      signInWithPopup(auth, provider)
-        .then(result => {
-          // Success is primarily handled by onAuthStateChanged listener
-          console.log("Popup sign-in successful for:", result.user.email);
-          if (analytics) {
-            logEvent(analytics, 'login', { method: 'GooglePopup' });
-          }
-          // No need to reset button here; onAuthStateChanged will update UI
-        })
-        .catch(error => {
-          console.error("signInWithPopup error:", error.code, error.message);
-          // Provide user feedback for common errors
-          if (error.code === 'auth/popup-blocked') {
-             alert('Popup blocked by browser. Please allow popups for this site and try again.');
-          } else if (error.code === 'auth/popup-closed-by-user' ||
-                     error.code === 'auth/cancelled-popup-request') {
-             // Benign: the user closed the popup, or a second sign-in superseded
-             // this one (rapid double-tap). Don't alert — just allow a retry.
-             console.log('Sign-in cancelled (popup closed or superseded):', error.code);
-          } else {
-             // Generic error message for other issues
-             alert(`Error during sign-in: ${error.message}`);
-          }
-          // Reset button on any popup error to allow retry
-          resetLoginButton();
-        });
-    };
-
-    // Sign-in must work on both desktop and touch. We bind 'touchend' AND 'click':
-    //  - On the game page, Controls.setupControls() (controls.js) installs a
-    //    document-level touchstart preventDefault, which suppresses the synthetic
-    //    click on this button — so a 'click'-only handler would never fire after the
-    //    game scripts load. 'touchend' is a valid user-activation gesture for
-    //    signInWithPopup that the global handler does NOT suppress.
-    //  - On desktop (no touch) only 'click' fires.
-    // handleSignIn calls preventDefault() (so the touchend tap won't also emit a
-    // click) and bails while the button is disabled, so the pair can't open two
-    // popups. We deliberately use 'touchend', not 'touchstart': touchstart fires
-    // before the tap completes and is a weaker popup gesture on iOS.
-    loginBtn.addEventListener('click', handleSignIn);
-    loginBtn.addEventListener('touchend', handleSignIn, { passive: false });
-  }
+  // Federated provider buttons (Google always present; GitHub/Apple optional).
+  PROVIDER_BUTTONS.forEach(meta => {
+    bindAuthButton(meta.id, btn => runProviderSignIn(meta, btn));
+  });
+  // Anonymous guest button (optional).
+  bindAuthButton(GUEST_BUTTON.id, signInAsGuest);
 
   // Logout button
   const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement;
@@ -565,4 +703,4 @@ const AuthModule = {
 export default AuthModule;
 window.AuthModule = AuthModule;
 
-console.log("Auth module (popup-only) successfully loaded and exported");
+console.log("Auth module (multi-provider popup + guest) successfully loaded and exported");

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -115,7 +115,12 @@ function getActiveUser() {
 
   try {
     const authStateUser = authModule.getAuthState?.()?.user || authModule.getCurrentUser?.();
-    if (authStateUser) {
+    // Anonymous "guest" users have no leaderboard identity: AuthModule still
+    // reports them as signed in (so the UI shows logged-in chrome), but their best
+    // time must stay local until they upgrade to a real provider (which reuses the
+    // same uid and re-fires this path with isAnonymous === false). Skipping them
+    // here ensures a guest finishing a run never writes to users/leaderboard.
+    if (authStateUser && !authStateUser.isAnonymous) {
       currentUser = authStateUser;
       return authStateUser;
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -356,8 +356,9 @@ canvas { display: block; }
     padding: 3px;
   }
 
-  /* Make login button smaller on mobile */
-  #loginBtn {
+  /* Make provider buttons smaller on mobile */
+  #loginBtn,
+  .provider-btn {
     font-size: 12px;
     padding: 4px 8px;
   }
@@ -489,8 +490,43 @@ canvas { display: block; }
 */
 #authUI {
   display: flex;
-  align-items: center;
+  flex-direction: column; /* Stack the provider buttons in the narrow panel */
+  align-items: stretch;
+  gap: 6px;
 }
+/*
+ * Shared base for every provider button. #loginBtn keeps its own block below for
+ * the Google brand color and the ripple ::after; the GitHub/Apple/Guest buttons
+ * inherit structure here and set only their brand color.
+ */
+.provider-btn {
+  color: white;
+  border: none;
+  padding: 10px 18px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  transition: transform 0.1s ease, background-color 0.2s ease;
+  min-height: 36px;
+  position: relative;
+}
+.provider-btn:active, .provider-btn.signing-in {
+  transform: scale(0.98);
+}
+.provider-github { background-color: #24292e; }
+.provider-github:hover { background-color: #1b1f23; }
+.provider-apple { background-color: #000000; }
+.provider-apple:hover { background-color: #1a1a1a; }
+.provider-guest { background-color: #555555; }
+.provider-guest:hover { background-color: #444444; }
 #loginBtn {
   background-color: #4285F4;
   color: white;

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -14,7 +14,12 @@ const { JSDOM } = require('jsdom');
 
 // ---- jsdom environment with the auth UI markup auth.js expects ----
 const dom = new JSDOM(`<!doctype html><html><body>
-  <div id="authUI" style="display:flex"><button id="loginBtn">Login with Google</button></div>
+  <div id="authUI" style="display:flex">
+    <button id="loginBtn">Login with Google</button>
+    <button id="githubLoginBtn">Login with GitHub</button>
+    <button id="appleLoginBtn">Sign in with Apple</button>
+    <button id="guestLoginBtn">Play as Guest</button>
+  </div>
   <div id="profileUI" style="display:none">
     <img id="profileAvatar" src=""><span id="profileName"></span>
     <button id="logoutBtn">Logout</button>
@@ -189,6 +194,98 @@ async function main() {
   loginBtn.dispatchEvent(new window.Event('click'));
   await flush();
   check('unknown error: shows a generic alert', alerts.length === 1 && /boom/.test(alerts[0]));
+
+  console.log('\n--- GitHub & Apple provider sign-in ---');
+  const githubBtn = window.document.getElementById('githubLoginBtn');
+  const appleBtn = window.document.getElementById('appleLoginBtn');
+
+  // GitHub: a federated popup logged with method 'GitHubPopup'.
+  fb.setNextPopupResult({ resolve: { user: { email: 'gh@glider.ai' } } });
+  const popupsBeforeGh = calls.signInWithPopup;
+  githubBtn.dispatchEvent(new window.Event('click'));
+  check('GitHub button opens a popup and shows "Signing In..."',
+    calls.signInWithPopup === popupsBeforeGh + 1 &&
+    githubBtn.disabled === true && /Signing In/.test(githubBtn.textContent));
+  check('starting one sign-in disables the other provider buttons too (no competing popups)',
+    loginBtn.disabled === true && appleBtn.disabled === true);
+  await flush();
+  check("'login' analytics logged with GitHubPopup method",
+    calls.logEvent.some(e => e.name === 'login' && e.params && e.params.method === 'GitHubPopup'));
+  fb.emitAuthState(null); // settle to signed-out, re-enable buttons
+
+  // Apple: OAuthProvider('apple.com') popup logged with method 'ApplePopup'.
+  fb.setNextPopupResult({ resolve: { user: { email: 'apple@glider.ai' } } });
+  const popupsBeforeApple = calls.signInWithPopup;
+  appleBtn.dispatchEvent(new window.Event('click'));
+  await flush();
+  check('Apple button opens a popup', calls.signInWithPopup === popupsBeforeApple + 1);
+  check("'login' analytics logged with ApplePopup method",
+    calls.logEvent.some(e => e.name === 'login' && e.params && e.params.method === 'ApplePopup'));
+  fb.emitAuthState(null);
+
+  console.log('\n--- Anonymous "play as guest" ---');
+  const guestBtn = window.document.getElementById('guestLoginBtn');
+  fb.setNextPopupResult(null);
+  const anonBefore = calls.signInAnonymously;
+  const popupsBeforeGuest = calls.signInWithPopup;
+  guestBtn.dispatchEvent(new window.Event('click'));
+  check('guest button calls signInAnonymously and opens no popup',
+    calls.signInAnonymously === anonBefore + 1 && calls.signInWithPopup === popupsBeforeGuest);
+  await flush();
+  check("'login' analytics logged with Anonymous method",
+    calls.logEvent.some(e => e.name === 'login' && e.params && e.params.method === 'Anonymous'));
+
+  // Firebase reports the anonymous user. The guest is kept OFF the leaderboard:
+  // recordScore must not write a Firestore identity even though logged-in chrome shows.
+  localStorage.clear();
+  fb.emitAuthState({ uid: 'guest1', isAnonymous: true, email: null, displayName: null });
+  check('anonymous guest: logged-in chrome shown (profile UI)',
+    authUI.style.display === 'none' && profileUI.style.display === 'flex');
+  check('anonymous guest: AuthModule still reports signed-in (for UI/onboarding)',
+    AuthModule.isUserSignedIn() === true);
+  AuthModule.recordScore(12.34); // guest finishes a run
+  await flush();
+  check('anonymous guest: recordScore writes NO leaderboard entry for the guest',
+    fb.read('leaderboard', 'guest1') === undefined &&
+    !calls.setDoc.some(c => c.path === 'leaderboard/guest1'));
+  localStorage.clear(); // isolate from the backstop test below
+  fb.emitAuthState(null);
+
+  console.log('\n--- Guest upgrade (link in place) ---');
+  // A signed-in anonymous guest upgrading via a provider LINKS (keeps the uid)
+  // rather than opening a fresh signInWithPopup, so their progress carries over.
+  fb.setAuthCurrentUser({ uid: 'guest1', isAnonymous: true });
+  fb.setNextLinkResult({ resolve: { user: { uid: 'guest1', isAnonymous: false, email: 'gh@glider.ai', displayName: 'GH' } } });
+  const linksBefore = calls.linkWithPopup;
+  const popupsBeforeUpgrade = calls.signInWithPopup;
+  githubBtn.dispatchEvent(new window.Event('click'));
+  await flush();
+  check('guest upgrade: uses linkWithPopup (keeps uid), not signInWithPopup',
+    calls.linkWithPopup === linksBefore + 1 && calls.signInWithPopup === popupsBeforeUpgrade);
+  check('guest upgrade: applies the now-named user directly (uid preserved, no longer anonymous)',
+    !!AuthModule.getAuthState().user && AuthModule.getAuthState().user.uid === 'guest1' &&
+    AuthModule.getAuthState().user.isAnonymous === false);
+  await new Promise(r => setTimeout(r, 120)); // drain the upgrade's syncUserData timer while localStorage is clear
+  await flush();
+  fb.setAuthCurrentUser(null);
+  fb.emitAuthState(null);
+
+  // Fallback: the provider account already exists -> linkWithPopup rejects with
+  // credential-already-in-use -> fall back to a normal signInWithPopup.
+  fb.setAuthCurrentUser({ uid: 'guest2', isAnonymous: true });
+  fb.setNextLinkResult({ reject: { code: 'auth/credential-already-in-use', message: 'exists' } });
+  fb.setNextPopupResult({ resolve: { user: { uid: 'existing1', email: 'existing@glider.ai', displayName: 'Existing' } } });
+  const linksBefore2 = calls.linkWithPopup;
+  const popupsBefore2 = calls.signInWithPopup;
+  appleBtn.dispatchEvent(new window.Event('click'));
+  await flush();
+  await flush();
+  check('guest upgrade fallback: link rejects -> signInWithPopup is used instead',
+    calls.linkWithPopup === linksBefore2 + 1 && calls.signInWithPopup === popupsBefore2 + 1);
+  fb.setAuthCurrentUser(null);
+  fb.emitAuthState(null);
+  fb.setNextPopupResult(null);
+  fb.setNextLinkResult(null);
 
   console.log('\n--- syncUserData login backstop + id token + direct sign-out ---');
   // A valid local best present at sign-in must be backfilled by the delayed

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -239,8 +239,12 @@ async function main() {
   // recordScore must not write a Firestore identity even though logged-in chrome shows.
   localStorage.clear();
   fb.emitAuthState({ uid: 'guest1', isAnonymous: true, email: null, displayName: null });
-  check('anonymous guest: logged-in chrome shown (profile UI)',
-    authUI.style.display === 'none' && profileUI.style.display === 'flex');
+  // The provider buttons (#authUI) MUST stay visible for a guest, since a provider
+  // click is the only entry point to the in-place upgrade (linkWithPopup). The guest
+  // also gets a lightweight "Guest" profile + logout.
+  check('anonymous guest: provider buttons stay visible for in-place upgrade',
+    authUI.style.display === 'flex' && profileUI.style.display === 'flex' &&
+    window.document.getElementById('profileName').textContent === 'Guest');
   check('anonymous guest: AuthModule still reports signed-in (for UI/onboarding)',
     AuthModule.isUserSignedIn() === true);
   AuthModule.recordScore(12.34); // guest finishes a run

--- a/tests/mocks/firebase.mjs
+++ b/tests/mocks/firebase.mjs
@@ -34,13 +34,16 @@ export const calls = {
   logEvent: [],
   // firebase-auth.js call counters (used by the auth harness)
   signInWithPopup: 0,
+  signInAnonymously: 0,
+  linkWithPopup: 0,
   signOut: 0,
   setPersistence: 0
 };
 
 // firebase-auth.js control surface, driven by the auth harness.
 let authStateCallback = null; // the onAuthStateChanged listener auth.ts registers
-let nextPopupResult = null;   // controls how the next signInWithPopup resolves/rejects
+let nextPopupResult = null;   // controls how the next signInWithPopup/signInAnonymously resolves/rejects
+let nextLinkResult = null;    // controls how the next linkWithPopup resolves/rejects (guest upgrade)
 
 // Sentinels handed back to callers that ask the SDK for the service instances.
 export const firestoreInstance = { __firestore: true };
@@ -89,6 +92,8 @@ export function reset() {
   calls.getDocs = [];
   calls.logEvent = [];
   calls.signInWithPopup = 0;
+  calls.signInAnonymously = 0;
+  calls.linkWithPopup = 0;
   calls.signOut = 0;
   calls.setPersistence = 0;
   pendingWritePath = null;
@@ -96,6 +101,8 @@ export function reset() {
   timestampCounter = 0;
   authStateCallback = null;
   nextPopupResult = null;
+  nextLinkResult = null;
+  authInstance.currentUser = null;
 }
 
 export function seed(collectionName, id, value) {
@@ -265,12 +272,70 @@ export class GoogleAuthProvider {
   }
 }
 
+// GitHub provider — same shape as Google (no-arg constructor).
+export class GithubAuthProvider {
+  constructor() {
+    this.providerId = 'github.com';
+    this.scopes = [];
+    this.params = {};
+  }
+  addScope(scope) {
+    this.scopes.push(scope);
+  }
+  setCustomParameters(params) {
+    this.params = params;
+  }
+}
+
+// Generic OAuth provider — Apple uses new OAuthProvider('apple.com').
+export class OAuthProvider {
+  constructor(providerId) {
+    this.providerId = providerId;
+    this.scopes = [];
+    this.params = {};
+  }
+  addScope(scope) {
+    this.scopes.push(scope);
+  }
+  setCustomParameters(params) {
+    this.params = params;
+  }
+}
+
 export function signInWithPopup() {
   calls.signInWithPopup++;
   if (nextPopupResult && nextPopupResult.reject) {
     return Promise.reject(nextPopupResult.reject);
   }
   return Promise.resolve(nextPopupResult ? nextPopupResult.resolve : { user: { email: 'x@y.z' } });
+}
+
+// Anonymous "play as guest". Shares nextPopupResult for error injection; the
+// default resolves to a fresh anonymous user (isAnonymous: true, no email).
+export function signInAnonymously() {
+  calls.signInAnonymously++;
+  if (nextPopupResult && nextPopupResult.reject) {
+    return Promise.reject(nextPopupResult.reject);
+  }
+  return Promise.resolve(
+    nextPopupResult && nextPopupResult.resolve
+      ? nextPopupResult.resolve
+      : { user: { uid: 'anon-1', isAnonymous: true, email: null, displayName: null } }
+  );
+}
+
+// Upgrade a guest in place. Driven by setNextLinkResult so the harness can model
+// both a clean link and the credential-already-in-use fallback to signInWithPopup.
+export function linkWithPopup(user, _provider) {
+  calls.linkWithPopup++;
+  if (nextLinkResult && nextLinkResult.reject) {
+    return Promise.reject(nextLinkResult.reject);
+  }
+  return Promise.resolve(
+    nextLinkResult
+      ? nextLinkResult.resolve
+      : { user: { ...user, isAnonymous: false, email: 'upgraded@glider.ai', displayName: 'Upgraded' } }
+  );
 }
 
 // auth.ts imports this as `signOut as firebaseSignOut`.
@@ -292,9 +357,19 @@ export const browserLocalPersistence = { __persistence: 'local' };
 
 // ---- auth test control surface ----
 
-/** Set how the next signInWithPopup() resolves: { resolve } or { reject }. */
+/** Set how the next signInWithPopup()/signInAnonymously() resolves: { resolve } or { reject }. */
 export function setNextPopupResult(result) {
   nextPopupResult = result;
+}
+
+/** Set how the next linkWithPopup() (guest upgrade) resolves: { resolve } or { reject }. */
+export function setNextLinkResult(result) {
+  nextLinkResult = result;
+}
+
+/** Seed auth.currentUser so the guest-upgrade branch (isAnonymous) can be driven. */
+export function setAuthCurrentUser(user) {
+  authInstance.currentUser = user;
 }
 
 /** The onAuthStateChanged listener auth.ts registered (null until initializeAuth). */


### PR DESCRIPTION
## What & why

Follow-up to a design discussion: rather than adopt a server-first library like better-auth (which would require standing up a backend + SQL DB and breaks the thin-client / static-GitHub-Pages / light-Firebase constraints), this gets the same user-facing wins — **more sign-in options + robustness** — *inside* Firebase with zero new infrastructure.

Adds **GitHub**, **Apple**, and an anonymous **"Play as Guest"** option alongside the existing Google popup sign-in.

## Changes

**`src/auth.ts`**
- Every `#authUI` button is driven from a `PROVIDER_BUTTONS` table: Google (`signInWithPopup`), GitHub (`GithubAuthProvider`), Apple (`OAuthProvider('apple.com')`), plus `signInAsGuest` → `signInAnonymously`. A button **absent from the DOM is skipped**, so markup can ship ahead of the server-side provider config.
- Refactored the Google-only `handleSignIn` into a shared `runProviderSignIn` + `setAuthButtonsBusy` / `resetAuthButtons` / `handleSignInError`, and factored the `onAuthStateChanged` branches into `handleSignedInUser` / `handleSignedOutUser`. **All existing Google behavior is preserved** (button states, `GooglePopup` analytics, the `touchend` gesture path, benign popup-error handling).
- **Guest upgrade:** a signed-in anonymous guest who picks a real provider is upgraded **in place via `linkWithPopup`** (same uid, progress carries over); on `credential-already-in-use` it falls back to a normal `signInWithPopup`.

**Keep guests off the global leaderboard** (the subtle part)
- `auth.ts` passes `null` to `ScoresModule.setCurrentUser` for anonymous users.
- `scores.ts` `getActiveUser()` now skips `isAnonymous` users — without this, its `AuthModule.getAuthState()` fallback would recover the guest and write them to the leaderboard as "Anonymous".
- A guest's best time stays in `localStorage` until they upgrade, at which point `syncUserData` backfills it.

**HTML/CSS** — buttons added to `index.html` + `auth.html`; `#authUI` stacked vertically in the narrow auth panel with a shared `.provider-btn` base + brand colors.

**Tests** — `tests/mocks/firebase.mjs` extended with `GithubAuthProvider`, `OAuthProvider`, `signInAnonymously`, `linkWithPopup` and a `setAuthCurrentUser`/`setNextLinkResult` control surface (required because `auth.ts` uses static named imports — a missing export breaks module link at test time). 13 new assertions cover GitHub/Apple/guest/upgrade/fallback + the guest-leaderboard guard.

## Validation
- `test:auth` **43/43**, `test:scores` **34/34**, `test:start-menu` 37, `test:controls` 22, `test:contract` 44, `test:verify` (DOM smoke 18 + physics invariants)
- `tsc --noEmit` clean · `eslint` 0 errors · `npm run build` succeeds

## Server-side config still required
GitHub needs a Firebase OAuth app; Apple needs an Apple Service ID (paid Apple Developer Program). The buttons exist but only succeed once those providers are enabled in the Firebase console — see updated README. Mobile popup behavior for the new providers is **not yet verified on real devices**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — server-side providers enabled (2026-06-19)

The Firebase `sn0wglider` project now has the matching providers enabled, so these buttons work end-to-end once merged:

| Provider | Server-side status |
|---|---|
| Anonymous ("Play as Guest") | ✅ enabled (was already on) |
| Google | ✅ enabled |
| **GitHub** | ✅ **enabled** (OAuth app registered via Identity Toolkit Admin API) |
| Apple | ⏳ manual (Apple Developer portal) — not done |

GitHub OAuth App callback must be `https://sn0wglider.firebaseapp.com/__/auth/handler`; GitHub reuses the same Firebase *Authorized domains* list as Google. Real-device popup behavior for the new providers is still unverified.

## Addressed Codex review (P2)

Codex flagged that `handleSignedInUser` hid `#authUI` for anonymous guests, making the in-place upgrade (`linkWithPopup`) unreachable since the provider buttons live in `#authUI`. Fixed in `883463c`: anonymous users now use `updateUIForGuestUser()`, which keeps the provider buttons visible (they double as the "sign in to save" upgrade affordance) plus a "Guest" indicator + logout. Added a regression assertion. Auth tests 43/43.
