### PR TITLE
refactor(ui): extract HUD to src/ui/hud.ts (R2.2, #34)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,11 +207,13 @@ camera.position -= shake                          // revert so smoothing stays c
 > `snowglider.ts` is being thinned into `src/game/*` (scene / loop / lifecycle) and
 > `src/ui/*` (HUD, overlays), and `snowman.ts` into `src/snowman/*`. Mechanical,
 > behavior-preserving moves only — the published `window.*` hooks and the
-> `publishGameGlobals()` proxy set stay in the coordinator. The first extracted
-> piece is **`src/ui/collapsible-panel.ts`**, the shared collapse / resize /
-> horizontal-swipe behavior for the Game Stats and Game Controls panels that was
-> previously duplicated across `initializeGameStats()` and
-> `initializeControlsToggle()`.
+> `publishGameGlobals()` proxy set stay in the coordinator. Extracted so far:
+> **`src/ui/collapsible-panel.ts`** (the shared collapse / resize / horizontal-swipe
+> behavior for the Game Stats and Game Controls panels, previously duplicated across
+> `initializeGameStats()` and `initializeControlsToggle()`) and **`src/ui/hud.ts`**
+> (the Game Stats / Controls panel init plus the per-frame speed/position/technique
+> readouts and the live run timer). The coordinator passes the run state into these
+> as parameters rather than letting them reach back into its bindings.
 
 ---
 

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -39,7 +39,7 @@ import { Physics } from './physics.js';
 import { Sky } from './sky.js';
 import type { RockPosition } from './mountains.js';
 import type { TreePosition } from './trees.js';
-import { setupCollapsiblePanel } from './ui/collapsible-panel.js';
+import { initializeGameStats, initializeControlsToggle, updateStatsHud, updateTimerDisplay } from './ui/hud.js';
 
 // Get keyboard controls from the Controls module
 Controls.setupControls();
@@ -342,26 +342,10 @@ function readStoredBestTime() {
 // Persisted best loaded once at module eval (may prune an invalid stored entry).
 state.bestTime = readStoredBestTime();
 
-// Initialize game stats functionality
-function initializeGameStats() {
-  const bestTimeElement = document.getElementById('bestTimeValue');
-  if (bestTimeElement) {
-    bestTimeElement.textContent = state.bestTime !== Infinity ? `${state.bestTime.toFixed(2)}s` : '--';
-  }
-
-  // Game stats panel collapse/swipe behavior (shared with the Controls panel).
-  setupCollapsiblePanel({
-    name: 'game stats',
-    containerId: 'gameStatsContainer',
-    toggleButtonId: 'toggleStats',
-    headerId: 'gameStatsHeader',
-  });
-}
-
 // Initialize the stats display when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
   console.log("DOM content loaded, initializing game stats");
-  initializeGameStats();
+  initializeGameStats(state.bestTime);
 });
 
 // Add best time to game over overlay
@@ -391,7 +375,7 @@ function resetSnowman() {
   Controls.resetControls();
   
   state.startTime = performance.now(); // Reset the timer when starting a new run
-  updateTimerDisplay();
+  updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
   
   // Reset course (gates/splits/ghost) and effects (avalanche UI, FOV, shake) for the new run
   lastTechnique = 'glide';
@@ -466,53 +450,8 @@ function updateSnowman(delta: number) {
     showGameOver: activeShowGameOver
   });
 
-  // Update game stats display
-  // Format speed with color based on value
-  const speed = result.currentSpeed.toFixed(1);
-  let speedColor = '#FFFFFF'; // Default white
-  
-  // Color code speed (green for slow, yellow for medium, red for fast)
-  if (result.currentSpeed > 20) {
-    speedColor = '#FF5252'; // Red for fast
-  } else if (result.currentSpeed > 12) {
-    speedColor = '#FFD700'; // Yellow for medium
-  } else if (result.currentSpeed > 5) {
-    speedColor = '#4CAF50'; // Green for good speed
-  }
-  
-  // Update individual stat elements
-  const speedElement = document.getElementById('speedValue');
-  if (speedElement) {
-    speedElement.textContent = speed;
-    speedElement.style.color = speedColor;
-  }
-  
-  const positionElement = document.getElementById('positionValue');
-  if (positionElement) {
-    positionElement.textContent = `${pos.x.toFixed(0)},${pos.z.toFixed(0)}`;
-  }
-  
-  const groundElement = document.getElementById('groundStatus');
-  if (groundElement) {
-    if (player.isInAir) {
-      groundElement.innerHTML = '🚀 JUMP!';
-      groundElement.style.color = '#00FFFF';
-    } else {
-      // Reflect the active ski technique so skill is legible in the HUD.
-      const techMap: Record<string, { txt: string; color: string }> = {
-        parallel: { txt: '🎿 Parallel', color: '#00d2ff' },
-        carve:    { txt: '🎿 Carving',  color: '#55efc4' },
-        hop:      { txt: '🦘 Hop turn', color: '#fab1a0' },
-        skid:     { txt: '💨 Skidding', color: '#ffeaa7' },
-        snowplow: { txt: '🍕 Snowplow', color: '#74b9ff' },
-        tuck:     { txt: '🏎️ Tuck',     color: '#ff7675' },
-        glide:    { txt: '⛷️ Ground',   color: '#AAFFAA' }
-      };
-      const t = techMap[result.technique] || techMap.glide;
-      groundElement.innerHTML = t.txt;
-      groundElement.style.color = t.color;
-    }
-  }
+  // Update game stats display (speed/position/technique)
+  updateStatsHud(result, pos, player.isInAir);
   lastTechnique = result.technique;
 
   // Camera shake on a meaningful landing (scales with time spent aloft).
@@ -618,7 +557,7 @@ function animate(time: number) {
     snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
     
     updateCamera();
-    updateTimerDisplay(); // Update the timer display
+    updateTimerDisplay(state.gameActive, state.startTime, state.bestTime); // Update the timer display
     
     // Camera juice: speed-based FOV + shake. Apply for the render only, then revert
     // the positional offset so the camera manager's own smoothing stays clean.
@@ -959,45 +898,11 @@ Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
 // Add event listener to restart button
 restartButton.addEventListener('click', restartGame);
 
-// Function to initialize controls toggle
-function initializeControlsToggle() {
-  // Controls panel collapse/swipe behavior (shared with the Game Stats panel).
-  // Resets stale listeners and auto-collapses on small screens — this is invoked
-  // more than once (DOMContentLoaded + initializeGameWithAudio).
-  setupCollapsiblePanel({
-    name: 'controls',
-    containerId: 'controlsInfo',
-    toggleButtonId: 'toggleControls',
-    headerId: 'controlsHeader',
-    resetListeners: true,
-    autoCollapseOnSmallScreens: true,
-  });
-}
-
 // Initialize controls toggle when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
   console.log("DOM content loaded, initializing controls toggle");
   initializeControlsToggle();
 });
-
-// Update timer display during gameplay
-function updateTimerDisplay() {
-  if (state.gameActive) {
-    const currentTime = (performance.now() - state.startTime) / 1000;
-
-    // Update the current time element in game stats
-    const currentTimeElement = document.getElementById('currentTime');
-    if (currentTimeElement) {
-      currentTimeElement.textContent = `${currentTime.toFixed(2)}s`;
-    }
-
-    // Keep best time updated
-    const bestTimeElement = document.getElementById('bestTimeValue');
-    if (bestTimeElement) {
-      bestTimeElement.textContent = state.bestTime !== Infinity ? `${state.bestTime.toFixed(2)}s` : '--';
-    }
-  }
-}
 
 // Function to initialize the game with audio - called from the start button
 // TODO: AUDIO DISABLED - Function name kept for compatibility, audio calls will be no-ops
@@ -1046,7 +951,7 @@ window.initializeGameWithAudio = function() {
   Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
   
   // Make sure game stats and controls are properly initialized and visible
-  initializeGameStats();
+  initializeGameStats(state.bestTime);
   initializeControlsToggle();
   
   // Initialize Game Stats
@@ -1061,7 +966,7 @@ window.initializeGameWithAudio = function() {
     }
     
     // Update initial values
-    updateTimerDisplay();
+    updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
   }
   
   // Initialize Controls

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,107 @@
+// In-game HUD: the Game Stats panel (best time + collapse/swipe), the live run
+// timer, and the per-frame speed / position / technique readouts. Extracted from
+// snowglider.ts; the orchestrator passes the run state in as parameters so this
+// module stays decoupled from the coordinator's bindings.
+
+import type { PlayerPos, UpdateResult } from '../snowman.js';
+import { setupCollapsiblePanel } from './collapsible-panel.js';
+
+// Seed the best-time readout and wire up the Game Stats panel collapse/swipe.
+export function initializeGameStats(bestTime: number): void {
+  const bestTimeElement = document.getElementById('bestTimeValue');
+  if (bestTimeElement) {
+    bestTimeElement.textContent = bestTime !== Infinity ? `${bestTime.toFixed(2)}s` : '--';
+  }
+
+  // Game stats panel collapse/swipe behavior (shared with the Controls panel).
+  setupCollapsiblePanel({
+    name: 'game stats',
+    containerId: 'gameStatsContainer',
+    toggleButtonId: 'toggleStats',
+    headerId: 'gameStatsHeader',
+  });
+}
+
+// Wire up the Game Controls panel collapse/swipe behavior. Resets stale listeners
+// and auto-collapses on small screens — this is invoked more than once
+// (DOMContentLoaded + initializeGameWithAudio).
+export function initializeControlsToggle(): void {
+  setupCollapsiblePanel({
+    name: 'controls',
+    containerId: 'controlsInfo',
+    toggleButtonId: 'toggleControls',
+    headerId: 'controlsHeader',
+    resetListeners: true,
+    autoCollapseOnSmallScreens: true,
+  });
+}
+
+// Per-frame stats readout: color-coded speed, x/z position, and the ground /
+// jump / ski-technique indicator.
+export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: boolean): void {
+  // Format speed with color based on value
+  const speed = result.currentSpeed.toFixed(1);
+  let speedColor = '#FFFFFF'; // Default white
+
+  // Color code speed (green for slow, yellow for medium, red for fast)
+  if (result.currentSpeed > 20) {
+    speedColor = '#FF5252'; // Red for fast
+  } else if (result.currentSpeed > 12) {
+    speedColor = '#FFD700'; // Yellow for medium
+  } else if (result.currentSpeed > 5) {
+    speedColor = '#4CAF50'; // Green for good speed
+  }
+
+  // Update individual stat elements
+  const speedElement = document.getElementById('speedValue');
+  if (speedElement) {
+    speedElement.textContent = speed;
+    speedElement.style.color = speedColor;
+  }
+
+  const positionElement = document.getElementById('positionValue');
+  if (positionElement) {
+    positionElement.textContent = `${pos.x.toFixed(0)},${pos.z.toFixed(0)}`;
+  }
+
+  const groundElement = document.getElementById('groundStatus');
+  if (groundElement) {
+    if (isInAir) {
+      groundElement.innerHTML = '🚀 JUMP!';
+      groundElement.style.color = '#00FFFF';
+    } else {
+      // Reflect the active ski technique so skill is legible in the HUD.
+      const techMap: Record<string, { txt: string; color: string }> = {
+        parallel: { txt: '🎿 Parallel', color: '#00d2ff' },
+        carve:    { txt: '🎿 Carving',  color: '#55efc4' },
+        hop:      { txt: '🦘 Hop turn', color: '#fab1a0' },
+        skid:     { txt: '💨 Skidding', color: '#ffeaa7' },
+        snowplow: { txt: '🍕 Snowplow', color: '#74b9ff' },
+        tuck:     { txt: '🏎️ Tuck',     color: '#ff7675' },
+        glide:    { txt: '⛷️ Ground',   color: '#AAFFAA' }
+      };
+      const t = techMap[result.technique] || techMap.glide;
+      groundElement.innerHTML = t.txt;
+      groundElement.style.color = t.color;
+    }
+  }
+}
+
+// Update the live timer (and keep the best-time value fresh) during gameplay.
+export function updateTimerDisplay(gameActive: boolean, startTime: number, bestTime: number): void {
+  if (gameActive) {
+    const currentTime = (performance.now() - startTime) / 1000;
+
+    // Update the current time element in game stats
+    const currentTimeElement = document.getElementById('currentTime');
+    if (currentTimeElement) {
+      currentTimeElement.textContent = `${currentTime.toFixed(2)}s`;
+    }
+
+    // Keep best time updated
+    const bestTimeElement = document.getElementById('bestTimeValue');
+    if (bestTimeElement) {
+      bestTimeElement.textContent = bestTime !== Infinity ? `${bestTime.toFixed(2)}s` : '--';
+    }
+  }
+}


### PR DESCRIPTION
## What

**R2 step 2** of the snowglider/snowman split (see
[`docs/REFACTORING_SNOWGLIDER_SNOWMAN.md`](https://github.com/den-run-ai/snowglider/blob/main/docs/REFACTORING_SNOWGLIDER_SNOWMAN.md), issue #34).

Extracts the in-game HUD out of `src/snowglider.ts` into a new **`src/ui/hud.ts`**:

- `initializeGameStats(bestTime)` — best-time readout + Game Stats panel setup
- `initializeControlsToggle()` — Game Controls panel setup
- `updateStatsHud(result, pos, isInAir)` — per-frame color-coded speed / position /
  ground+technique readouts, lifted verbatim out of `updateSnowman()`
- `updateTimerDisplay(gameActive, startTime, bestTime)` — live run timer

Both panel-init wrappers delegate to the shared `collapsible-panel` helper from
R2.1, so that generic helper stays panel-agnostic (it does not learn specific
element IDs).

## Behavior preserved (mechanical move only)

The coordinator passes run state in as parameters; the extracted functions never
reach back into coordinator bindings. `lastTechnique` and the landing-shake call
stay in `updateSnowman()` (they move with the loop in R2.5). No change to the
published `window.*` hooks or `publishGameGlobals()`. `snowglider.ts` drops ~93
net lines.

## Verification

- `npm run lint` (0 new warnings) / `npm run typecheck` — clean
- `npm test` incl. **contract-surface guard 44/44**
- `npm run build` (Vite) — green
- `npm run test:browser` (puppeteer) — **87/87 across 7/7 suites**

## Stacking

Stacked on **#144 (R2.1)** — this PR's base is `refactor/r2-1-collapsible-panel`;
it will be retargeted to `main` once #144 merges. Review the per-commit diff for
the isolated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)