### PR TITLE
refactor(game): extract run lifecycle to src/game/lifecycle.ts; drop dead addTestHooks (R2.6, #34)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,11 +222,19 @@ camera.position -= shake                          // revert so smoothing stays c
 > `rockPositions` / `isTestMode` data globals), and **`src/game/main-loop.ts`**
 > (the per-frame run loop: `createMainLoop(deps)` returns `updateSnowman` /
 > `updateCamera` / `animate` / `startLoop` / `handleResize`; it owns the private
-> `lastTime`, and lifecycle code calls `startLoop()` to seed+kick the loop). The
-> coordinator calls `setupScene()` once, destructures the handles the
-> loop/lifecycle/proxies use, builds the loop, and passes run state + overlay DOM
-> nodes into the modules as parameters rather than letting them reach back into its
-> bindings.
+> `lastTime`, and lifecycle code calls `startLoop()` to seed+kick the loop), and
+> **`src/game/lifecycle.ts`** (`createLifecycle(deps)` returns `resetSnowman` /
+> `restartGame` / `toggleCameraView` + `initLifecycleUI()`, which wires the reset /
+> camera-toggle / restart DOM controls). The coordinator calls `setupScene()` once,
+> destructures the handles the loop/lifecycle/proxies use, builds the loop and
+> lifecycle, and passes run state + overlay DOM nodes into the modules as parameters
+> rather than letting them reach back into its bindings.
+>
+> After R2, `snowglider.ts` is a ~380-line coordinator: imports + `setupScene()` /
+> `createMainLoop()` / `createLifecycle()` wiring, the eager `Snowman.addTestHooks`
+> calls, `window.initializeGameWithAudio`, `publishGameGlobals()`, and the test-mode
+> auto-start. (The dead local `addTestHooks` shim was deleted — the real browser hooks
+> come from `Snowman.addTestHooks`.) `snowman.ts` is the next target (Stage R3).
 
 ---
 

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -1,0 +1,173 @@
+// Run lifecycle for SnowGlider: reset (new run), restart (after game over), camera
+// view toggle, and the DOM controls that drive them (reset button, camera-toggle
+// button, restart button). Extracted from snowglider.ts as `createLifecycle(deps)`;
+// the coordinator injects the scene handles + run/player state and re-publishes
+// reset/restart/toggle on `window`. Mechanical move — behavior is unchanged.
+
+import { Controls } from '../controls.js';
+import { Snow } from '../snow.js';
+import { AudioModule } from '../audio.js';
+import { CourseModule } from '../course.js';
+import { EffectsModule } from '../effects.js';
+import { Physics, type PlayerState } from '../physics.js';
+import { updateTimerDisplay } from '../ui/hud.js';
+import type { SceneContext } from './scene-setup.js';
+
+export interface LifecycleDeps extends
+  Pick<SceneContext, 'state' | 'cameraManager' | 'snowman' | 'gameOverOverlay' | 'restartButton'> {
+  player: PlayerState;
+  startLoop: () => void;
+}
+
+export function createLifecycle(deps: LifecycleDeps) {
+  const { state, cameraManager, snowman, gameOverOverlay, restartButton, player, startLoop } = deps;
+  const pos = player.pos;
+
+  function resetSnowman() {
+    // Reset the snowman + player physics state (position, velocity, camera, and the
+    // air/auto-turn scalars) to the start of a run.
+    Physics.resetPlayer(player, snowman, Snow.getTerrainHeight, cameraManager);
+
+    // Reset avalanche system
+    const avalanche = state.avalanche;
+    if (avalanche) {
+      avalanche.reset();
+      state.avalancheTriggered = false;
+      state.lastAvalancheZ = pos.z; // Reset to starting position
+    }
+
+    // Reset keyboard controls
+    Controls.resetControls();
+
+    state.startTime = performance.now(); // Reset the timer when starting a new run
+    updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
+
+    // Reset course (gates/splits/ghost) and effects (avalanche UI, FOV, shake) for the new run
+    if (CourseModule) CourseModule.reset();
+    if (EffectsModule) EffectsModule.reset();
+
+    // Track game reset in Analytics if available
+    try {
+      // Only try to use analytics when properly initialized with modular SDK
+      if (window.firebaseModules && typeof window.firebaseModules.logEvent === 'function' && window.location.protocol !== 'file:') {
+        // Using the direct logEvent function
+        window.firebaseModules.logEvent('game_reset');
+      }
+    } catch (e) {
+      console.log("Analytics tracking skipped:", (e as Error).message);
+    }
+  }
+
+  function restartGame() {
+    gameOverOverlay.style.display = 'none';
+    state.gameActive = true;
+
+    // Clear the finish result panel from the previous run, if present.
+    const oldResult = document.getElementById('courseResult');
+    if (oldResult && oldResult.parentNode) oldResult.parentNode.removeChild(oldResult);
+
+    // Add game-active class to body for styling
+    document.body.classList.add('game-active');
+
+    // Show and reset game stats
+    const gameStatsContainer = document.getElementById('gameStatsContainer');
+    if (gameStatsContainer) {
+      gameStatsContainer.classList.remove('collapsed');
+      const toggleBtn = document.getElementById('toggleStats');
+      if (toggleBtn) {
+        toggleBtn.textContent = '▲';
+      }
+
+      // Reset colors for best time display
+      const bestTimeElement = document.getElementById('bestTimeValue');
+      if (bestTimeElement) {
+        bestTimeElement.style.color = ''; // Reset to default color
+      }
+    }
+
+    resetSnowman();
+
+    // Initialize camera with the snowman's position and rotation
+    cameraManager.initialize(snowman.position, snowman.rotation);
+
+    // TODO: AUDIO DISABLED - Resume audio (will be no-op if disabled)
+    if (AudioModule) {
+      AudioModule.enableSound(true);
+    }
+
+    // Reset animation if it was stopped
+    if (!state.animationRunning) {
+      state.animationRunning = true;
+      startLoop();
+    }
+  }
+
+  // Toggle between first-person and third-person camera views
+  function toggleCameraView() {
+    // Call the camera manager's toggle method
+    const newMode = cameraManager.toggleCameraMode();
+
+    // Reset camera initialization with current snowman position and rotation
+    cameraManager.initialize(snowman.position, snowman.rotation);
+
+    // Update the camera mode text in the controls info
+    const viewControlItem = document.querySelector('#controlsContent .control-item:last-child');
+    if (viewControlItem) {
+      const keyBadge = viewControlItem.querySelector('.key-badge');
+      const textSpan = viewControlItem.querySelector('span:last-child');
+
+      if (keyBadge && textSpan) {
+        keyBadge.textContent = 'V';
+        textSpan.textContent = `Toggle ${newMode === 'thirdPerson' ? 'Normal' : 'Chase'} View`;
+      }
+    }
+
+    // Update the toggle button text
+    const cameraToggleBtn = document.getElementById('cameraToggleBtn');
+    if (cameraToggleBtn) {
+      cameraToggleBtn.textContent = `Toggle ${newMode === 'thirdPerson' ? 'Normal' : 'Chase'} View`;
+    }
+
+    // Return the new mode (useful for tests)
+    return newMode;
+  }
+
+  // Wire the DOM controls that drive the lifecycle: the reset button, the
+  // camera-toggle button (created + appended here), and the restart button.
+  function initLifecycleUI() {
+    // Initialize controls but don't reset the snowman yet
+    document.getElementById('resetBtn')!.addEventListener('click', resetSnowman);
+
+    // Add camera toggle button
+    const cameraToggleBtn = document.createElement('button');
+    cameraToggleBtn.id = 'cameraToggleBtn';
+    cameraToggleBtn.textContent = 'Toggle Chase View';
+    cameraToggleBtn.style.position = 'absolute';
+    cameraToggleBtn.style.bottom = '20px';
+    cameraToggleBtn.style.left = '170px'; // Position it next to reset button
+    cameraToggleBtn.style.padding = '15px 20px';
+    cameraToggleBtn.style.border = 'none';
+    cameraToggleBtn.style.borderRadius = '8px';
+    cameraToggleBtn.style.backgroundColor = '#4a69bd'; // Different color from reset button
+    cameraToggleBtn.style.color = 'white';
+    cameraToggleBtn.style.cursor = 'pointer';
+    cameraToggleBtn.style.fontSize = '16px';
+    cameraToggleBtn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255, 255, 255, 0.5)');
+    cameraToggleBtn.style.touchAction = 'manipulation'; // Removes delay on mobile devices
+    cameraToggleBtn.style.userSelect = 'none';
+
+    // Add both click and touchend events to ensure cross-platform compatibility
+    cameraToggleBtn.addEventListener('click', toggleCameraView);
+    cameraToggleBtn.addEventListener('touchend', function(event) {
+      event.preventDefault();
+      toggleCameraView();
+    }, { passive: false });
+
+    document.body.appendChild(cameraToggleBtn);
+
+    // Add event listener to restart button
+    restartButton.addEventListener('click', restartGame);
+  }
+
+  return { resetSnowman, restartGame, toggleCameraView, initLifecycleUI };
+}

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -30,14 +30,13 @@ import * as THREE from 'three';
 import { Controls } from './controls.js';
 import { Snow } from './snow.js';
 import { Snowman } from './snowman.js';
-import { CourseModule } from './course.js';
-import { EffectsModule } from './effects.js';
 import { AudioModule } from './audio.js';
 import { Physics } from './physics.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
 import { readStoredBestTime, createShowGameOver } from './ui/result-overlay.js';
 import { setupScene } from './game/scene-setup.js';
 import { createMainLoop } from './game/main-loop.js';
+import { createLifecycle } from './game/lifecycle.js';
 
 // Get keyboard controls from the Controls module
 Controls.setupControls();
@@ -92,73 +91,6 @@ bestTimeDisplay.style.fontSize = '20px';
 bestTimeDisplay.style.marginBottom = '20px';
 gameOverOverlay.insertBefore(bestTimeDisplay, restartButton);
 
-function resetSnowman() {
-  // Reset the snowman + player physics state (position, velocity, camera, and the
-  // air/auto-turn scalars) to the start of a run.
-  Physics.resetPlayer(player, snowman, Snow.getTerrainHeight, cameraManager);
-
-  // Reset avalanche system
-  const avalanche = state.avalanche;
-  if (avalanche) {
-    avalanche.reset();
-    state.avalancheTriggered = false;
-    state.lastAvalancheZ = pos.z; // Reset to starting position
-  }
-  
-  // Reset keyboard controls
-  Controls.resetControls();
-  
-  state.startTime = performance.now(); // Reset the timer when starting a new run
-  updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
-  
-  // Reset course (gates/splits/ghost) and effects (avalanche UI, FOV, shake) for the new run
-  if (CourseModule) CourseModule.reset();
-  if (EffectsModule) EffectsModule.reset();
-  
-  // Track game reset in Analytics if available
-  try {
-    // Only try to use analytics when properly initialized with modular SDK
-    if (window.firebaseModules && typeof window.firebaseModules.logEvent === 'function' && window.location.protocol !== 'file:') {
-      // Using the direct logEvent function
-      window.firebaseModules.logEvent('game_reset');
-    }
-  } catch (e) {
-    console.log("Analytics tracking skipped:", (e as Error).message);
-  }
-}
-// Make resetSnowman accessible globally for touch handler
-window.resetSnowman = resetSnowman;
-
-// Initialize controls but don't reset the snowman yet
-document.getElementById('resetBtn')!.addEventListener('click', resetSnowman);
-
-// Add camera toggle button
-const cameraToggleBtn = document.createElement('button');
-cameraToggleBtn.id = 'cameraToggleBtn';
-cameraToggleBtn.textContent = 'Toggle Chase View';
-cameraToggleBtn.style.position = 'absolute';
-cameraToggleBtn.style.bottom = '20px';
-cameraToggleBtn.style.left = '170px'; // Position it next to reset button
-cameraToggleBtn.style.padding = '15px 20px';
-cameraToggleBtn.style.border = 'none';
-cameraToggleBtn.style.borderRadius = '8px';
-cameraToggleBtn.style.backgroundColor = '#4a69bd'; // Different color from reset button
-cameraToggleBtn.style.color = 'white';
-cameraToggleBtn.style.cursor = 'pointer';
-cameraToggleBtn.style.fontSize = '16px';
-cameraToggleBtn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255, 255, 255, 0.5)');
-cameraToggleBtn.style.touchAction = 'manipulation'; // Removes delay on mobile devices
-cameraToggleBtn.style.userSelect = 'none';
-
-// Add both click and touchend events to ensure cross-platform compatibility
-cameraToggleBtn.addEventListener('click', toggleCameraView);
-cameraToggleBtn.addEventListener('touchend', function(event) {
-  event.preventDefault();
-  toggleCameraView();
-}, { passive: false });
-
-document.body.appendChild(cameraToggleBtn);
-
 // --- Initial Camera Setup ---
 // Initialize camera with the snowman's position and rotation
 cameraManager.initialize(
@@ -197,131 +129,30 @@ const { updateSnowman, updateCamera, startLoop, handleResize } = createMainLoop(
 });
 window.addEventListener('resize', handleResize);
 
-function restartGame() {
-  gameOverOverlay.style.display = 'none';
-  state.gameActive = true;
-
-  // Clear the finish result panel from the previous run, if present.
-  const oldResult = document.getElementById('courseResult');
-  if (oldResult && oldResult.parentNode) oldResult.parentNode.removeChild(oldResult);
-  
-  // Add game-active class to body for styling
-  document.body.classList.add('game-active');
-  
-  // Show and reset game stats
-  const gameStatsContainer = document.getElementById('gameStatsContainer');
-  if (gameStatsContainer) {
-    gameStatsContainer.classList.remove('collapsed');
-    const toggleBtn = document.getElementById('toggleStats');
-    if (toggleBtn) {
-      toggleBtn.textContent = '▲';
-    }
-    
-    // Reset colors for best time display
-    const bestTimeElement = document.getElementById('bestTimeValue');
-    if (bestTimeElement) {
-      bestTimeElement.style.color = ''; // Reset to default color
-    }
-  }
-  
-  resetSnowman();
-  
-  // Initialize camera with the snowman's position and rotation
-  cameraManager.initialize(snowman.position, snowman.rotation);
-  
-  // TODO: AUDIO DISABLED - Resume audio (will be no-op if disabled)
-  if (AudioModule) {
-    AudioModule.enableSound(true);
-  }
-  
-  // Reset animation if it was stopped
-  if (!state.animationRunning) {
-    state.animationRunning = true;
-    startLoop();
-  }
-}
-// Make restartGame accessible globally for touch handler
+// --- Run lifecycle (see game/lifecycle.ts): reset / restart / camera toggle ---
+// Built after the loop (restartGame uses startLoop). Re-publish the three hooks the
+// touch handlers + controls.js drive by bare name, then wire the DOM controls.
+const { resetSnowman, restartGame, toggleCameraView, initLifecycleUI } = createLifecycle({
+  state,
+  cameraManager,
+  snowman,
+  gameOverOverlay,
+  restartButton,
+  player,
+  startLoop,
+});
+// Make reset/restart/toggle accessible globally for touch + keyboard handlers.
+window.resetSnowman = resetSnowman;
 window.restartGame = restartGame;
+window.toggleCameraView = toggleCameraView;
+initLifecycleUI();
 
 // Make showGameOver accessible globally for test hooks
 window.showGameOver = showGameOver;
-
-// Toggle between first-person and third-person camera views
-function toggleCameraView() {
-  // Call the camera manager's toggle method
-  const newMode = cameraManager.toggleCameraMode();
-  
-  // Reset camera initialization with current snowman position and rotation
-  cameraManager.initialize(snowman.position, snowman.rotation);
-  
-  // Update the camera mode text in the controls info
-  const viewControlItem = document.querySelector('#controlsContent .control-item:last-child');
-  if (viewControlItem) {
-    const keyBadge = viewControlItem.querySelector('.key-badge');
-    const textSpan = viewControlItem.querySelector('span:last-child');
-    
-    if (keyBadge && textSpan) {
-      keyBadge.textContent = 'V';
-      textSpan.textContent = `Toggle ${newMode === 'thirdPerson' ? 'Normal' : 'Chase'} View`;
-    }
-  }
-  
-  // Update the toggle button text
-  const cameraToggleBtn = document.getElementById('cameraToggleBtn');
-  if (cameraToggleBtn) {
-    cameraToggleBtn.textContent = `Toggle ${newMode === 'thirdPerson' ? 'Normal' : 'Chase'} View`;
-  }
-  
-  // Return the new mode (useful for tests)
-  return newMode;
-}
-
-// Make toggleCameraView accessible globally for the keyboard handler in controls.js
-window.toggleCameraView = toggleCameraView;
-
-// Add test hook functions for tree collision testing
-function addTestHooks(
-  pos: { x: number; y: number; z: number },
-  showGameOver: (reason: string) => void,
-  getTerrainHeight: TerrainHeightFn
-) {
-  console.log("Snowman.addTestHooks called - setting up test hooks");
-  
-  if (!window.testHooks) {
-    window.testHooks = {};
-  }
-  
-  // Add a force collision function that can be called by tests
-  window.testHooks.forceTreeCollision = function() {
-    console.log("TEST: forceTreeCollision hook called");
-    
-    // Create a direct function reference to ensure it works
-    const directShowGameOver = window.showGameOver || showGameOver;
-    
-    // Call the function directly to ensure it works
-    console.log("TEST: Forcing tree collision (direct call)");
-    try {
-      directShowGameOver("BANG!!! You hit a tree!");
-      console.log("TEST: Successfully called showGameOver");
-    } catch (error) {
-      console.error("TEST ERROR: Failed to call showGameOver:", error);
-      // As a fallback, just simulate the collision for the test
-      window.testCollisionDetected = true;
-    }
-    
-    return true;
-  };
-  
-  // Other test hooks and functionality...
-}
-
 // Initialize test hooks explicitly to ensure they're available immediately
 // This is important for browser tests that run soon after page load
 console.log("Initializing test hooks on startup");
 Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
-
-// Add event listener to restart button
-restartButton.addEventListener('click', restartGame);
 
 // Initialize controls toggle when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## What

**R2 step 6 (final R2)** of the snowglider/snowman split (see
[`docs/REFACTORING_SNOWGLIDER_SNOWMAN.md`](https://github.com/den-run-ai/snowglider/blob/main/docs/REFACTORING_SNOWGLIDER_SNOWMAN.md), issue #34).

Extracts the run lifecycle out of `src/snowglider.ts` into a new
**`src/game/lifecycle.ts`** (`createLifecycle(deps)`), returning `resetSnowman` /
`restartGame` / `toggleCameraView` plus `initLifecycleUI()` (which wires the reset
button, the camera-toggle button — created + appended here — and the restart button).
The coordinator re-publishes the three hooks on `window` and calls `initLifecycleUI()`.

**Deletes the dead local `addTestHooks` shim** — never called by bare name (all live
sites call `Snowman.addTestHooks`); a stale, incomplete duplicate that only installed
`forceTreeCollision`. The real browser hooks come from `Snowman.addTestHooks`, which
the coordinator still calls eagerly. `publishGameGlobals()`, the `isTestMode` flag, and
the test-mode auto-start stay in the coordinator (they proxy its own bindings).

## Result: snowglider.ts is now a thin coordinator

**1380 → ~380 lines.** It now contains only: imports + the
`setupScene()` / `createMainLoop()` / `createLifecycle()` wiring, the eager
`Snowman.addTestHooks` calls, `window.initializeGameWithAudio`,
`publishGameGlobals()`, and the test-mode auto-start.

## Behavior preserved (mechanical move only)

- Every `window.*` hook (`resetSnowman` / `restartGame` / `toggleCameraView` /
  `showGameOver` / `initializeGameWithAudio`) and the `publishGameGlobals()` proxy set
  are unchanged (contract guard 44/44).
- Dropped now-unused coordinator imports: `CourseModule`, `EffectsModule`.

## Verification

- `npm run lint` (0 errors) / `npm run typecheck` — clean
- `npm test` incl. **contract-surface guard 44/44**
- `npm run build` (Vite) — green
- `npm run test:browser` (puppeteer) — **87/87 across 7/7 suites** (controls/camera
  drive reset/restart/toggle).

## Stacking

Stacked on **#150 (R2.5)**; base is `refactor/r2-5-main-loop`. This completes Stage R2
(issue #34); Stage R3 (`snowman.ts` → `src/snowman/*`) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)