### PR TITLE
refactor(ui): extract shared collapsible-panel from snowglider.ts (R2.1, #34)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,6 +201,17 @@ camera.position -= shake                          // revert so smoothing stays c
  showGameOver(reason) ─→ Course.onFinish ─→ Scores.recordScore ─→ (localStorage + Firestore)
 ```
 
+> **Refactor in progress (Stages R2/R3, see
+> [`REFACTORING_SNOWGLIDER_SNOWMAN.md`](REFACTORING_SNOWGLIDER_SNOWMAN.md)):**
+> `snowglider.ts` is being thinned into `src/game/*` (scene / loop / lifecycle) and
+> `src/ui/*` (HUD, overlays), and `snowman.ts` into `src/snowman/*`. Mechanical,
+> behavior-preserving moves only — the published `window.*` hooks and the
+> `publishGameGlobals()` proxy set stay in the coordinator. The first extracted
+> piece is **`src/ui/collapsible-panel.ts`**, the shared collapse / resize /
+> horizontal-swipe behavior for the Game Stats and Game Controls panels that was
+> previously duplicated across `initializeGameStats()` and
+> `initializeControlsToggle()`.
+
 ---
 
 ## 6. Input

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -38,6 +38,7 @@ import { AudioModule } from './audio.js';
 import { Physics } from './physics.js';
 import type { RockPosition } from './mountains.js';
 import type { TreePosition } from './trees.js';
+import { setupCollapsiblePanel } from './ui/collapsible-panel.js';
 
 // Get keyboard controls from the Controls module
 Controls.setupControls();
@@ -334,78 +335,18 @@ state.bestTime = readStoredBestTime();
 
 // Initialize game stats functionality
 function initializeGameStats() {
-  console.log("Initializing game stats");
   const bestTimeElement = document.getElementById('bestTimeValue');
   if (bestTimeElement) {
     bestTimeElement.textContent = state.bestTime !== Infinity ? `${state.bestTime.toFixed(2)}s` : '--';
   }
-  
-  // Add game stats toggle functionality
-  const statsContainer = document.getElementById('gameStatsContainer');
-  const toggleStatsBtn = document.getElementById('toggleStats');
-  const statsHeader = document.getElementById('gameStatsHeader');
-  
-  if (statsContainer && toggleStatsBtn && statsHeader) {
-    console.log("Setting up game stats toggle");
-    // Function to toggle stats visibility
-    const toggleStats = function() {
-      console.log("Toggle stats called, current state:", statsContainer.classList.contains('collapsed'));
-      statsContainer.classList.toggle('collapsed');
-      toggleStatsBtn.textContent = statsContainer.classList.contains('collapsed') ? '▼' : '▲';
-    };
-    
-    // Add click and touch event listeners
-    toggleStatsBtn.addEventListener('click', function(e) {
-      console.log("Toggle button clicked");
-      e.stopPropagation();
-      toggleStats();
-    });
-    
-    statsHeader.addEventListener('click', function(e) {
-      console.log("Stats header clicked");
-      toggleStats();
-    });
-    
-    statsHeader.addEventListener('touchend', function(e) {
-      console.log("Stats header touch end");
-      e.preventDefault();
-      toggleStats();
-    }, { passive: false });
-    
-    // Add horizontal swipe handler for the stats window
-    let touchStartX = 0;
-    
-    statsHeader.addEventListener('touchstart', function(e) {
-      touchStartX = e.touches[0].clientX;
-    }, { passive: true });
-    
-    statsHeader.addEventListener('touchmove', function(e) {
-      const touchX = e.touches[0].clientX;
-      const diff = touchX - touchStartX;
-      
-      // If swiping left and stats expanded, collapse them
-      if (diff < -30 && !statsContainer.classList.contains('collapsed')) {
-        console.log("Swipe left detected, collapsing");
-        statsContainer.classList.add('collapsed');
-        toggleStatsBtn.textContent = '▼';
-        e.preventDefault();
-      }
-      
-      // If swiping right and stats collapsed, expand them
-      if (diff > 30 && statsContainer.classList.contains('collapsed')) {
-        console.log("Swipe right detected, expanding");
-        statsContainer.classList.remove('collapsed');
-        toggleStatsBtn.textContent = '▲';
-        e.preventDefault();
-      }
-    }, { passive: false });
-  } else {
-    console.warn("Game stats elements not found:", {
-      statsContainer: !!statsContainer,
-      toggleStatsBtn: !!toggleStatsBtn,
-      statsHeader: !!statsHeader
-    });
-  }
+
+  // Game stats panel collapse/swipe behavior (shared with the Controls panel).
+  setupCollapsiblePanel({
+    name: 'game stats',
+    containerId: 'gameStatsContainer',
+    toggleButtonId: 'toggleStats',
+    headerId: 'gameStatsHeader',
+  });
 }
 
 // Initialize the stats display when DOM is loaded
@@ -1009,126 +950,17 @@ restartButton.addEventListener('click', restartGame);
 
 // Function to initialize controls toggle
 function initializeControlsToggle() {
-  console.log("Initializing controls toggle");
-  const controlsInfo = document.getElementById('controlsInfo');
-  const toggleButton = document.getElementById('toggleControls');
-  const controlsHeader = document.getElementById('controlsHeader');
-  const controlsContent = document.getElementById('controlsContent');
-  
-  if (controlsInfo && toggleButton && controlsHeader) {
-    console.log("Setting up controls toggle");
-    
-    // Ensure previous event listeners are removed (if possible)
-    try {
-      controlsHeader.replaceWith(controlsHeader.cloneNode(true));
-      const newControlsHeader = document.getElementById('controlsHeader')!;
-      const newToggleButton = document.getElementById('toggleControls')!;
-
-      // Setup the toggle functionality
-      const toggleControls = function() {
-        console.log("Toggle controls called, current state:", controlsInfo.classList.contains('collapsed'));
-        if (controlsInfo.classList.contains('collapsed')) {
-          controlsInfo.classList.remove('collapsed');
-          newToggleButton.textContent = '▲';
-        } else {
-          controlsInfo.classList.add('collapsed');
-          newToggleButton.textContent = '▼';
-        }
-      };
-      
-      // Add click listener to both the button and header
-      newToggleButton.addEventListener('click', function(e) {
-        console.log("Controls toggle button clicked");
-        e.stopPropagation(); // Prevent triggering the header click
-        toggleControls();
-      });
-      
-      newControlsHeader.addEventListener('click', function(e) {
-        console.log("Controls header clicked");
-        toggleControls();
-      });
-      
-      // Add touch events for better mobile experience
-      newControlsHeader.addEventListener('touchend', function(e) {
-        console.log("Controls header touch end");
-        e.preventDefault(); // Prevent default touch behavior
-        toggleControls();
-      }, { passive: false });
-      
-      // Auto-collapse on small screens
-      const handleScreenSizeChange = () => {
-        if (window.innerWidth <= 480 || 
-            (window.innerWidth <= 768 && window.innerHeight <= 500)) {
-          // Auto-collapse on small screens and landscape mobile
-          if (!controlsInfo.classList.contains('collapsed')) {
-            console.log("Auto-collapsing controls for small screen");
-            controlsInfo.classList.add('collapsed');
-            newToggleButton.textContent = '▼';
-          }
-        }
-      };
-      
-      // Check on resize
-      window.addEventListener('resize', handleScreenSizeChange);
-      
-      // Check on initial load
-      handleScreenSizeChange();
-      
-      // Add horizontal swipe handler for the controls (like Game Stats)
-      let touchStartX = 0;
-      
-      newControlsHeader.addEventListener('touchstart', function(e) {
-        touchStartX = e.touches[0].clientX;
-      }, { passive: true });
-      
-      newControlsHeader.addEventListener('touchmove', function(e) {
-        const touchX = e.touches[0].clientX;
-        const diff = touchX - touchStartX;
-        
-        // If swiping left and controls expanded, collapse them
-        if (diff < -30 && !controlsInfo.classList.contains('collapsed')) {
-          console.log("Swipe left detected, collapsing controls");
-          controlsInfo.classList.add('collapsed');
-          newToggleButton.textContent = '▼';
-          e.preventDefault();
-        }
-        
-        // If swiping right and controls collapsed, expand them
-        if (diff > 30 && controlsInfo.classList.contains('collapsed')) {
-          console.log("Swipe right detected, expanding controls");
-          controlsInfo.classList.remove('collapsed');
-          newToggleButton.textContent = '▲';
-          e.preventDefault();
-        }
-      }, { passive: false });
-    } catch (e) {
-      console.error("Error setting up controls toggle:", e);
-      
-      // Fall back to simple toggle without cloning
-      const toggleControls = function() {
-        if (controlsInfo.classList.contains('collapsed')) {
-          controlsInfo.classList.remove('collapsed');
-          toggleButton.textContent = '▲';
-        } else {
-          controlsInfo.classList.add('collapsed');
-          toggleButton.textContent = '▼';
-        }
-      };
-      
-      toggleButton.addEventListener('click', function(e) {
-        e.stopPropagation();
-        toggleControls();
-      });
-      
-      controlsHeader.addEventListener('click', toggleControls);
-    }
-  } else {
-    console.warn("Controls elements not found:", {
-      controlsInfo: !!controlsInfo,
-      toggleButton: !!toggleButton,
-      controlsHeader: !!controlsHeader
-    });
-  }
+  // Controls panel collapse/swipe behavior (shared with the Game Stats panel).
+  // Resets stale listeners and auto-collapses on small screens — this is invoked
+  // more than once (DOMContentLoaded + initializeGameWithAudio).
+  setupCollapsiblePanel({
+    name: 'controls',
+    containerId: 'controlsInfo',
+    toggleButtonId: 'toggleControls',
+    headerId: 'controlsHeader',
+    resetListeners: true,
+    autoCollapseOnSmallScreens: true,
+  });
 }
 
 // Initialize controls toggle when DOM is loaded

--- a/src/ui/collapsible-panel.ts
+++ b/src/ui/collapsible-panel.ts
@@ -1,0 +1,167 @@
+// Shared collapse / resize / horizontal-swipe behavior for the in-game HUD panels
+// (Game Stats and Game Controls). Extracted from snowglider.ts, which previously
+// carried two near-identical copies of this logic in initializeGameStats() and
+// initializeControlsToggle(). The two panels differ only in a couple of opt-in
+// behaviors (listener reset + small-screen auto-collapse), so those are flags here
+// and the rest is unified — behavior is preserved per panel.
+
+export interface CollapsiblePanelOptions {
+  /** Human label used in the diagnostic console logs. */
+  name: string;
+  /** id of the outer container that gets the `collapsed` class toggled. */
+  containerId: string;
+  /** id of the ▲/▼ toggle button (re-fetched after a header clone). */
+  toggleButtonId: string;
+  /** id of the clickable / swipeable header. */
+  headerId: string;
+  /**
+   * Replace the header node with a clone first so any listeners attached by a
+   * previous call are dropped (the Controls panel is initialized more than once).
+   * When false the existing nodes are wired directly (the Stats panel behavior).
+   */
+  resetListeners?: boolean;
+  /**
+   * Auto-collapse on small / landscape-mobile screens and keep watching resize
+   * (Controls panel only).
+   */
+  autoCollapseOnSmallScreens?: boolean;
+}
+
+// Wire the collapse toggle, click/touch handlers, optional small-screen
+// auto-collapse, and the horizontal swipe gesture onto a resolved header/button.
+function wirePanel(
+  container: HTMLElement,
+  toggleButton: HTMLElement,
+  header: HTMLElement,
+  name: string,
+  autoCollapseOnSmallScreens: boolean,
+): void {
+  const setCollapsed = function(collapsed: boolean) {
+    container.classList.toggle('collapsed', collapsed);
+    toggleButton.textContent = collapsed ? '▼' : '▲';
+  };
+
+  const toggle = function() {
+    console.log(`Toggle ${name} called, current state:`, container.classList.contains('collapsed'));
+    setCollapsed(!container.classList.contains('collapsed'));
+  };
+
+  // Add click and touch event listeners
+  toggleButton.addEventListener('click', function(e) {
+    console.log(`${name} toggle button clicked`);
+    e.stopPropagation(); // Prevent triggering the header click
+    toggle();
+  });
+
+  header.addEventListener('click', function() {
+    console.log(`${name} header clicked`);
+    toggle();
+  });
+
+  header.addEventListener('touchend', function(e) {
+    console.log(`${name} header touch end`);
+    e.preventDefault();
+    toggle();
+  }, { passive: false });
+
+  // Auto-collapse on small screens and landscape mobile
+  if (autoCollapseOnSmallScreens) {
+    const handleScreenSizeChange = function() {
+      if (window.innerWidth <= 480 ||
+          (window.innerWidth <= 768 && window.innerHeight <= 500)) {
+        if (!container.classList.contains('collapsed')) {
+          console.log(`Auto-collapsing ${name} for small screen`);
+          setCollapsed(true);
+        }
+      }
+    };
+    window.addEventListener('resize', handleScreenSizeChange);
+    handleScreenSizeChange();
+  }
+
+  // Add horizontal swipe handler for the panel
+  let touchStartX = 0;
+
+  header.addEventListener('touchstart', function(e) {
+    touchStartX = e.touches[0].clientX;
+  }, { passive: true });
+
+  header.addEventListener('touchmove', function(e) {
+    const touchX = e.touches[0].clientX;
+    const diff = touchX - touchStartX;
+
+    // If swiping left and panel expanded, collapse it
+    if (diff < -30 && !container.classList.contains('collapsed')) {
+      console.log(`Swipe left detected, collapsing ${name}`);
+      setCollapsed(true);
+      e.preventDefault();
+    }
+
+    // If swiping right and panel collapsed, expand it
+    if (diff > 30 && container.classList.contains('collapsed')) {
+      console.log(`Swipe right detected, expanding ${name}`);
+      setCollapsed(false);
+      e.preventDefault();
+    }
+  }, { passive: false });
+}
+
+// Fallback used when the header clone/refetch path throws: a bare toggle with no
+// touch or swipe support (matches the previous initializeControlsToggle catch path).
+function wireFallback(container: HTMLElement, toggleButton: HTMLElement, header: HTMLElement): void {
+  const toggle = function() {
+    if (container.classList.contains('collapsed')) {
+      container.classList.remove('collapsed');
+      toggleButton.textContent = '▲';
+    } else {
+      container.classList.add('collapsed');
+      toggleButton.textContent = '▼';
+    }
+  };
+
+  toggleButton.addEventListener('click', function(e) {
+    e.stopPropagation();
+    toggle();
+  });
+
+  header.addEventListener('click', toggle);
+}
+
+// Set up a collapsible HUD panel. Idempotent for panels that pass
+// `resetListeners` (it clones the header to drop stale listeners first).
+export function setupCollapsiblePanel(options: CollapsiblePanelOptions): void {
+  const { name, containerId, toggleButtonId, headerId } = options;
+  console.log(`Initializing ${name} toggle`);
+
+  const container = document.getElementById(containerId);
+  const toggleButton = document.getElementById(toggleButtonId);
+  const header = document.getElementById(headerId);
+
+  if (!(container && toggleButton && header)) {
+    console.warn(`${name} elements not found:`, {
+      container: !!container,
+      toggleButton: !!toggleButton,
+      header: !!header,
+    });
+    return;
+  }
+
+  console.log(`Setting up ${name} toggle`);
+
+  if (!options.resetListeners) {
+    wirePanel(container, toggleButton, header, name, !!options.autoCollapseOnSmallScreens);
+    return;
+  }
+
+  // Ensure previous event listeners are removed (if possible) by replacing the
+  // header with a clone, then re-resolving the cloned header/button by id.
+  try {
+    header.replaceWith(header.cloneNode(true));
+    const newHeader = document.getElementById(headerId)!;
+    const newToggleButton = document.getElementById(toggleButtonId)!;
+    wirePanel(container, newToggleButton, newHeader, name, !!options.autoCollapseOnSmallScreens);
+  } catch (e) {
+    console.error(`Error setting up ${name} toggle:`, e);
+    wireFallback(container, toggleButton, header);
+  }
+}


### PR DESCRIPTION
## What

First step of the **R2/R3 refactor** operationalized in
[`docs/REFACTORING_SNOWGLIDER_SNOWMAN.md`](https://github.com/den-run-ai/snowglider/blob/main/docs/REFACTORING_SNOWGLIDER_SNOWMAN.md)
(merged in #140), implementing **issue #34**.

Extracts the shared HUD-panel **collapse / resize / horizontal-swipe** behavior —
previously two near-identical copies in `initializeGameStats()` and
`initializeControlsToggle()` inside `src/snowglider.ts` — into a new
**`src/ui/collapsible-panel.ts`** (`setupCollapsiblePanel`). `snowglider.ts` drops
~188 lines of duplication.

## Behavior preserved (mechanical move only)

The two panels differed only in two opt-in behaviors, kept as flags so nothing
changes at runtime:

- **Game Stats** — wires the existing nodes directly (no listener reset, no
  small-screen auto-collapse), exactly as before.
- **Game Controls** — clones the header to drop stale listeners (it is initialized
  more than once: `DOMContentLoaded` + `initializeGameWithAudio`) and auto-collapses
  on small / landscape-mobile screens, with the same `try/catch` fallback.

No change to the published `window.*` hooks or the `publishGameGlobals()` proxy set
— both stay in the coordinator. This is purely the dedupe the proposal flagged
("removes real duplication, not just lines").

## Verification

- `npm run lint` — 0 errors (new file adds 0 warnings)
- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm test` (Node suites, incl. the **contract-surface guard** from #142) — 44/44
- `npm run build` (Vite) — green
- `npm run test:browser` (puppeteer) — **87/87 across 7/7 suites**

## Stacking

This is PR **1 of the R2/R3 sequence** (steps 2–6 thin `snowglider.ts` into
`src/game/*` + `src/ui/*`; steps 7–12 split `snowman.ts` into `src/snowman/*`).
Targets `main`; later PRs stack on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)