### PR TITLE
fix(auth): account-chip avatar, fold login options, hide unconfigured Apple

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,18 +120,28 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
   Google, GitHub (`GithubAuthProvider`), Apple (`OAuthProvider('apple.com')`), plus
   anonymous "Play as Guest" (`signInAnonymously`). Add a provider by extending that
   table and adding a button with the matching id; a button absent from the DOM is skipped.
+  The **Apple button is currently omitted from `index.html`** (its Service ID isn't
+  configured) — `PROVIDER_BUTTONS` still lists it, so re-adding the `<button
+  id="appleLoginBtn">` re-enables it. Unconfigured providers also fail gracefully
+  (`auth/operation-not-allowed` → friendly message, not the raw Firebase error).
+- Signed-in UI is a compact **account chip** (`#profileChip`): a generated avatar
+  (`renderAvatar` — the real provider photo, else initials or a snow glyph on a
+  deterministic random color) + name + logout, with the provider buttons folded away.
 - Anonymous guests are kept OUT of Firestore and the global leaderboard: `auth.ts`
   passes `null` to `ScoresModule.setCurrentUser` and `scores.ts` `getActiveUser()`
   skips `isAnonymous` users. A guest who later signs in with a real provider is
   upgraded in place via `linkWithPopup` (same uid), and `syncUserData` backfills
   their local best time to the leaderboard. Preserve this guard when touching auth/scores.
+  For guests the provider buttons are **folded behind the chip** (click `#profileChip`
+  to unfold `#authUI`) so the upgrade stays reachable without cluttering the panel.
 - Set `window.FIREBASE_MANUAL_INIT = true` to prevent 404 errors 
 - Implement specialized handling for popup-blocked and popup-closed-by-user errors
 - Provide graceful degradation to localStorage when Firebase is unavailable
 - Include visual state indicators during the authentication process
 - Maintain automatic detection between development and production environments
-- GitHub/Apple require server-side Firebase console config (OAuth app; Apple Service ID);
-  the buttons exist but only succeed once those providers are enabled.
+- GitHub/Apple require server-side Firebase console config (OAuth app; Apple Service ID).
+  GitHub + Google + Anonymous are enabled on the `sn0wglider` project; Apple is not,
+  which is why its button is omitted for now.
 
 ## Scoring and Leaderboard Implementation
 - User scoring and leaderboard functionality is managed by the ScoresModule in `scores.ts`

--- a/auth.html
+++ b/auth.html
@@ -99,8 +99,13 @@
             <button id="guestLoginBtn">Play as Guest</button>
         </div>
         <div id="profileUI">
-            <img id="profileAvatar" src="" alt="Profile">
-            <span id="profileName"></span>
+            <!-- #profileChip is required for the guest fold/unfold: clicking it
+                 reveals #authUI so a guest can upgrade in place. Without it,
+                 updateUIForGuestUser keeps #authUI visible (never folds). -->
+            <button id="profileChip" type="button" title="Account">
+                <span id="profileAvatar" class="avatar"></span>
+                <span id="profileName"></span>
+            </button>
             <button id="logoutBtn">Logout</button>
         </div>
         <div id="status" class="status"></div>

--- a/auth.html
+++ b/auth.html
@@ -96,7 +96,6 @@
         <div id="authUI">
             <button id="loginBtn">Login with Google</button>
             <button id="githubLoginBtn">Login with GitHub</button>
-            <button id="appleLoginBtn">Sign in with Apple</button>
             <button id="guestLoginBtn">Play as Guest</button>
         </div>
         <div id="profileUI">

--- a/index.html
+++ b/index.html
@@ -162,20 +162,33 @@
   <div id="authContainer">
     <div id="authUI">
       <!--
-        Provider buttons. auth.ts wires each by id and skips any that are absent,
-        so buttons can ship ahead of (or behind) the server-side Firebase config.
-        Apple is intentionally omitted until its Service ID is configured — re-add
-        <button id="appleLoginBtn" class="provider-btn provider-apple"><span>Sign in with Apple</span></button>
-        once enabled and auth.ts will pick it up (PROVIDER_BUTTONS already lists it).
+        Compact brand-icon buttons (inline SVG keeps the repo binary-free). auth.ts
+        wires each by id and skips any that are absent, so buttons can ship ahead of
+        (or behind) the server-side Firebase config. Apple is intentionally omitted
+        until its Service ID is configured — re-add a matching
+        <button id="appleLoginBtn" class="provider-btn provider-apple"> with the Apple
+        glyph and auth.ts will pick it up (PROVIDER_BUTTONS already lists it).
       -->
-      <button id="loginBtn" class="provider-btn provider-google">
-        <span>Login with Google</span>
+      <button id="loginBtn" class="provider-btn provider-google" title="Sign in with Google" aria-label="Sign in with Google">
+        <svg class="provider-icon" viewBox="0 0 48 48" aria-hidden="true">
+          <path fill="#FFC107" d="M43.6 20.1H42V20H24v8h11.3C33.7 32.7 29.2 36 24 36c-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.8 1.2 8 3l5.7-5.7C34 6.1 29.3 4 24 4 12.9 4 4 12.9 4 24s8.9 20 20 20 20-9 20-20c0-1.3-.1-2.7-.4-3.9z"/>
+          <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.7 15.1 19 12 24 12c3.1 0 5.8 1.2 8 3l5.7-5.7C34 6.1 29.3 4 24 4 16.3 4 9.7 8.3 6.3 14.7z"/>
+          <path fill="#4CAF50" d="M24 44c5.2 0 9.9-2 13.4-5.2l-6.2-5.2C29.2 35 26.7 36 24 36c-5.2 0-9.6-3.3-11.3-7.9l-6.5 5C9.5 39.6 16.2 44 24 44z"/>
+          <path fill="#1976D2" d="M43.6 20.1H42V20H24v8h11.3c-.8 2.2-2.2 4.2-4.1 5.6l6.2 5.2C37 39.2 44 34 44 24c0-1.3-.1-2.7-.4-3.9z"/>
+        </svg>
+        <span class="provider-label">Google</span>
       </button>
-      <button id="githubLoginBtn" class="provider-btn provider-github">
-        <span>Login with GitHub</span>
+      <button id="githubLoginBtn" class="provider-btn provider-github" title="Sign in with GitHub" aria-label="Sign in with GitHub">
+        <svg class="provider-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        <span class="provider-label">GitHub</span>
       </button>
-      <button id="guestLoginBtn" class="provider-btn provider-guest">
-        <span>Play as Guest</span>
+      <button id="guestLoginBtn" class="provider-btn provider-guest" title="Play as Guest (no account)" aria-label="Play as Guest">
+        <svg class="provider-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+        </svg>
+        <span class="provider-label">Guest</span>
       </button>
     </div>
     <div id="profileUI">

--- a/index.html
+++ b/index.html
@@ -162,10 +162,11 @@
   <div id="authContainer">
     <div id="authUI">
       <!--
-        Provider buttons. GitHub/Apple only work once their providers are enabled
-        in the Firebase console (GitHub OAuth app; Apple Service ID). auth.ts wires
-        each by id and skips any that are absent, so buttons can ship ahead of the
-        server-side config without breaking sign-in.
+        Provider buttons. auth.ts wires each by id and skips any that are absent,
+        so buttons can ship ahead of (or behind) the server-side Firebase config.
+        Apple is intentionally omitted until its Service ID is configured — re-add
+        <button id="appleLoginBtn" class="provider-btn provider-apple"><span>Sign in with Apple</span></button>
+        once enabled and auth.ts will pick it up (PROVIDER_BUTTONS already lists it).
       -->
       <button id="loginBtn" class="provider-btn provider-google">
         <span>Login with Google</span>
@@ -173,16 +174,18 @@
       <button id="githubLoginBtn" class="provider-btn provider-github">
         <span>Login with GitHub</span>
       </button>
-      <button id="appleLoginBtn" class="provider-btn provider-apple">
-        <span>Sign in with Apple</span>
-      </button>
       <button id="guestLoginBtn" class="provider-btn provider-guest">
         <span>Play as Guest</span>
       </button>
     </div>
     <div id="profileUI">
-      <img id="profileAvatar" src="" alt="Profile">
-      <span id="profileName"></span>
+      <!-- Compact account chip. The avatar is generated (random color + initials or
+           a snow glyph) when there's no provider photo. For guests, clicking the chip
+           unfolds #authUI to reveal the "sign in to save" upgrade options. -->
+      <button id="profileChip" type="button" title="Account">
+        <span id="profileAvatar" class="avatar"></span>
+        <span id="profileName"></span>
+      </button>
       <button id="logoutBtn">Logout</button>
     </div>
   </div>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -328,9 +328,13 @@ function updateUIForGuestUser() {
     return;
   }
 
-  authUI.style.display = 'none';     // folded by default; revealed via the chip
+  // Only FOLD the provider buttons when there's a chip to unfold them again.
+  // Pages without #profileChip (e.g. the standalone auth.html, or any future host)
+  // keep #authUI visible so the in-place guest upgrade stays reachable.
+  const hasChip = !!document.getElementById('profileChip');
+  authUI.style.display = hasChip ? 'none' : 'flex';
   profileUI.style.display = 'flex';
-  profileUI.classList.add('guest');  // CSS shows an "expand to upgrade" caret
+  profileUI.classList.toggle('guest', hasChip); // caret hint only when foldable
   profileUI.classList.remove('expanded');
   if (profileName) profileName.textContent = 'Guest';
   if (profileAvatar) renderAvatar(profileAvatar, { isAnonymous: true, uid: currentUser?.uid });
@@ -342,7 +346,8 @@ function updateUIForGuestUser() {
 // The anonymous `guestLoginBtn` has no provider and is wired separately.
 type ProviderButton = {
   id: string;
-  label: string;
+  label: string;   // full label / accessible text (also the fallback for plain buttons)
+  short: string;   // compact label shown under the brand icon in #authUI
   method: string;
   makeProvider: () => AuthProvider;
 };
@@ -351,6 +356,7 @@ const PROVIDER_BUTTONS: ProviderButton[] = [
   {
     id: 'loginBtn',
     label: 'Login with Google',
+    short: 'Google',
     method: 'GooglePopup',
     makeProvider: () => {
       const provider = new GoogleAuthProvider();
@@ -363,6 +369,7 @@ const PROVIDER_BUTTONS: ProviderButton[] = [
   {
     id: 'githubLoginBtn',
     label: 'Login with GitHub',
+    short: 'GitHub',
     method: 'GitHubPopup',
     makeProvider: () => {
       const provider = new GithubAuthProvider();
@@ -373,6 +380,7 @@ const PROVIDER_BUTTONS: ProviderButton[] = [
   {
     id: 'appleLoginBtn',
     label: 'Sign in with Apple',
+    short: 'Apple',
     method: 'ApplePopup',
     makeProvider: () => {
       const provider = new OAuthProvider('apple.com');
@@ -383,20 +391,32 @@ const PROVIDER_BUTTONS: ProviderButton[] = [
   }
 ];
 
-const GUEST_BUTTON = { id: 'guestLoginBtn', label: 'Play as Guest' };
+const GUEST_BUTTON = { id: 'guestLoginBtn', label: 'Play as Guest', short: 'Guest' };
 
 // Every auth button that should be enabled/disabled/reset together.
 function allAuthButtonMeta() {
   return [...PROVIDER_BUTTONS, GUEST_BUTTON];
 }
 
+// Set a button's visible label without clobbering its icon. Icon buttons (#authUI
+// in index.html) hold an inline brand <svg> + a `.provider-label` span, so we write
+// to that span; plain text buttons (auth.html, the test DOM) have no span, so we
+// fall back to textContent.
+function setButtonLabel(btn: HTMLElement, text: string) {
+  const labelEl = btn.querySelector('.provider-label');
+  if (labelEl) labelEl.textContent = text;
+  else btn.textContent = text;
+}
+
 // Reset all present auth buttons to their default, enabled state. (Replaces the
 // old single-button resetLoginButton; a missing button id is simply skipped.)
 function resetAuthButtons() {
-  allAuthButtonMeta().forEach(({ id, label }) => {
-    const btn = document.getElementById(id) as HTMLButtonElement | null;
+  allAuthButtonMeta().forEach((meta) => {
+    const btn = document.getElementById(meta.id) as HTMLButtonElement | null;
     if (!btn) return;
-    btn.textContent = label;
+    // Icon buttons restore the short label under the icon; plain buttons restore
+    // the full label.
+    setButtonLabel(btn, btn.querySelector('.provider-label') ? meta.short : meta.label);
     btn.disabled = false;
     btn.classList.remove('signing-in');
     btn.classList.remove('retry-auth'); // legacy redirect-retry class
@@ -404,15 +424,17 @@ function resetAuthButtons() {
 }
 
 // Mark a sign-in as in flight: disable every auth button (so a second provider
-// can't open a competing popup) and show the active one as "Signing In...".
+// can't open a competing popup) and flag the active one as signing in. Icon buttons
+// keep their icon and show the busy state via the `.signing-in` class; plain text
+// buttons swap to "Signing In...".
 function setAuthButtonsBusy(activeBtn: HTMLButtonElement) {
   allAuthButtonMeta().forEach(({ id }) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) return;
     btn.disabled = true;
     if (btn === activeBtn) {
-      btn.textContent = 'Signing In...';
       btn.classList.add('signing-in');
+      if (!btn.querySelector('.provider-label')) btn.textContent = 'Signing In...';
     }
   });
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -228,51 +228,80 @@ function handleSignedOutUser() {
   console.log("Finished processing signed-out state.");
 }
 
-// Update UI when user is logged in
+// --- Generated avatar (random color + content) for users without a photo ---
+// Snow-themed glyphs used when there's no name to derive initials from (e.g. an
+// anonymous guest). The pick + color are deterministic from a seed, so they stay
+// stable for the session but vary between users.
+const AVATAR_GLYPHS = ['⛄', '🎿', '🏂', '❄️', '🏔️', '🐧', '🧣', '🌨️'];
+
+function hashString(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (h * 31 + seed.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+// Deterministic, pleasant background color from a seed string.
+function avatarColor(seed: string): string {
+  return `hsl(${hashString(seed) % 360}, 60%, 45%)`;
+}
+
+// Up to two initials from a display name or email local-part.
+function avatarInitials(name: string): string {
+  const base = name.replace(/@.*/, '').replace(/[^A-Za-z0-9]+/g, ' ').trim();
+  const parts = base.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return '';
+}
+
+// Paint #profileAvatar: the real photo if present, otherwise a generated avatar
+// with a random color plus either the user's initials or a random snow glyph.
+function renderAvatar(el: HTMLElement, user: {
+  isAnonymous?: boolean; uid?: string;
+  displayName?: string | null; email?: string | null; photoURL?: string | null;
+}) {
+  const seed = user.uid || user.displayName || user.email || 'guest';
+  el.textContent = '';
+  el.style.backgroundImage = '';
+  el.classList.add('avatar');
+  el.style.display = 'flex';
+
+  if (!user.isAnonymous && user.photoURL) {
+    el.style.backgroundImage = `url("${user.photoURL}")`;
+    el.style.backgroundSize = 'cover';
+    el.style.backgroundPosition = 'center';
+    el.style.backgroundColor = 'transparent';
+    return;
+  }
+
+  el.style.backgroundColor = avatarColor(seed);
+  const name = user.isAnonymous ? '' : (user.displayName || user.email || '');
+  el.textContent = avatarInitials(name) || AVATAR_GLYPHS[hashString(seed) % AVATAR_GLYPHS.length];
+}
+
+// Update UI when a real (non-anonymous) user is logged in: show the compact avatar
+// chip + name + logout, and fold the provider buttons away entirely.
 function updateUIForLoggedInUser(user: User) {
-  // --- Edit 2: Add logging inside UI update function ---
-  console.log("updateUIForLoggedInUser: Attempting to update UI for", user?.email);
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
   const profileName = document.getElementById('profileName');
-  const profileAvatar = document.getElementById('profileAvatar') as HTMLImageElement;
+  const profileAvatar = document.getElementById('profileAvatar');
 
   if (!authUI || !profileUI) {
     console.error("updateUIForLoggedInUser: Could not find authUI or profileUI elements!");
     return;
   }
-  console.log("updateUIForLoggedInUser: Found UI elements.");
 
-  // Update display
-  authUI.style.display = 'none';
+  authUI.style.display = 'none';     // login options folded once signed in
   profileUI.style.display = 'flex';
-  console.log("updateUIForLoggedInUser: Set authUI display=none, profileUI display=flex");
-
-  if (profileName) {
-    profileName.textContent = user.displayName || user.email;
-    console.log("updateUIForLoggedInUser: Set profile name to", profileName.textContent);
-  } else {
-    console.warn("updateUIForLoggedInUser: profileName element not found.");
-  }
-
-  // Set profile image if available
-  if (profileAvatar) {
-    if (user.photoURL) {
-      profileAvatar.src = user.photoURL;
-      profileAvatar.style.display = 'block';
-      console.log("updateUIForLoggedInUser: Set profile avatar src to", user.photoURL);
-    } else {
-      profileAvatar.style.display = 'none';
-      console.log("updateUIForLoggedInUser: Hiding profile avatar (no photoURL).");
-    }
-  } else {
-     console.warn("updateUIForLoggedInUser: profileAvatar element not found.");
-  }
-  console.log("updateUIForLoggedInUser: UI update complete.");
-  // --- End Edit 2 ---
+  profileUI.classList.remove('guest', 'expanded');
+  if (profileName) profileName.textContent = user.displayName || user.email || '';
+  if (profileAvatar) renderAvatar(profileAvatar, user);
 }
 
-// Update UI when user is logged out
+// Update UI when user is logged out: provider buttons visible, profile hidden.
 function updateUIForLoggedOutUser() {
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
@@ -281,28 +310,30 @@ function updateUIForLoggedOutUser() {
 
   authUI.style.display = 'flex';
   profileUI.style.display = 'none';
+  profileUI.classList.remove('guest', 'expanded');
 }
 
-// Update UI for an anonymous "guest" session. Unlike a fully logged-in user, we
-// keep the provider buttons (#authUI) visible so the guest can upgrade in place
-// (a provider click becomes a linkWithPopup on the same uid). We also show a small
-// "Guest" profile + logout so they can see they're playing as a guest and can end
-// the session. The provider button labels double as the "sign in to save" affordance.
+// Update UI for an anonymous "guest" session. The login options are FOLDED behind
+// the avatar chip so the panel isn't cluttered, but stay reachable: clicking the
+// chip toggles #authUI back on, where a provider click upgrades the guest in place
+// (linkWithPopup, same uid). A "Guest" label + logout remain visible.
 function updateUIForGuestUser() {
   const authUI = document.getElementById('authUI');
   const profileUI = document.getElementById('profileUI');
   const profileName = document.getElementById('profileName');
-  const profileAvatar = document.getElementById('profileAvatar') as HTMLImageElement;
+  const profileAvatar = document.getElementById('profileAvatar');
 
   if (!authUI || !profileUI) {
     console.error("updateUIForGuestUser: Could not find authUI or profileUI elements!");
     return;
   }
 
-  authUI.style.display = 'flex';     // keep provider buttons available for upgrade
-  profileUI.style.display = 'flex';  // show the guest indicator + logout
+  authUI.style.display = 'none';     // folded by default; revealed via the chip
+  profileUI.style.display = 'flex';
+  profileUI.classList.add('guest');  // CSS shows an "expand to upgrade" caret
+  profileUI.classList.remove('expanded');
   if (profileName) profileName.textContent = 'Guest';
-  if (profileAvatar) profileAvatar.style.display = 'none';
+  if (profileAvatar) renderAvatar(profileAvatar, { isAnonymous: true, uid: currentUser?.uid });
 }
 
 // Provider metadata for the buttons in #authUI. Each federated provider maps a
@@ -400,6 +431,10 @@ function handleSignInError(error: { code?: string; message?: string }) {
     // The email is already linked to a different provider.
     alert('An account already exists with this email using a different sign-in method. ' +
           'Please sign in with that method instead.');
+  } else if (error.code === 'auth/operation-not-allowed') {
+    // The provider isn't enabled in the Firebase console yet (e.g. Apple before
+    // its Service ID is set up). Show a friendly message instead of the raw error.
+    alert("That sign-in method isn't available yet. Please use another option.");
   } else {
     alert(`Error during sign-in: ${error.message}`);
   }
@@ -510,6 +545,25 @@ function setupAuthButtons() {
   });
   // Anonymous guest button (optional).
   bindAuthButton(GUEST_BUTTON.id, signInAsGuest);
+
+  // Profile chip: in guest mode it folds/unfolds the provider buttons (#authUI) so
+  // a guest can reveal the "sign in to save" upgrade options. For a fully signed-in
+  // user it does nothing (login options stay hidden).
+  const profileChip = document.getElementById('profileChip');
+  if (profileChip) {
+    const toggleGuestUpgrade = (e: Event) => {
+      if (e) e.preventDefault();
+      if (!currentUser || !currentUser.isAnonymous) return;
+      const authUI = document.getElementById('authUI');
+      const profileUI = document.getElementById('profileUI');
+      if (!authUI) return;
+      const collapsed = authUI.style.display === 'none';
+      authUI.style.display = collapsed ? 'flex' : 'none';
+      if (profileUI) profileUI.classList.toggle('expanded', collapsed);
+    };
+    profileChip.addEventListener('click', toggleGuestUpgrade);
+    profileChip.addEventListener('touchend', toggleGuestUpgrade, { passive: false });
+  }
 
   // Logout button
   const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement;

--- a/styles/main.css
+++ b/styles/main.css
@@ -580,17 +580,55 @@ canvas { display: block; }
 #profileUI {
   display: none;
   align-items: center;
+  gap: 8px;
   color: white;
 }
-#profileAvatar {
+/* Account chip: avatar + name, rendered as a borderless button. */
+#profileChip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: white;
+  cursor: default;
+  -webkit-tap-highlight-color: transparent;
+}
+/* In guest mode the chip is interactive (unfolds the upgrade options). */
+#profileUI.guest #profileChip {
+  cursor: pointer;
+}
+#profileUI.guest #profileChip::after {
+  content: '▾';
+  font-size: 10px;
+  opacity: 0.85;
+}
+#profileUI.guest.expanded #profileChip::after {
+  content: '▴';
+}
+/* Generated avatar: a colored circle with initials or a glyph (background-color +
+   text are set inline by renderAvatar; a real photo is set as background-image). */
+#profileAvatar,
+.avatar {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  margin-right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+  flex: 0 0 auto;
+  user-select: none;
 }
 #profileName {
   font-size: 14px;
-  margin-right: 8px;
   max-width: 90px; /* Prevent long names from causing overflow */
   overflow: hidden;
   text-overflow: ellipsis;

--- a/styles/main.css
+++ b/styles/main.css
@@ -357,11 +357,12 @@ canvas { display: block; }
   }
 
   /* Make provider buttons smaller on mobile */
-  #loginBtn,
   .provider-btn {
-    font-size: 12px;
-    padding: 4px 8px;
+    width: 52px;
+    padding: 6px 3px;
+    font-size: 10px;
   }
+  .provider-icon { width: 20px; height: 20px; }
 
   /* Make the profile UI smaller on mobile */
   #profileUI {
@@ -490,93 +491,53 @@ canvas { display: block; }
 */
 #authUI {
   display: flex;
-  flex-direction: column; /* Stack the provider buttons in the narrow panel */
-  align-items: stretch;
+  flex-direction: row;        /* compact icon row instead of full-width stack */
+  flex-wrap: wrap;
+  justify-content: flex-end;  /* align to the panel's right edge */
   gap: 6px;
 }
 /*
- * Shared base for every provider button. #loginBtn keeps its own block below for
- * the Google brand color and the ripple ::after; the GitHub/Apple/Guest buttons
- * inherit structure here and set only their brand color.
+ * Compact brand-icon button: an inline-SVG brand mark stacked over a short label
+ * (Google / GitHub / Guest). The buttons share one translucent style with a small
+ * brand-colored underline, rather than a full brand-colored bar each.
  */
 .provider-btn {
-  color: white;
-  border: none;
-  padding: 10px 18px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 3px;
+  width: 60px;
+  padding: 7px 4px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  background-color: rgba(255, 255, 255, 0.10);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   user-select: none;
   -webkit-user-select: none;
-  transition: transform 0.1s ease, background-color 0.2s ease;
-  min-height: 36px;
-  position: relative;
+  transition: transform 0.1s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
-.provider-btn:active, .provider-btn.signing-in {
-  transform: scale(0.98);
-}
-.provider-github { background-color: #24292e; }
-.provider-github:hover { background-color: #1b1f23; }
-.provider-apple { background-color: #000000; }
-.provider-apple:hover { background-color: #1a1a1a; }
-.provider-guest { background-color: #555555; }
-.provider-guest:hover { background-color: #444444; }
-#loginBtn {
-  background-color: #4285F4;
-  color: white;
-  border: none;
-  /* Increased padding for larger touch target */
-  padding: 10px 18px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500; /* Slightly bolder text */
-  display: flex;
-  align-items: center;
-  justify-content: center; /* Center text */
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation; /* Better touch response */
-  /* Prevent text selection */
-  user-select: none;
-  -webkit-user-select: none;
-  /* Add transition for smoother visual feedback */
-  transition: transform 0.1s ease, background-color 0.2s ease;
-  min-height: 36px; /* Ensure consistent height */
-  min-width: 120px; /* Ensure sufficient width for touch */
-  position: relative; /* For ::after pseudo-element */
-  overflow: visible; /* Allow overflow for glow effect */
-}
-#loginBtn:hover {
-  background-color: #3367D6;
-}
-#loginBtn:active, #loginBtn.signing-in {
-  background-color: #2A56C6; /* Feedback for touch action */
-  transform: scale(0.98); /* Visual feedback */
-}
-/* Add ripple effect on touch */
-#loginBtn::after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  background-color: rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-#loginBtn:active::after, #loginBtn.signing-in::after {
-  opacity: 1;
-  transition: opacity 0s;
-}
+.provider-btn:hover { background-color: rgba(255, 255, 255, 0.20); }
+.provider-btn:active { transform: scale(0.96); }
+.provider-icon { width: 22px; height: 22px; display: block; pointer-events: none; }
+.provider-label { pointer-events: none; }
+/* Small brand accent so the buttons stay recognizable at a glance. */
+.provider-google { border-bottom: 2px solid #4285F4; }
+.provider-github { border-bottom: 2px solid #6e5494; }
+.provider-apple  { border-bottom: 2px solid #cccccc; }
+.provider-guest  { border-bottom: 2px solid #8a8a8a; }
+/* Busy state: the active button dims + pulses while its popup is open; the others
+   just dim to show they're temporarily disabled. */
+.provider-btn:disabled { cursor: default; }
+.provider-btn:disabled:not(.signing-in) { opacity: 0.5; }
+.provider-btn.signing-in { animation: provider-pulse 1s ease-in-out infinite; }
+@keyframes provider-pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 0.9; } }
 #profileUI {
   display: none;
   align-items: center;

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -21,7 +21,7 @@ const dom = new JSDOM(`<!doctype html><html><body>
     <button id="guestLoginBtn">Play as Guest</button>
   </div>
   <div id="profileUI" style="display:none">
-    <img id="profileAvatar" src=""><span id="profileName"></span>
+    <button id="profileChip"><span id="profileAvatar" class="avatar"></span><span id="profileName"></span></button>
     <button id="logoutBtn">Logout</button>
   </div>
 </body></html>`, { url: 'https://snowglider.ai/' });
@@ -126,10 +126,19 @@ async function main() {
     authUI.style.display === 'none' && profileUI.style.display === 'flex');
   check('signed-in: profile name populated',
     window.document.getElementById('profileName').textContent === 'Snow');
+  check('signed-in: avatar uses the provider photo when present',
+    /url\("?http:\/\/p\/x\.png"?\)/.test(window.document.getElementById('profileAvatar').style.backgroundImage));
   check('signed-in: getAuthState reflects the user',
     AuthModule.isUserSignedIn() === true && AuthModule.getAuthState().user.uid === 'u1');
   check('signed-in: login button reset to default label',
     loginBtn.disabled === false && /Login with Google/.test(loginBtn.textContent));
+
+  // A user with no photo gets a generated avatar: initials on a deterministic color.
+  fb.emitAuthState({ uid: 'u2', email: 'jane.doe@x.io', displayName: 'Jane Doe', photoURL: null });
+  check('signed-in (no photo): avatar shows initials + generated color',
+    window.document.getElementById('profileAvatar').textContent === 'JD' &&
+    /rgb\(/.test(window.document.getElementById('profileAvatar').style.backgroundColor));
+  fb.emitAuthState({ uid: 'u1', email: 'snow@glider.ai', displayName: 'Snow', photoURL: 'http://p/x.png' });
 
   console.log('\n--- Sign-out ---');
   const logoutBtn = window.document.getElementById('logoutBtn');
@@ -238,13 +247,22 @@ async function main() {
   // Firebase reports the anonymous user. The guest is kept OFF the leaderboard:
   // recordScore must not write a Firestore identity even though logged-in chrome shows.
   localStorage.clear();
+  const profileChip = window.document.getElementById('profileChip');
+  const profileAvatar = window.document.getElementById('profileAvatar');
   fb.emitAuthState({ uid: 'guest1', isAnonymous: true, email: null, displayName: null });
-  // The provider buttons (#authUI) MUST stay visible for a guest, since a provider
-  // click is the only entry point to the in-place upgrade (linkWithPopup). The guest
-  // also gets a lightweight "Guest" profile + logout.
-  check('anonymous guest: provider buttons stay visible for in-place upgrade',
-    authUI.style.display === 'flex' && profileUI.style.display === 'flex' &&
+  // For a guest the login options are FOLDED behind the avatar chip (not cluttering
+  // the panel), but must stay reachable: the chip is in "guest" mode and the avatar
+  // shows generated content (a glyph, since a guest has no name).
+  check('anonymous guest: login options folded behind the chip',
+    authUI.style.display === 'none' && profileUI.style.display === 'flex' &&
+    profileUI.classList.contains('guest') &&
     window.document.getElementById('profileName').textContent === 'Guest');
+  check('anonymous guest: avatar has a generated glyph + background color',
+    profileAvatar.textContent.length > 0 && /rgb\(/.test(profileAvatar.style.backgroundColor));
+  // Clicking the chip unfolds #authUI so the guest can pick a provider to upgrade.
+  profileChip.dispatchEvent(new window.Event('click'));
+  check('anonymous guest: clicking the chip reveals the provider buttons for upgrade',
+    authUI.style.display === 'flex' && profileUI.classList.contains('expanded'));
   check('anonymous guest: AuthModule still reports signed-in (for UI/onboarding)',
     AuthModule.isUserSignedIn() === true);
   AuthModule.recordScore(12.34); // guest finishes a run

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -17,7 +17,9 @@ const dom = new JSDOM(`<!doctype html><html><body>
   <div id="authUI" style="display:flex">
     <button id="loginBtn">Login with Google</button>
     <button id="githubLoginBtn">Login with GitHub</button>
-    <button id="appleLoginBtn">Sign in with Apple</button>
+    <!-- appleLoginBtn is icon-style (svg + .provider-label) to exercise the
+         label-span branch of setButtonLabel/resetAuthButtons. -->
+    <button id="appleLoginBtn"><svg class="provider-icon"></svg><span class="provider-label">Apple</span></button>
     <button id="guestLoginBtn">Play as Guest</button>
   </div>
   <div id="profileUI" style="display:none">
@@ -223,14 +225,22 @@ async function main() {
   fb.emitAuthState(null); // settle to signed-out, re-enable buttons
 
   // Apple: OAuthProvider('apple.com') popup logged with method 'ApplePopup'.
+  // appleBtn is icon-style, so its busy/reset must go through the .provider-label
+  // span (not textContent) to avoid wiping the inline SVG icon.
   fb.setNextPopupResult({ resolve: { user: { email: 'apple@glider.ai' } } });
   const popupsBeforeApple = calls.signInWithPopup;
   appleBtn.dispatchEvent(new window.Event('click'));
+  check('icon button busy keeps its label (icon preserved; no "Signing In..." text clobber)',
+    appleBtn.classList.contains('signing-in') &&
+    appleBtn.querySelector('.provider-label').textContent === 'Apple');
   await flush();
   check('Apple button opens a popup', calls.signInWithPopup === popupsBeforeApple + 1);
   check("'login' analytics logged with ApplePopup method",
     calls.logEvent.some(e => e.name === 'login' && e.params && e.params.method === 'ApplePopup'));
+  appleBtn.querySelector('.provider-label').textContent = 'XXX'; // mangle to prove reset rewrites it
   fb.emitAuthState(null);
+  check('icon button reset rewrites the short label via .provider-label',
+    appleBtn.querySelector('.provider-label').textContent === 'Apple' && appleBtn.disabled === false);
 
   console.log('\n--- Anonymous "play as guest" ---');
   const guestBtn = window.document.getElementById('guestLoginBtn');
@@ -344,6 +354,16 @@ async function main() {
   fb.emitAuthState(null);
   check('getUserIdToken resolves null when no user is signed in',
     (await AuthModule.getUserIdToken()) === null);
+
+  console.log('\n--- Guest fold guard: no #profileChip keeps upgrade reachable ---');
+  // On a page without #profileChip (e.g. auth.html), the guest UI must NOT fold the
+  // provider buttons — there'd be no way to unfold them, leaving upgrade unreachable.
+  const chip = window.document.getElementById('profileChip');
+  chip.remove();
+  fb.emitAuthState({ uid: 'guestNoChip', isAnonymous: true, email: null, displayName: null });
+  check('guest without a chip: provider buttons stay visible (not folded)',
+    authUI.style.display === 'flex' && profileUI.classList.contains('guest') === false);
+  fb.emitAuthState(null);
 
   console.log(`\nAUTH TEST TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Why
Live-site feedback on the multi-provider auth UI from #143:
1. **Apple button threw a raw Firebase error** (`auth/operation-not-allowed`) because the Apple provider isn't configured on the project yet.
2. **The auth panel didn't fold** — once signed in (especially as a guest) it showed a tall stack of login buttons + logout that overlapped the Game Stats panel.
3. Request: a **standard account avatar** (random color + initials/glyph) that folds the login options away when signed in.

## Changes
- **Apple** removed from `index.html` / `auth.html` (the provider isn't enabled). `PROVIDER_BUTTONS` still lists it, so re-adding the `<button id="appleLoginBtn">` re-enables it. Added graceful `auth/operation-not-allowed` handling so any unconfigured provider shows a friendly message, not the raw error.
- **Account chip** (`#profileChip`): once signed in, the provider buttons fold away and the panel shows a compact **generated avatar** + name + logout. `renderAvatar` uses the provider photo when present, otherwise **initials** (real users) or a **snow-themed glyph** (guests) on a **deterministic random color** (stable per user/session).
- **Guests**: the login options fold *behind* the chip — clicking `#profileChip` unfolds `#authUI` so a guest can still upgrade in place (`linkWithPopup`). This keeps the Codex-flagged upgrade path reachable while removing the clutter.
- `profileAvatar` changes from `<img>` to a `<span>` that the generated avatar paints into.

### Sample generated avatars
```
Jane Doe         -> "JD" on hsl(77, 60%, 45%)
snow@glider.ai   -> "SN" on hsl(78, 60%, 45%)
guest abc123     -> "⛄" on hsl(112, 60%, 45%)
guest xyz789     -> "🎿" on hsl(25, 60%, 45%)
```

## Tests
- `test:auth` **47/47** (new: avatar initials/glyph + color, chip-unfold reveals upgrade buttons, refreshed guest-fold assertions)
- scores 34 · start-menu 37 · controls 22 · contract 44 · verify (smoke 18 + physics invariants)
- `tsc --noEmit` clean · eslint 0 errors · `npm run build` OK

## Notes
- **Apple** is still the only un-done provider (needs Apple Developer Service ID). Re-adding the button is a one-line change once configured.
- Real-device popup behavior for GitHub/guest still unverified from here — worth a click on the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)