### PR TITLE
refactor(snowman): extract pose updates to src/snowman/pose.ts (R3.9, #34)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,9 +240,10 @@ camera.position -= shake                          // revert so smoothing stays c
 > **`src/snowman/index.ts`** behind a thin **`src/snowman.ts`** facade
 > (`export * from './snowman/index.js'`) so every `./snowman.js` importer keeps
 > resolving a sibling file. R3.8 moved model construction into
-> **`src/snowman/model.ts`**; the verification harness self-registers the same
+> **`src/snowman/model.ts`**, and R3.9 moved heading/tilt/ski-pose animation into
+> **`src/snowman/pose.ts`**. The verification harness self-registers the same
 > `.js` -> `.ts` resolver as the Node suites before importing the facade, so the
-> public seam remains the thing under test as steps 9–12 carve `pose` / `physics` /
+> public seam remains the thing under test as steps 10–12 carve `physics` /
 > `collision` / `test-hooks` out of `index.ts`.
 
 ---

--- a/src/snowman/index.ts
+++ b/src/snowman/index.ts
@@ -17,6 +17,7 @@
 // confirms coasting stays bit-identical to the frozen baseline.
 import * as THREE from 'three';
 import { createSnowman } from './model.js';
+import { applySnowmanPose } from './pose.js';
 
 // These contract types are exported so the typed player-state layer in
 // physics.ts (PR 3.21) shares snowman's exact call contract instead of
@@ -79,7 +80,7 @@ export interface CameraManagerLike {
 export type ShowGameOverFn = (reason: string) => void;
 
 /** Ski technique surfaced for the HUD + ski pose. */
-type SkiTechnique = 'air' | 'glide' | 'snowplow' | 'skid' | 'carve' | 'parallel' | 'tuck' | 'hop';
+export type SkiTechnique = 'air' | 'glide' | 'snowplow' | 'skid' | 'carve' | 'parallel' | 'tuck' | 'hop';
 
 /** Per-frame physics output returned by updateSnowman. */
 export interface UpdateResult {
@@ -434,30 +435,6 @@ function updateSnowman(snowman: THREE.Object3D, delta: number, pos: PlayerPos, v
     velocity.x *= (1 - totalFriction);
     velocity.z *= (1 - totalFriction);
     
-    // Show the current technique on the snowman: a snowplow forms a beginner ski
-    // wedge (tips inward), while a parallel turn draws the skis together and rolls
-    // them onto their edges into the turn (angulation) — visually distinct from the
-    // wedge. Purely cosmetic; none of this touches the physics.
-    if (snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
-      const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
-      const lerp = Math.min(1, delta * 10);
-      const wedge = snowplow ? 0.35 : 0.0; // radians; tips angled inward
-      ls.rotation.y += ((-wedge) - ls.rotation.y) * lerp;
-      rs.rotation.y += ((wedge) - rs.rotation.y) * lerp;
-      // Parallel angulation: both skis edge the same way (into the turn) and slide
-      // toward each other; everything relaxes back to neutral otherwise.
-      const isParallel = technique === 'parallel';
-      const edge = isParallel ? steering * 0.28 : 0.0;
-      const draw = isParallel ? 0.35 : 0.0;
-      const lbx = (snowman.userData.leftSkiBaseX ?? -1) + draw;
-      const rbx = (snowman.userData.rightSkiBaseX ?? 1) - draw;
-      ls.rotation.z += (edge - ls.rotation.z) * lerp;
-      rs.rotation.z += (edge - rs.rotation.z) * lerp;
-      ls.position.x += (lbx - ls.position.x) * lerp;
-      rs.position.x += (rbx - rs.position.x) * lerp;
-      snowman.userData.technique = technique;
-    }
-    
     // Update y position to terrain height when not in air
     pos.y = terrainHeightAtPosition;
   }
@@ -469,90 +446,20 @@ function updateSnowman(snowman: THREE.Object3D, delta: number, pos: PlayerPos, v
   // Store current terrain height for next frame
   lastTerrainHeight = terrainHeightAtPosition;
   
-  // Update snowman position and rotation
-  snowman.position.set(pos.x, pos.y, pos.z);
-  
-  // More sophisticated rotation handling with smoothing
-  const movementDir = { x: velocity.x, z: velocity.z };
-  
-  // Add persistent rotation value for smoother transitions
-  if (!snowman.userData) snowman.userData = {};
-  if (snowman.userData.targetRotationY === undefined) {
-    snowman.userData.targetRotationY = Math.PI; // Default facing downhill
-    snowman.userData.currentRotX = 0;
-    snowman.userData.currentRotZ = 0;
-  }
-  
-  if (currentSpeed > 0.5) { // Only rotate if moving with significant speed
-    // Calculate target rotation - keep existing if below threshold
-    snowman.userData.targetRotationY = Math.atan2(movementDir.x, movementDir.z);
-  }
-  
-  // Apply rotation with smoothing - more stability at higher speeds
-  const rotationSmoothingY = Math.min(1, Math.max(0.05, delta * 2.5));
-  
-  // Interpolate toward target rotation - never rotate more than 15 degrees at once
-  const currentRotY = snowman.rotation.y;
-  const targetRotY = snowman.userData.targetRotationY;
-  
-  // Determine the shortest rotation direction (handle wrapping at 2π)
-  let deltaRotation = targetRotY - currentRotY;
-  if (deltaRotation > Math.PI) deltaRotation -= Math.PI * 2;
-  if (deltaRotation < -Math.PI) deltaRotation += Math.PI * 2;
-  
-  // Apply smoothed rotation with a max rate to prevent spinning
-  const maxRotationRate = delta * 3; // Max ~180° per second
-  const appliedDelta = Math.max(-maxRotationRate, Math.min(maxRotationRate, deltaRotation * rotationSmoothingY));
-  snowman.rotation.y += appliedDelta;
-  
-  // Normalize rotation to 0-2π range
-  snowman.rotation.y = snowman.rotation.y % (Math.PI * 2);
-  if (snowman.rotation.y < 0) snowman.rotation.y += Math.PI * 2;
-  
-  // Calculate a tilt based on the slope and turning with improved smoothing
-  // Use wider sample points for more stable gradients
-  const sampleDist = 0.4; // Even wider sampling for stability
-  const gradX = (getTerrainHeight(pos.x + sampleDist, pos.z) - getTerrainHeight(pos.x - sampleDist, pos.z)) / (2 * sampleDist);
-  const gradZ = (getTerrainHeight(pos.x, pos.z + sampleDist) - getTerrainHeight(pos.x, pos.z - sampleDist)) / (2 * sampleDist);
-  
-  // Add more dramatic jump rotation - lean forward during jumps
-  let jumpTilt = 0;
-  if (isInAir) {
-    // More dramatic tilt during jumps, especially on takeoff
-    if (verticalVelocity > 0) {
-      // Lean back on ascent
-      jumpTilt = -Math.min(0.4, verticalVelocity * 0.03);
-    } else {
-      // Lean forward on descent, more as you fall faster
-      jumpTilt = Math.min(0.5, -verticalVelocity * 0.025);
-    }
-  }
-  
-  // Add more controlled turning tilt with speed-based scaling
-  const turnTiltFactor = Math.min(0.3, currentSpeed / 25); // Less tilt at lower speeds
-  const turnTilt = velocity.x * turnTiltFactor;
-  
-  // Limit maximum tilt angles to prevent unrealistic leaning
-  const maxTiltAngle = 0.25; // Reduced to about 14 degrees maximum tilt
-  
-  // Apply smoothing and clamping to rotation values
-  const targetRotX = gradZ * 0.3 + jumpTilt; // Add jump tilt to X rotation
-  const targetRotZ = -gradX * 0.3 - turnTilt;
-  
-  // Significantly improve tilt smoothing
-  const tiltSmoothing = isInAir ? 0.05 : 0.08; // Lower values for smoother transitions
-  
-  // Use lerp for smooth rotation
-  snowman.userData.currentRotX = snowman.userData.currentRotX || 0;
-  snowman.userData.currentRotZ = snowman.userData.currentRotZ || 0;
-  
-  // Smoothly transition current rotations toward target
-  snowman.userData.currentRotX += (targetRotX - snowman.userData.currentRotX) * tiltSmoothing;
-  snowman.userData.currentRotZ += (targetRotZ - snowman.userData.currentRotZ) * tiltSmoothing;
-  
-  // Apply clamped rotations 
-  snowman.rotation.x = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotX));
-  snowman.rotation.z = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotZ));
+  applySnowmanPose(snowman, {
+    delta,
+    pos,
+    velocity,
+    isInAir,
+    verticalVelocity,
+    currentSpeed,
+    technique,
+    // Steering sign for parallel ski angulation — recomputed here from `controls`
+    // (the updateSnowman param, always in scope), matching the physics branch's
+    // block-scoped local `steering` so the cosmetic pose is unchanged from #146.
+    steering: (controls.left ? -1 : 0) + (controls.right ? 1 : 0),
+    getTerrainHeight
+  });
   
   // Check if snowman is off the terrain or falling
   const fallThreshold = 0.5; // How far below terrain to allow before reset
@@ -654,9 +561,8 @@ function updateSnowman(snowman: THREE.Object3D, delta: number, pos: PlayerPos, v
     const horizontalDistance = Math.sqrt(dx*dx + dz*dz);
     // Collision radius (max 3u). Kept in sync with Mountains.rockCollisionRadius,
     // which the placement-time safe-zone uses to exclude rocks that would reach the
-    // ski lane/spawn pocket. Duplicated inline (rather than imported) because
-    // snowman.ts must stay free of relative imports: some Node test harnesses load
-    // it without the .js->.ts resolve hook, and Node 22 won't map ./mountains.js.
+    // ski lane/spawn pocket. Duplicated inline (rather than imported) to keep the
+    // snowman/collision layer independent of mountain placement helpers during R3.
     const rockRadius = Math.max(1.25, Math.min(3.0, rockPos.size * 0.75 + 0.75));
     const exposedRockTop = rockPos.y + rockPos.size * 0.7;
     // Clearance is height-based: once the snowman is airborne and above the rock

--- a/src/snowman/pose.ts
+++ b/src/snowman/pose.ts
@@ -1,0 +1,139 @@
+// Snowman visual pose updates: ski wedge, heading, terrain tilt, jump tilt, and turn lean.
+import * as THREE from 'three';
+
+import type { PlanarVelocity, PlayerPos, SkiTechnique, TerrainHeightFn } from './index.js';
+
+interface SnowmanPoseState {
+  delta: number;
+  pos: PlayerPos;
+  velocity: PlanarVelocity;
+  isInAir: boolean;
+  verticalVelocity: number;
+  currentSpeed: number;
+  technique: SkiTechnique;
+  steering: number;
+  getTerrainHeight: TerrainHeightFn;
+}
+
+export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseState): void {
+  const {
+    delta,
+    pos,
+    velocity,
+    isInAir,
+    verticalVelocity,
+    currentSpeed,
+    technique,
+    steering,
+    getTerrainHeight
+  } = state;
+
+  // Show the current technique on the snowman: a snowplow forms a beginner ski
+  // wedge (tips inward), while a parallel turn draws the skis together and rolls
+  // them onto their edges into the turn (angulation) — visually distinct from the
+  // wedge. Purely cosmetic; none of this touches the physics.
+  if (!isInAir && snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
+    const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
+    const lerp = Math.min(1, delta * 10);
+    const wedge = technique === 'snowplow' ? 0.35 : 0.0; // radians; tips angled inward
+    ls.rotation.y += ((-wedge) - ls.rotation.y) * lerp;
+    rs.rotation.y += ((wedge) - rs.rotation.y) * lerp;
+    // Parallel angulation: both skis edge the same way (into the turn) and slide
+    // toward each other; everything relaxes back to neutral otherwise.
+    const isParallel = technique === 'parallel';
+    const edge = isParallel ? steering * 0.28 : 0.0;
+    const draw = isParallel ? 0.35 : 0.0;
+    const lbx = (snowman.userData.leftSkiBaseX ?? -1) + draw;
+    const rbx = (snowman.userData.rightSkiBaseX ?? 1) - draw;
+    ls.rotation.z += (edge - ls.rotation.z) * lerp;
+    rs.rotation.z += (edge - rs.rotation.z) * lerp;
+    ls.position.x += (lbx - ls.position.x) * lerp;
+    rs.position.x += (rbx - rs.position.x) * lerp;
+    snowman.userData.technique = technique;
+  }
+
+  // Update snowman position and rotation
+  snowman.position.set(pos.x, pos.y, pos.z);
+  
+  // More sophisticated rotation handling with smoothing
+  const movementDir = { x: velocity.x, z: velocity.z };
+  
+  // Add persistent rotation value for smoother transitions
+  if (!snowman.userData) snowman.userData = {};
+  if (snowman.userData.targetRotationY === undefined) {
+    snowman.userData.targetRotationY = Math.PI; // Default facing downhill
+    snowman.userData.currentRotX = 0;
+    snowman.userData.currentRotZ = 0;
+  }
+  
+  if (currentSpeed > 0.5) { // Only rotate if moving with significant speed
+    // Calculate target rotation - keep existing if below threshold
+    snowman.userData.targetRotationY = Math.atan2(movementDir.x, movementDir.z);
+  }
+  
+  // Apply rotation with smoothing - more stability at higher speeds
+  const rotationSmoothingY = Math.min(1, Math.max(0.05, delta * 2.5));
+  
+  // Interpolate toward target rotation - never rotate more than 15 degrees at once
+  const currentRotY = snowman.rotation.y;
+  const targetRotY = snowman.userData.targetRotationY;
+  
+  // Determine the shortest rotation direction (handle wrapping at 2pi)
+  let deltaRotation = targetRotY - currentRotY;
+  if (deltaRotation > Math.PI) deltaRotation -= Math.PI * 2;
+  if (deltaRotation < -Math.PI) deltaRotation += Math.PI * 2;
+  
+  // Apply smoothed rotation with a max rate to prevent spinning
+  const maxRotationRate = delta * 3; // Max ~180deg per second
+  const appliedDelta = Math.max(-maxRotationRate, Math.min(maxRotationRate, deltaRotation * rotationSmoothingY));
+  snowman.rotation.y += appliedDelta;
+  
+  // Normalize rotation to 0-2pi range
+  snowman.rotation.y = snowman.rotation.y % (Math.PI * 2);
+  if (snowman.rotation.y < 0) snowman.rotation.y += Math.PI * 2;
+  
+  // Calculate a tilt based on the slope and turning with improved smoothing
+  // Use wider sample points for more stable gradients
+  const sampleDist = 0.4; // Even wider sampling for stability
+  const gradX = (getTerrainHeight(pos.x + sampleDist, pos.z) - getTerrainHeight(pos.x - sampleDist, pos.z)) / (2 * sampleDist);
+  const gradZ = (getTerrainHeight(pos.x, pos.z + sampleDist) - getTerrainHeight(pos.x, pos.z - sampleDist)) / (2 * sampleDist);
+  
+  // Add more dramatic jump rotation - lean forward during jumps
+  let jumpTilt = 0;
+  if (isInAir) {
+    // More dramatic tilt during jumps, especially on takeoff
+    if (verticalVelocity > 0) {
+      // Lean back on ascent
+      jumpTilt = -Math.min(0.4, verticalVelocity * 0.03);
+    } else {
+      // Lean forward on descent, more as you fall faster
+      jumpTilt = Math.min(0.5, -verticalVelocity * 0.025);
+    }
+  }
+  
+  // Add more controlled turning tilt with speed-based scaling
+  const turnTiltFactor = Math.min(0.3, currentSpeed / 25); // Less tilt at lower speeds
+  const turnTilt = velocity.x * turnTiltFactor;
+  
+  // Limit maximum tilt angles to prevent unrealistic leaning
+  const maxTiltAngle = 0.25; // Reduced to about 14 degrees maximum tilt
+  
+  // Apply smoothing and clamping to rotation values
+  const targetRotX = gradZ * 0.3 + jumpTilt; // Add jump tilt to X rotation
+  const targetRotZ = -gradX * 0.3 - turnTilt;
+  
+  // Significantly improve tilt smoothing
+  const tiltSmoothing = isInAir ? 0.05 : 0.08; // Lower values for smoother transitions
+  
+  // Use lerp for smooth rotation
+  snowman.userData.currentRotX = snowman.userData.currentRotX || 0;
+  snowman.userData.currentRotZ = snowman.userData.currentRotZ || 0;
+  
+  // Smoothly transition current rotations toward target
+  snowman.userData.currentRotX += (targetRotX - snowman.userData.currentRotX) * tiltSmoothing;
+  snowman.userData.currentRotZ += (targetRotZ - snowman.userData.currentRotZ) * tiltSmoothing;
+  
+  // Apply clamped rotations 
+  snowman.rotation.x = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotX));
+  snowman.rotation.z = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotZ));
+}


### PR DESCRIPTION
## What

**R3 step 9** of the snowglider/snowman split (issue #34).

Extracts the snowman visual pose update code from `src/snowman/index.ts` into **`src/snowman/pose.ts`**:

- ski wedge animation for snowplow/glide technique display
- world position assignment after physics integration
- heading smoothing
- terrain tilt sampling
- jump tilt and turn lean
- clamped `rotation.x` / `rotation.z` smoothing

`updateSnowman()` still owns physics state, current-speed calculation, jump/air control, ski-technique classification, collision checks, and the return value. It now delegates visual pose work through `applySnowmanPose(...)` with the same inputs the inline block already used.

## Behavior preserved

The extraction preserves the existing ordering:

1. physics integrates velocity/position
2. `lastTerrainHeight` is updated
3. visual pose is applied
4. collision/finish checks run
5. the same `UpdateResult` object is returned

The ski wedge still only updates while grounded, matching the old `else` branch. `SkiTechnique` is exported as a type so the new pose module can share the existing contract without a runtime dependency.

Also updates a stale inline comment that still claimed snowman had to stay free of relative imports; R3.8 already began the submodule split.

## Verification

Run under Node `v23.10.0` via nvm:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors, existing 27 warnings
- `npm run test:verify` — physics invariant OK; DOM smoke 18/0
- `npm test` — all Node suites pass, incl. contract-surface guard 44/44
- `npm run build` — green
- `npm run test:browser` — **87/87 across 7/7 suites**

## Stacking

Stacked on **#154 (R3.8)**; base is `refactor/r3-8-snowman-model`. Next steps split physics / collision / test hooks from `src/snowman/index.ts`.

🤖 Generated with Codex