### PR TITLE
feat(sky): visible sky — gradient + Preetham atmospheric sky & fog (#2)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,6 +104,7 @@ by name. The per-module `window.*` namespace bridges that used to link them were
 | `Mountains` | `mountains.ts` | object + fns | Terrain height field, gradient, mesh, rocks / `rockPositions`, `SimplexNoise` |
 | `Trees` | `trees.ts` | object + fns | Tree meshes + placement; returns `treePositions` |
 | `Snow` | `snow.ts` | object + fns | Snowflakes + ski snow-splash particles |
+| `Sky` | `sky.ts` | object + fns | Gradient sky dome + horizon distance fog (issue #2) |
 | `Camera` | `camera.ts` | `class Camera` | Chase/orbit camera positioning & look-ahead |
 | `Snowman` | `snowman.ts` | object + fns | Snowman model, `updateSnowman` physics, test hooks |
 | `Physics` | `physics.ts` | object + fns | Typed per-frame `PlayerState` container over the snowman kernel |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,7 +104,7 @@ by name. The per-module `window.*` namespace bridges that used to link them were
 | `Mountains` | `mountains.ts` | object + fns | Terrain height field, gradient, mesh, rocks / `rockPositions`, `SimplexNoise` |
 | `Trees` | `trees.ts` | object + fns | Tree meshes + placement; returns `treePositions` |
 | `Snow` | `snow.ts` | object + fns | Snowflakes + ski snow-splash particles |
-| `Sky` | `sky.ts` | object + fns | Gradient sky dome + horizon distance fog (issue #2) |
+| `Sky` | `sky.ts` | object + fns | Preetham atmospheric sky + sun & horizon distance fog (gradient-dome fallback), issue #2 |
 | `Camera` | `camera.ts` | `class Camera` | Chase/orbit camera positioning & look-ahead |
 | `Snowman` | `snowman.ts` | object + fns | Snowman model, `updateSnowman` physics, test hooks |
 | `Physics` | `physics.ts` | object + fns | Typed per-frame `PlayerState` container over the snowman kernel |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,20 +13,32 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
-### Visible sky — gradient sky + distance fog (#2)
+### Visible sky — gradient sky, atmospheric sky + sun, distance fog (#2)
 - Replaced the flat `scene.background = Color(0x87CEEB)` (and no fog) with a
-  graduated sky and matching horizon fog, in a new `src/sky.ts` module
-  (`Sky.applyGradientSky`).
-- The sky is a large `BackSide` dome whose vertex shader pins it to the far plane
+  graduated sky and matching horizon fog, in a new `src/sky.ts` module.
+- **Tier 1 — gradient sky + fog (`Sky.applyGradientSky`, kept as a fallback):**
+  a large `BackSide` dome whose vertex shader pins it to the far plane
   (`gl_Position.z = gl_Position.w`), so it behaves as a skybox: it never clips
   against the camera far plane and fills every pixel not covered by scene
   geometry. The gradient is evaluated per-pixel from the view direction so it
   tracks the chase camera's pitch.
-- `scene.fog` is a linear fog tinted to the dome's horizon colour, tuned to keep
-  the gameplay area crisp (`near = 140`) and fade only distant terrain / the far
+- **Tier 2 — atmospheric sky + sun (`Sky.applyAtmosphericSky`, what the game
+  uses):** the Preetham daylight model ported from three.js's
+  `examples/jsm/objects/Sky.js`, inlined so it imports only bare `three` (a
+  `three/addons/*` specifier would 404 on the verbatim-copied dist `?test=`
+  pages). The sun direction is the scene's directional-light position, so the
+  visible sun disc and the cast shadows agree. Scattering params lean slightly
+  clearer than three's ACES demo because the project runs the legacy colour
+  pipeline (no tone mapping); an `exposure` uniform stands in for
+  `renderer.toneMappingExposure`.
+- `scene.fog` is a linear fog tinted to the horizon colour, tuned to keep the
+  gameplay area crisp (`near = 140`) and fade only distant terrain / the far
   peak (`far = 750`) so the slope no longer hard-cuts at the far plane.
 - Purely visual: no physics, collision, scoring, or lighting changes (the
   directional light and its shadows are untouched).
+- The exact sky look (turbidity / rayleigh / exposure / fog tint) was set under
+  the legacy pipeline and is tunable — eyeball on-device and adjust the
+  constants in `src/sky.ts` if needed.
 
 ### Skiing skill — carve vs. skid speed trade-off (#48 / #54)
 - Deepened the ski-technique model (P1 of [`ROADMAP.md`](ROADMAP.md)) from the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,21 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Visible sky — gradient sky + distance fog (#2)
+- Replaced the flat `scene.background = Color(0x87CEEB)` (and no fog) with a
+  graduated sky and matching horizon fog, in a new `src/sky.ts` module
+  (`Sky.applyGradientSky`).
+- The sky is a large `BackSide` dome whose vertex shader pins it to the far plane
+  (`gl_Position.z = gl_Position.w`), so it behaves as a skybox: it never clips
+  against the camera far plane and fills every pixel not covered by scene
+  geometry. The gradient is evaluated per-pixel from the view direction so it
+  tracks the chase camera's pitch.
+- `scene.fog` is a linear fog tinted to the dome's horizon colour, tuned to keep
+  the gameplay area crisp (`near = 140`) and fade only distant terrain / the far
+  peak (`far = 750`) so the slope no longer hard-cuts at the far plane.
+- Purely visual: no physics, collision, scoring, or lighting changes (the
+  directional light and its shadows are untouched).
+
 ### Skiing skill — carve vs. skid speed trade-off (#48 / #54)
 - Deepened the ski-technique model (P1 of [`ROADMAP.md`](ROADMAP.md)) from the
   intentionally-thin #56 first pass into a real speed-management trade-off: a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,9 +111,9 @@ Timer/best-time and leaderboard existed, but there was no reason to play 20 runs
 
 A skiing game lives on speed readability and mountain atmosphere.
 
-- **Shipped:** speed-based FOV (widens at speed) and camera shake on hard landings / avalanche proximity.
-- **Remaining (○):** snow trails carved from the back of the skis, weather variation and a day→sunset→night skybox, stronger slope contrast and obstacle silhouettes, depth cues, a readable horizon, and an intro fly-over of the mountain.
-- **Open issues:** intro fly-over (**#51**), plus open issues on lighting/shadows, snow/tree/rock/snowman textures, and a visible sky.
+- **Shipped:** speed-based FOV (widens at speed), camera shake on hard landings / avalanche proximity, and a **visible sky** — a Preetham atmospheric sky with a sun aligned to the directional light, plus horizon distance fog so terrain reads with depth instead of hard-cutting at the far plane (**#2**, `src/sky.ts`).
+- **Remaining (○):** snow trails carved from the back of the skis, weather variation and a day→sunset→night skybox (the sky module is a static daytime sky for now), stronger slope contrast and obstacle silhouettes, depth cues, and an intro fly-over of the mountain.
+- **Open issues:** intro fly-over (**#51**), plus open issues on lighting/shadows and snow/tree/rock/snowman textures. Visible sky (**#2**) is ◐ partial — static sky shipped; clouds / day-night cycle remain.
 
 ### 8. Audio consistency and completion — ○ open
 
@@ -322,7 +322,7 @@ Many recommendations align with the maintainer's backlog, which is a good sign t
 | Gyro/tilt controls | #24 | ○ open |
 | Lighting and shadows | #18 | ○ open |
 | Textures (snow, trees, rocks, snowman) | #17 | ○ open |
-| Visible sky | #2 | ○ open |
+| Visible sky | #2 | ◐ partial — atmospheric sky + sun + horizon fog shipped (`src/sky.ts`); clouds / day-night cycle open |
 
 ### Infrastructure, tooling & exploratory
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import './mountains.js';
 import './snow.js';
 import './snowman.js';
 import './audio.js';
+import './sky.js';
 
 /** Revision of the three.js build pulled from npm and bundled by Vite. */
 export const BUNDLED_THREE_REVISION = THREE.REVISION;

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -7,10 +7,15 @@
 // mountain reads with depth and a horizon instead of a flat wall of blue
 // (issue #2 — "visible sky").
 //
-// Tier 1 (this commit): a vertical-gradient sky dome plus linear distance fog
-// tinted to the horizon colour, so distant terrain fades into the sky rather
-// than popping at the far plane. Tier 2 layers the Preetham atmospheric model
-// and a sun on top — see `applyAtmosphericSky` once it lands.
+// Tier 1: a vertical-gradient sky dome plus linear distance fog tinted to the
+// horizon colour (`applyGradientSky`), so distant terrain fades into the sky
+// rather than popping at the far plane. Kept as a lightweight fallback.
+//
+// Tier 2: the Preetham atmospheric-scattering model plus a sun disc
+// (`applyAtmosphericSky`) — a physically-motivated graduated sky whose sun is
+// aligned with the scene's directional light so the sky and the cast shadows
+// agree. This is what the game uses; see the `SKY_SHADER` note for the legacy
+// colour-pipeline caveat.
 //
 // Implementation notes:
 // - The dome is a large box with `BackSide` + `depthWrite: false`, and the
@@ -95,10 +100,207 @@ function applyGradientSky(scene: THREE.Scene): void {
   scene.add(createGradientDome());
 }
 
+// --- Tier 2: Preetham atmospheric sky -------------------------------------
+//
+// Ported from three.js's `examples/jsm/objects/Sky.js` (the de-facto Preetham
+// daylight model). It is inlined here rather than imported from
+// `three/addons/*` deliberately: the verbatim-copied `dist/src/*.js` browser
+// `?test=` pages only rewrite/copy the bare-`three` build graph, so a
+// `three/addons/objects/Sky.js` specifier would 404 on the deployed test pages.
+// This module imports only named symbols from bare `three`, so it resolves
+// identically across the Vite bundle, the raw-source import map, and the dist
+// test pages.
+//
+// Colour-pipeline caveat: the project runs the legacy pipeline
+// (`ColorManagement.enabled = false`, linear output, no tone mapping), which is
+// the era this shader was originally tuned for, so it renders a recognisable
+// sky without ACES. The `#include <tonemapping_fragment>` / `<colorspace_fragment>`
+// chunks are kept for forward-compat but are no-ops under the current renderer
+// settings; an explicit `exposure` uniform stands in for the
+// `renderer.toneMappingExposure` knob the addon would otherwise use.
+
+// Scattering parameters (tunable). With no tone mapping (legacy pipeline) the
+// shader's HDR output would clip the green/blue channels to white across most of
+// the sky at the addon's usual exposure, so `SKY_EXPOSURE` is set low to keep
+// the whole dome in-gamut: this yields zenith ≈ (88,136,196), mid-sky ≈
+// (122,182,237) and a pale, hazy horizon ≈ (209,229,235) — a cheerful clear-sky
+// blue that brackets the old flat 0x87CEEB without any channel clipping. The
+// numbers were chosen by evaluating the fragment math directly; eyeball and
+// adjust if the on-device look differs.
+const SKY_TURBIDITY = 8.0;
+const SKY_RAYLEIGH = 3.0;
+const SKY_MIE_COEFFICIENT = 0.005;
+const SKY_MIE_DIRECTIONAL_G = 0.8;
+const SKY_EXPOSURE = 0.35;
+
+// Distance fog tuned to the atmospheric horizon colour (a pale, hazy blue) so
+// terrain fades into the sky seamlessly. Same near/far envelope as the gradient
+// sky so the gameplay area stays crisp.
+const ATMOSPHERE_FOG_COLOR = 0xd1e5eb;
+
+const SKY_SHADER = {
+  uniforms: {
+    turbidity: { value: SKY_TURBIDITY },
+    rayleigh: { value: SKY_RAYLEIGH },
+    mieCoefficient: { value: SKY_MIE_COEFFICIENT },
+    mieDirectionalG: { value: SKY_MIE_DIRECTIONAL_G },
+    exposure: { value: SKY_EXPOSURE },
+    sunPosition: { value: new THREE.Vector3() },
+    up: { value: new THREE.Vector3(0, 1, 0) }
+  },
+  vertexShader: /* glsl */`
+    uniform vec3 sunPosition;
+    uniform float rayleigh;
+    uniform float turbidity;
+    uniform float mieCoefficient;
+    uniform vec3 up;
+
+    varying vec3 vWorldPosition;
+    varying vec3 vSunDirection;
+    varying float vSunfade;
+    varying vec3 vBetaR;
+    varying vec3 vBetaM;
+    varying float vSunE;
+
+    const float e = 2.71828182845904523536028747135266249775724709369995957;
+    const float pi = 3.141592653589793238462643383279502884197169;
+
+    const vec3 totalRayleigh = vec3( 5.804542996261093E-6, 1.3562911419845635E-5, 3.0265902468824876E-5 );
+    const float v = 4.0;
+    const vec3 K = vec3( 0.686, 0.678, 0.666 );
+    const vec3 MieConst = vec3( 1.8399918514433978E14, 2.7798023919660528E14, 4.0790479543861094E14 );
+
+    const float cutoffAngle = 1.6110731556870734;
+    const float steepness = 1.5;
+    const float EE = 1000.0;
+
+    float sunIntensity( float zenithAngleCos ) {
+      zenithAngleCos = clamp( zenithAngleCos, -1.0, 1.0 );
+      return EE * max( 0.0, 1.0 - pow( e, -( ( cutoffAngle - acos( zenithAngleCos ) ) / steepness ) ) );
+    }
+
+    vec3 totalMie( float T ) {
+      float c = ( 0.2 * T ) * 10E-18;
+      return 0.434 * c * MieConst;
+    }
+
+    void main() {
+      vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+      vWorldPosition = worldPosition.xyz;
+
+      gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+      gl_Position.z = gl_Position.w; // pin to the far plane (skybox behaviour)
+
+      vSunDirection = normalize( sunPosition );
+      vSunE = sunIntensity( dot( vSunDirection, up ) );
+      vSunfade = 1.0 - clamp( 1.0 - exp( ( sunPosition.y / 450000.0 ) ), 0.0, 1.0 );
+
+      float rayleighCoefficient = rayleigh - ( 1.0 * ( 1.0 - vSunfade ) );
+      vBetaR = totalRayleigh * rayleighCoefficient;
+      vBetaM = totalMie( turbidity ) * mieCoefficient;
+    }`,
+  fragmentShader: /* glsl */`
+    varying vec3 vWorldPosition;
+    varying vec3 vSunDirection;
+    varying float vSunfade;
+    varying vec3 vBetaR;
+    varying vec3 vBetaM;
+    varying float vSunE;
+
+    uniform float mieDirectionalG;
+    uniform float exposure;
+    uniform vec3 up;
+
+    const float pi = 3.141592653589793238462643383279502884197169;
+
+    const float rayleighZenithLength = 8.4E3;
+    const float mieZenithLength = 1.25E3;
+    const float sunAngularDiameterCos = 0.999956676946448443553574619906976478926848692873900859324;
+
+    const float THREE_OVER_SIXTEENPI = 0.05968310365946075;
+    const float ONE_OVER_FOURPI = 0.07957747154594767;
+
+    float rayleighPhase( float cosTheta ) {
+      return THREE_OVER_SIXTEENPI * ( 1.0 + pow( cosTheta, 2.0 ) );
+    }
+
+    float hgPhase( float cosTheta, float g ) {
+      float g2 = pow( g, 2.0 );
+      float inverse = 1.0 / pow( 1.0 - 2.0 * g * cosTheta + g2, 1.5 );
+      return ONE_OVER_FOURPI * ( ( 1.0 - g2 ) * inverse );
+    }
+
+    void main() {
+      vec3 direction = normalize( vWorldPosition - cameraPosition );
+
+      float zenithAngle = acos( max( 0.0, dot( up, direction ) ) );
+      float inverse = 1.0 / ( cos( zenithAngle ) + 0.15 * pow( 93.885 - ( ( zenithAngle * 180.0 ) / pi ), -1.253 ) );
+      float sR = rayleighZenithLength * inverse;
+      float sM = mieZenithLength * inverse;
+
+      vec3 Fex = exp( -( vBetaR * sR + vBetaM * sM ) );
+
+      float cosTheta = dot( direction, vSunDirection );
+
+      float rPhase = rayleighPhase( cosTheta * 0.5 + 0.5 );
+      vec3 betaRTheta = vBetaR * rPhase;
+
+      float mPhase = hgPhase( cosTheta, mieDirectionalG );
+      vec3 betaMTheta = vBetaM * mPhase;
+
+      vec3 Lin = pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * ( 1.0 - Fex ), vec3( 1.5 ) );
+      Lin *= mix( vec3( 1.0 ), pow( vSunE * ( ( betaRTheta + betaMTheta ) / ( vBetaR + vBetaM ) ) * Fex, vec3( 1.0 / 2.0 ) ), clamp( pow( 1.0 - dot( up, vSunDirection ), 5.0 ), 0.0, 1.0 ) );
+
+      vec3 L0 = vec3( 0.1 ) * Fex;
+      float sundisk = smoothstep( sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta );
+      L0 += ( vSunE * 19000.0 * Fex ) * sundisk;
+
+      vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );
+      vec3 retColor = pow( texColor, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );
+
+      gl_FragColor = vec4( retColor * exposure, 1.0 );
+
+      #include <tonemapping_fragment>
+      #include <colorspace_fragment>
+    }`
+};
+
+function createAtmosphericSky(sunDirection: THREE.Vector3): THREE.Mesh {
+  const material = new THREE.ShaderMaterial({
+    name: 'AtmosphericSky',
+    uniforms: THREE.UniformsUtils.clone(SKY_SHADER.uniforms),
+    vertexShader: SKY_SHADER.vertexShader,
+    fragmentShader: SKY_SHADER.fragmentShader,
+    side: THREE.BackSide,
+    depthWrite: false
+  });
+  // Direction only — the shader normalises it; magnitude does not matter.
+  material.uniforms.sunPosition.value.copy(sunDirection).normalize();
+
+  const sky = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material);
+  sky.scale.setScalar(DOME_SCALE);
+  sky.frustumCulled = false;
+  sky.name = 'AtmosphericSky';
+  return sky;
+}
+
+/**
+ * Apply the Tier 2 Preetham atmospheric sky (with a sun) and matching distance
+ * fog. `sunDirection` should be the scene's directional-light direction so the
+ * visible sun and the cast shadows agree (magnitude is ignored).
+ */
+function applyAtmosphericSky(scene: THREE.Scene, sunDirection: THREE.Vector3): void {
+  scene.background = new THREE.Color(ATMOSPHERE_FOG_COLOR);
+  scene.fog = new THREE.Fog(ATMOSPHERE_FOG_COLOR, FOG_NEAR, FOG_FAR);
+  scene.add(createAtmosphericSky(sunDirection));
+}
+
 export const Sky = {
   applyGradientSky,
+  applyAtmosphericSky,
   ZENITH_COLOR,
   HORIZON_COLOR,
+  ATMOSPHERE_FOG_COLOR,
   FOG_NEAR,
   FOG_FAR
 };

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -1,0 +1,104 @@
+// Sky rendering for SnowGlider.
+//
+// The original scene used a single flat clear colour
+// (`scene.background = new THREE.Color(0x87CEEB)`) and no fog, so the procedural
+// terrain hard-cut against a featureless blue at the camera far plane. This
+// module replaces that with a graduated sky and matching distance fog so the
+// mountain reads with depth and a horizon instead of a flat wall of blue
+// (issue #2 — "visible sky").
+//
+// Tier 1 (this commit): a vertical-gradient sky dome plus linear distance fog
+// tinted to the horizon colour, so distant terrain fades into the sky rather
+// than popping at the far plane. Tier 2 layers the Preetham atmospheric model
+// and a sun on top — see `applyAtmosphericSky` once it lands.
+//
+// Implementation notes:
+// - The dome is a large box with `BackSide` + `depthWrite: false`, and the
+//   vertex shader pins it to the far plane (`gl_Position.z = gl_Position.w`).
+//   Combined with three.js's default `LessEqualDepth` test that makes it behave
+//   as a skybox: it fills every pixel not covered by scene geometry regardless
+//   of draw order, and never clips against the camera far plane (so the box
+//   scale only has to enclose the camera, not fit inside `far`).
+// - The gradient is evaluated from the per-pixel view direction
+//   (`worldPosition - cameraPosition`), so it tracks camera orientation
+//   correctly as the chase camera pitches.
+// - The dome material intentionally has no fog: it *is* the horizon. Scene
+//   geometry (terrain/trees/rocks, all `fog: true` by default) fogs toward the
+//   horizon colour so terrain and sky meet seamlessly.
+
+import * as THREE from 'three';
+
+// Gradient endpoints. Colours are consumed under the project's legacy colour
+// pipeline (`ColorManagement.enabled = false`, linear output), matching how the
+// rest of the scene's colours are authored.
+const ZENITH_COLOR = 0x4696e1;   // deeper blue overhead
+const HORIZON_COLOR = 0xc8e1f5;  // pale, hazy blue near the horizon
+
+// Linear distance fog. The terrain plane spans z ∈ [-200, 200] and the run is
+// ~180 units long, so keep the gameplay area (well within FOG_NEAR) crisp and
+// only fade genuinely distant terrain / the far peak.
+const FOG_NEAR = 140;
+const FOG_FAR = 750;
+
+// Box half-extent only has to enclose the camera's travel; the far-plane pin
+// (see above) does the rest.
+const DOME_SCALE = 10000;
+
+function createGradientDome(): THREE.Mesh {
+  const material = new THREE.ShaderMaterial({
+    name: 'GradientSky',
+    uniforms: {
+      topColor: { value: new THREE.Color(ZENITH_COLOR) },
+      bottomColor: { value: new THREE.Color(HORIZON_COLOR) },
+      offset: { value: 0.0 },
+      exponent: { value: 0.6 }
+    },
+    vertexShader: /* glsl */`
+      varying vec3 vWorldPosition;
+      void main() {
+        vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+        vWorldPosition = worldPosition.xyz;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        gl_Position.z = gl_Position.w; // pin to the far plane (skybox behaviour)
+      }`,
+    fragmentShader: /* glsl */`
+      uniform vec3 topColor;
+      uniform vec3 bottomColor;
+      uniform float offset;
+      uniform float exponent;
+      varying vec3 vWorldPosition;
+      void main() {
+        vec3 direction = normalize(vWorldPosition - cameraPosition);
+        float h = max(direction.y + offset, 0.0);
+        float t = clamp(pow(h, exponent), 0.0, 1.0);
+        gl_FragColor = vec4(mix(bottomColor, topColor, t), 1.0);
+      }`,
+    side: THREE.BackSide,
+    depthWrite: false
+  });
+
+  const dome = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), material);
+  dome.scale.setScalar(DOME_SCALE);
+  dome.frustumCulled = false; // huge bounds; keep it from ever being culled
+  dome.name = 'GradientSky';
+  return dome;
+}
+
+/**
+ * Apply the Tier 1 gradient sky dome and matching distance fog to a scene.
+ * Also sets `scene.background` to the horizon colour as a cheap fallback for any
+ * frame before the dome draws.
+ */
+function applyGradientSky(scene: THREE.Scene): void {
+  scene.background = new THREE.Color(HORIZON_COLOR);
+  scene.fog = new THREE.Fog(HORIZON_COLOR, FOG_NEAR, FOG_FAR);
+  scene.add(createGradientDome());
+}
+
+export const Sky = {
+  applyGradientSky,
+  ZENITH_COLOR,
+  HORIZON_COLOR,
+  FOG_NEAR,
+  FOG_FAR
+};

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -36,6 +36,7 @@ import { EffectsModule, type ShakeOffset } from './effects.js';
 import { AvalancheSystem } from './avalanche.js';
 import { AudioModule } from './audio.js';
 import { Physics } from './physics.js';
+import { Sky } from './sky.js';
 import type { RockPosition } from './mountains.js';
 import type { TreePosition } from './trees.js';
 
@@ -56,7 +57,9 @@ Controls.setupControls();
 const THREECompat = THREE as any;
 THREECompat.ColorManagement.enabled = false;
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x87CEEB);
+// Sky background + distance fog are applied after the lights are set up
+// (see Sky.applyGradientSky below) so the gradient sky / horizon fog replace the
+// old flat `scene.background = Color(0x87CEEB)` (issue #2).
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 (renderer as any).outputColorSpace = THREECompat.LinearSRGBColorSpace;
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -161,6 +164,11 @@ directionalLight.castShadow = true;
 directionalLight.shadow.mapSize.width = 2048;
 directionalLight.shadow.mapSize.height = 2048;
 scene.add(directionalLight);
+
+// --- Sky & fog ---
+// Gradient sky dome + horizon-tinted distance fog (issue #2). Replaces the flat
+// blue clear colour so the terrain reads with depth and fades into a horizon.
+Sky.applyGradientSky(scene);
 
 // --- Create main game objects ---
 // Store terrain in a global for precise object positioning

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -166,9 +166,10 @@ directionalLight.shadow.mapSize.height = 2048;
 scene.add(directionalLight);
 
 // --- Sky & fog ---
-// Gradient sky dome + horizon-tinted distance fog (issue #2). Replaces the flat
-// blue clear colour so the terrain reads with depth and fades into a horizon.
-Sky.applyGradientSky(scene);
+// Preetham atmospheric sky + sun, with horizon-tinted distance fog (issue #2).
+// The sun direction is the directional light's position so the visible sun and
+// the cast shadows agree. (Sky.applyGradientSky is a lighter-weight fallback.)
+Sky.applyAtmosphericSky(scene, directionalLight.position);
 
 // --- Create main game objects ---
 // Store terrain in a global for precise object positioning


### PR DESCRIPTION
## Visible sky (#2)

Replaces the flat `scene.background = Color(0x87CEEB)` (and absence of fog) with a graduated sky and matching horizon fog, so the procedural mountain reads with depth and a horizon instead of a flat wall of blue that hard-cuts at the camera far plane. New self-contained `src/sky.ts` module.

Two commits, as requested:

### Commit 1 — Tier 1: gradient sky dome + distance fog (`Sky.applyGradientSky`)
- A large `BackSide` dome whose vertex shader pins it to the far plane (`gl_Position.z = gl_Position.w`); with three.js's default `LessEqualDepth` test it behaves as a skybox — never clips against `camera.far`, fills every pixel not covered by scene geometry regardless of draw order. The gradient is evaluated per-pixel from the view direction, so it tracks the chase camera's pitch.
- Linear `scene.fog` tinted to the horizon colour, tuned to keep the gameplay area crisp (`near = 140`) and fade only distant terrain / the far peak (`far = 750`).
- Kept as a lightweight fallback after Tier 2 lands.

### Commit 2 — Tier 2: Preetham atmospheric sky + sun (`Sky.applyAtmosphericSky`, what the game uses)
- The Preetham daylight model ported from three.js's `examples/jsm/objects/Sky.js`, with a sun disc. The sun direction is the scene's `directionalLight.position`, so the **visible sun and the cast shadows agree**.
- **Tuned for the legacy colour pipeline.** The project runs `ColorManagement.enabled = false`, linear output, and no tone mapping. Without ACES the shader's HDR output clips to cyan/white across most of the sky at the addon's usual exposure, so I evaluated the fragment math directly and set `rayleigh = 3` / `exposure = 0.35` to keep the whole dome in-gamut: zenith ≈ `(88,136,196)`, mid-sky ≈ `(122,182,237)`, pale horizon ≈ `(209,229,235)` — a cheerful clear-sky blue bracketing the old `0x87CEEB`. The fog is retinted to match the horizon. An `exposure` uniform stands in for the `renderer.toneMappingExposure` knob the addon would normally use; the `tonemapping`/`colorspace` includes are kept but are no-ops under these settings.

### Why the shader is inlined (not `three/addons/*`)
`src/sky.ts` imports **only bare `three`**. A `three/addons/objects/Sky.js` specifier would 404 on the deployed `?test=` pages: the build's verbatim `dist/src/*.js` copy only rewrites/copies the bare-`three` build graph (`copyThreeBuildGraph` + the import rewrite in `vite.config.js`), not the addons tree. Inlining keeps the module resolving identically across the Vite bundle, the raw-source import map, and the dist test pages (all three verified).

### Scope / risk
Purely visual — **no physics, collision, scoring, or lighting changes** (the directional light and its shadows are untouched). Docs updated in the same PR: `ARCHITECTURE.md` module table, `CHANGELOG.md`, and `ROADMAP.md` (#2 → ◐ partial).

### Testing
- `npm run typecheck` + `npm run lint` (new module): clean (0 errors).
- `npm test` (Node + verification incl. physics-invariant harness): pass.
- `npm run build`: green; confirmed `dist/src/sky.js` is transpiled with its `three` import rewritten and **no `three/addons` specifier leaks**.
- `npm run test:browser` (puppeteer): **87/87, 7/7 suites**.
- In-game screenshot (headless Chrome) confirms a blue sky + horizon fog with **no shader/console errors**.

> Note: the exact sky look (turbidity / rayleigh / exposure / fog tint) was dialled in via the fragment math under the legacy pipeline and is a one-line tweak in `src/sky.ts` — worth a final eyeball on real hardware.

---

## Next steps — Tier 3 (follow-up, out of scope here)
The sky is currently a **static daytime** sky. Natural follow-ups, roughly in effort order:

1. **Day → sunset → night cycle.** Animate the sun direction (and drive `directionalLight.position` from the same vector so shadows track it), retune `rayleigh`/`turbidity` over the cycle, and crossfade the fog colour. The `exposure` uniform already gives a brightness knob. This is the marquee Tier 3 item and what most "visible sky" polish implies (ROADMAP Finding 7's "day→sunset→night skybox").
2. **Clouds.** Cheapest: a scrolling cloud texture on a high dome / billboard layer. Richer: volumetric/noise-based clouds (more GPU cost — gate behind the mobile performance-scaling work in ROADMAP #135 territory).
3. **Stars / moon** for the night phase of the cycle.
4. **HDRI / cubemap skybox** option as an alternative to the analytic sky (would add image assets via Git LFS, and the deployed `?test=` pages would need those assets copied like the three build graph).
5. **Weather variation** (overcast/snowfall-linked sky), tying the existing snow particle system to a greyer sky + denser fog.
6. **`prefers-reduced-motion` / perf**: keep any sky *animation* (cycle, clouds) behind the same reduced-motion gate `EffectsModule` already uses, and add a static-sky fast path for low-end devices.

Closes part of #2 (static sky); leaves the day-night cycle / clouds tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
