### PR TITLE
refactor(snowman): extract collision handling to src/snowman/collision.ts (R3.11, #34)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,10 +242,11 @@ camera.position -= shake                          // revert so smoothing stays c
 > resolving a sibling file. R3.8 moved model construction into
 > **`src/snowman/model.ts`**, and R3.9 moved heading/tilt/ski-pose animation into
 > **`src/snowman/pose.ts`**. R3.10 moved reset + movement integration into
-> **`src/snowman/physics.ts`**. The verification harness self-registers the same
-> `.js` -> `.ts` resolver as the Node suites before importing the facade, so the
-> public seam remains the thing under test as steps 11–12 carve `collision` /
-> `test-hooks` out of `index.ts`.
+> **`src/snowman/physics.ts`**. R3.11 moved tree/rock/bounds/end-of-run checks
+> into **`src/snowman/collision.ts`**. The verification harness self-registers
+> the same `.js` -> `.ts` resolver as the Node suites before importing the facade,
+> so the public seam remains the thing under test as step 12 carves `test-hooks`
+> out of `index.ts`.
 
 ---
 

--- a/src/snowman/collision.ts
+++ b/src/snowman/collision.ts
@@ -1,0 +1,173 @@
+// Snowman collision and finish-state checks.
+import type { PlayerPos, RockPos, ShowGameOverFn, TreePos } from './index.js';
+
+interface SnowmanCollisionState {
+  pos: PlayerPos;
+  isInAir: boolean;
+  verticalVelocity: number;
+  terrainHeightAtPosition: number;
+  treePositions: TreePos[];
+  rockPositions: RockPos[];
+  gameActive: boolean;
+  showGameOver: ShowGameOverFn;
+}
+
+export function detectCollisionsAndFinish(state: SnowmanCollisionState): void {
+  const {
+    pos,
+    isInAir,
+    verticalVelocity,
+    terrainHeightAtPosition,
+    treePositions,
+    rockPositions,
+    gameActive,
+    showGameOver
+  } = state;
+
+  // Check if snowman is off the terrain or falling
+  const fallThreshold = 0.5; // How far below terrain to allow before reset
+
+  // Check for tree collisions
+  // Use the window variable for collision radius if set (for testing), otherwise use default
+  const treeCollisionRadius = window.treeCollisionRadius || 2.5; // Collision distance for trees
+
+  // In test mode, output complete tree positions for debugging
+  if (window.location.search.includes('test=true') && treePositions.length > 0) {
+    console.log(`TREES LOADED: ${treePositions.length} trees found`);
+    console.log(`SNOWMAN POS: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}, z=${pos.z.toFixed(2)}`);
+    console.log(`FIRST TREE: x=${treePositions[0].x.toFixed(2)}, y=${treePositions[0].y.toFixed(2)}, z=${treePositions[0].z.toFixed(2)}`);
+  }
+
+  // Count trees in extended terrain area for logging
+  const extendedTreesCount = treePositions.filter(t => t.z < -80).length;
+  const totalTreesCount = treePositions.length;
+
+  // Log tree information when in test mode
+  if (window.location.search.includes('test=true') && !window._treeCheckLogged) {
+    console.log(`TREE COLLISION INFO: ${totalTreesCount} total trees, ${extendedTreesCount} in extended area (z < -80)`);
+
+    // Log the ranges to verify coverage
+    if (treePositions.length > 0) {
+      const zMin = Math.min(...treePositions.map(t => t.z));
+      const zMax = Math.max(...treePositions.map(t => t.z));
+      const xMin = Math.min(...treePositions.map(t => t.x));
+      const xMax = Math.max(...treePositions.map(t => t.x));
+      console.log(`TREE COLLISION RANGES: X: ${xMin.toFixed(1)} to ${xMax.toFixed(1)}, Z: ${zMin.toFixed(1)} to ${zMax.toFixed(1)}`);
+    }
+    window._treeCheckLogged = true;
+  }
+
+  // Check collision with any tree
+  const treeCollision = treePositions.some(treePos => {
+    // Special case for tests - direct position match or very close positions always collide
+    // Use a small epsilon for floating point comparison, increased for test reliability
+    // This helps with floating-point precision issues in tests
+    const epsilon = window.location.search.includes('test') ? 0.1 : 0.001;
+
+    const exactMatch =
+      Math.abs(pos.x - treePos.x) < epsilon &&
+      Math.abs(pos.z - treePos.z) < epsilon;
+
+    if (exactMatch) {
+      if (window.location.search.includes('test=true')) {
+        console.log(`DIRECT TREE HIT at (${pos.x.toFixed(2)}, ${pos.z.toFixed(2)})`);
+      }
+      return true;
+    }
+
+    // Check horizontal distance for collision (2D distance ignoring height)
+    const dx = pos.x - treePos.x;
+    const dz = pos.z - treePos.z;
+    const horizontalDistance = Math.sqrt(dx*dx + dz*dz);
+
+    // We only detect collision if the horizontal distance is close enough
+    // Tree collision only happens when snowman is on the ground or close to it
+    const isCloseEnough = horizontalDistance < treeCollisionRadius;
+
+    // Only consider jumping over trees when genuinely in the air AND moving upward AND high enough
+    const isJumpingHighAboveTrees = isInAir && verticalVelocity > 0 && pos.y > (treePos.y + 5);
+
+    // Debug collision in browser tests when needed
+    if (window.location.search.includes('test=true')) {
+      // For extended terrain trees, log additional info
+      const inExtendedArea = treePos.z < -80;
+      console.log(`TREE CHECK: dist=${horizontalDistance.toFixed(2)}, radius=${treeCollisionRadius}, jumping=${isJumpingHighAboveTrees}, collision=${isCloseEnough && !isJumpingHighAboveTrees}, extended=${inExtendedArea}`);
+
+      // Extra debugging info for very close trees
+      if (horizontalDistance < 5) {
+        console.log(`CLOSE TREE: x=${treePos.x.toFixed(2)}, y=${treePos.y.toFixed(2)}, z=${treePos.z.toFixed(2)}, snowman: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}, z=${pos.z.toFixed(2)}`);
+      }
+    }
+
+    // Special handling for tests in browser-tests.js
+    if (window.location.search.includes('test') && horizontalDistance < 0.5) {
+      console.log(`TEST MODE: Forcing collision with very close tree (${horizontalDistance.toFixed(2)})`);
+      return true;
+    }
+
+    // Special handling for tree jumping test
+    if (window.testTreeJumpingCheck && isJumpingHighAboveTrees) {
+      console.log(`TREE JUMPING TEST: Allowing jump over tree (dist=${horizontalDistance.toFixed(2)})`);
+      // Don't detect collision during jump - normal game behavior
+      return false;
+    }
+
+    // Allow jumping over trees but collide when on the ground
+    return isCloseEnough && !isJumpingHighAboveTrees;
+  });
+
+  // Check collision with large, exposed rocks. Small half-buried stones remain
+  // terrain detail; only positions returned by Mountains.addRocks reach this list.
+  const rockCollision = rockPositions.some(rockPos => {
+    const dx = pos.x - rockPos.x;
+    const dz = pos.z - rockPos.z;
+    const horizontalDistance = Math.sqrt(dx*dx + dz*dz);
+    // Collision radius (max 3u). Kept in sync with Mountains.rockCollisionRadius,
+    // which the placement-time safe-zone uses to exclude rocks that would reach the
+    // ski lane/spawn pocket. Duplicated inline (rather than imported) to keep the
+    // snowman/collision layer independent of mountain placement helpers during R3.
+    const rockRadius = Math.max(1.25, Math.min(3.0, rockPos.size * 0.75 + 0.75));
+    const exposedRockTop = rockPos.y + rockPos.size * 0.7;
+    // Clearance is height-based: once the snowman is airborne and above the rock
+    // top it clears the hazard whether it is still rising or already descending past
+    // the jump apex. (Requiring upward motion made descending-but-high jumps crash.)
+    const isJumpingOverRock = isInAir && pos.y > exposedRockTop + 0.5;
+
+    if (window.location.search.includes('test=true') && horizontalDistance < 5) {
+      console.log(`ROCK CHECK: dist=${horizontalDistance.toFixed(2)}, radius=${rockRadius.toFixed(2)}, jumping=${isJumpingOverRock}, collision=${horizontalDistance < rockRadius && !isJumpingOverRock}`);
+    }
+
+    return horizontalDistance < rockRadius && !isJumpingOverRock;
+  });
+
+  // Reset if: reaches end of slope, goes off sides, falls off terrain, or hits a tree
+  // Allow wider boundaries to match the extended mountain terrain
+  // Only skip boundary check during regression/tree tests, but NOT during browser tests or unified tests
+  const inExtendedMountainTest = window.location.search.includes('test=regression') ||
+                                window.location.search.includes('test=tree'); // Only skip for specific tests
+  if (pos.z < -195 || // Extended from -95 to -195 for longer run
+      (!inExtendedMountainTest && Math.abs(pos.x) > 120) || // Keep boundary check during browser/unified tests
+      (!isInAir && pos.y < terrainHeightAtPosition - fallThreshold) ||
+      treeCollision ||
+      rockCollision) {
+
+    if (gameActive) {
+      // Determine the reason for game over
+      let reason = "You crashed!";
+
+      if (treeCollision) {
+        reason = "BANG!!! You hit a tree!";
+      } else if (rockCollision) {
+        reason = "BANG!!! You hit a rock!";
+      } else if (pos.z < -195) {
+        reason = "You reached the end of the slope!";
+      } else if (Math.abs(pos.x) > 120) {
+        reason = "You went off the mountain!";
+      } else if (!isInAir && pos.y < terrainHeightAtPosition - fallThreshold) {
+        reason = "You fell off the terrain!";
+      }
+
+      showGameOver(reason);
+    }
+  }
+}

--- a/src/snowman/index.ts
+++ b/src/snowman/index.ts
@@ -16,6 +16,7 @@
 // native type-stripping run it exactly as before; the physics-invariant harness
 // confirms coasting stays bit-identical to the frozen baseline.
 import * as THREE from 'three';
+import { detectCollisionsAndFinish } from './collision.js';
 import { createSnowman } from './model.js';
 import { resetSnowman, stepSnowmanPhysics } from './physics.js';
 import { applySnowmanPose } from './pose.js';
@@ -142,154 +143,18 @@ function updateSnowman(snowman: THREE.Object3D, delta: number, pos: PlayerPos, v
 
   isInAir = result.isInAir;
   verticalVelocity = result.verticalVelocity;
-  
-  // Check if snowman is off the terrain or falling
-  const fallThreshold = 0.5; // How far below terrain to allow before reset
-  
-  // Check for tree collisions
-  // Use the window variable for collision radius if set (for testing), otherwise use default
-  const treeCollisionRadius = window.treeCollisionRadius || 2.5; // Collision distance for trees
-  
-  // In test mode, output complete tree positions for debugging
-  if (window.location.search.includes('test=true') && treePositions.length > 0) {
-    console.log(`TREES LOADED: ${treePositions.length} trees found`);
-    console.log(`SNOWMAN POS: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}, z=${pos.z.toFixed(2)}`);
-    console.log(`FIRST TREE: x=${treePositions[0].x.toFixed(2)}, y=${treePositions[0].y.toFixed(2)}, z=${treePositions[0].z.toFixed(2)}`);
-  }
-  
-  // Count trees in extended terrain area for logging
-  const extendedTreesCount = treePositions.filter(t => t.z < -80).length;
-  const totalTreesCount = treePositions.length;
-  
-  // Log tree information when in test mode
-  if (window.location.search.includes('test=true') && !window._treeCheckLogged) {
-    console.log(`TREE COLLISION INFO: ${totalTreesCount} total trees, ${extendedTreesCount} in extended area (z < -80)`);
-    
-    // Log the ranges to verify coverage
-    if (treePositions.length > 0) {
-      const zMin = Math.min(...treePositions.map(t => t.z));
-      const zMax = Math.max(...treePositions.map(t => t.z));
-      const xMin = Math.min(...treePositions.map(t => t.x));
-      const xMax = Math.max(...treePositions.map(t => t.x));
-      console.log(`TREE COLLISION RANGES: X: ${xMin.toFixed(1)} to ${xMax.toFixed(1)}, Z: ${zMin.toFixed(1)} to ${zMax.toFixed(1)}`);
-    }
-    window._treeCheckLogged = true;
-  }
-  
-  // Check collision with any tree
-  const treeCollision = treePositions.some(treePos => {
-    // Special case for tests - direct position match or very close positions always collide
-    // Use a small epsilon for floating point comparison, increased for test reliability
-    // This helps with floating-point precision issues in tests
-    const epsilon = window.location.search.includes('test') ? 0.1 : 0.001;
-    
-    const exactMatch = 
-      Math.abs(pos.x - treePos.x) < epsilon && 
-      Math.abs(pos.z - treePos.z) < epsilon;
-    
-    if (exactMatch) {
-      if (window.location.search.includes('test=true')) {
-        console.log(`DIRECT TREE HIT at (${pos.x.toFixed(2)}, ${pos.z.toFixed(2)})`);
-      }
-      return true;
-    }
-    
-    // Check horizontal distance for collision (2D distance ignoring height)
-    const dx = pos.x - treePos.x;
-    const dz = pos.z - treePos.z;
-    const horizontalDistance = Math.sqrt(dx*dx + dz*dz);
-    
-    // We only detect collision if the horizontal distance is close enough
-    // Tree collision only happens when snowman is on the ground or close to it
-    const isCloseEnough = horizontalDistance < treeCollisionRadius;
-    
-    // Only consider jumping over trees when genuinely in the air AND moving upward AND high enough
-    const isJumpingHighAboveTrees = isInAir && verticalVelocity > 0 && pos.y > (treePos.y + 5);
-    
-    // Debug collision in browser tests when needed
-    if (window.location.search.includes('test=true')) {
-      // For extended terrain trees, log additional info
-      const inExtendedArea = treePos.z < -80;
-      console.log(`TREE CHECK: dist=${horizontalDistance.toFixed(2)}, radius=${treeCollisionRadius}, jumping=${isJumpingHighAboveTrees}, collision=${isCloseEnough && !isJumpingHighAboveTrees}, extended=${inExtendedArea}`);
-      
-      // Extra debugging info for very close trees
-      if (horizontalDistance < 5) {
-        console.log(`CLOSE TREE: x=${treePos.x.toFixed(2)}, y=${treePos.y.toFixed(2)}, z=${treePos.z.toFixed(2)}, snowman: x=${pos.x.toFixed(2)}, y=${pos.y.toFixed(2)}, z=${pos.z.toFixed(2)}`);
-      }
-    }
-    
-    // Special handling for tests in browser-tests.js
-    if (window.location.search.includes('test') && horizontalDistance < 0.5) {
-      console.log(`TEST MODE: Forcing collision with very close tree (${horizontalDistance.toFixed(2)})`);
-      return true;
-    }
-    
-    // Special handling for tree jumping test
-    if (window.testTreeJumpingCheck && isJumpingHighAboveTrees) {
-      console.log(`TREE JUMPING TEST: Allowing jump over tree (dist=${horizontalDistance.toFixed(2)})`);
-      // Don't detect collision during jump - normal game behavior
-      return false;
-    }
-    
-    // Allow jumping over trees but collide when on the ground
-    return isCloseEnough && !isJumpingHighAboveTrees;
+
+  detectCollisionsAndFinish({
+    pos,
+    isInAir,
+    verticalVelocity,
+    terrainHeightAtPosition,
+    treePositions,
+    rockPositions,
+    gameActive,
+    showGameOver
   });
 
-  // Check collision with large, exposed rocks. Small half-buried stones remain
-  // terrain detail; only positions returned by Mountains.addRocks reach this list.
-  const rockCollision = rockPositions.some(rockPos => {
-    const dx = pos.x - rockPos.x;
-    const dz = pos.z - rockPos.z;
-    const horizontalDistance = Math.sqrt(dx*dx + dz*dz);
-    // Collision radius (max 3u). Kept in sync with Mountains.rockCollisionRadius,
-    // which the placement-time safe-zone uses to exclude rocks that would reach the
-    // ski lane/spawn pocket. Duplicated inline (rather than imported) to keep the
-    // snowman/collision layer independent of mountain placement helpers during R3.
-    const rockRadius = Math.max(1.25, Math.min(3.0, rockPos.size * 0.75 + 0.75));
-    const exposedRockTop = rockPos.y + rockPos.size * 0.7;
-    // Clearance is height-based: once the snowman is airborne and above the rock
-    // top it clears the hazard whether it is still rising or already descending past
-    // the jump apex. (Requiring upward motion made descending-but-high jumps crash.)
-    const isJumpingOverRock = isInAir && pos.y > exposedRockTop + 0.5;
-
-    if (window.location.search.includes('test=true') && horizontalDistance < 5) {
-      console.log(`ROCK CHECK: dist=${horizontalDistance.toFixed(2)}, radius=${rockRadius.toFixed(2)}, jumping=${isJumpingOverRock}, collision=${horizontalDistance < rockRadius && !isJumpingOverRock}`);
-    }
-
-    return horizontalDistance < rockRadius && !isJumpingOverRock;
-  });
-  
-  // Reset if: reaches end of slope, goes off sides, falls off terrain, or hits a tree
-  // Allow wider boundaries to match the extended mountain terrain
-  // Only skip boundary check during regression/tree tests, but NOT during browser tests or unified tests
-  const inExtendedMountainTest = window.location.search.includes('test=regression') || 
-                                window.location.search.includes('test=tree'); // Only skip for specific tests
-  if (pos.z < -195 || // Extended from -95 to -195 for longer run
-      (!inExtendedMountainTest && Math.abs(pos.x) > 120) || // Keep boundary check during browser/unified tests
-      (!isInAir && pos.y < terrainHeightAtPosition - fallThreshold) ||
-      treeCollision ||
-      rockCollision) {
-    
-    if (gameActive) {
-      // Determine the reason for game over
-      let reason = "You crashed!";
-      
-      if (treeCollision) {
-        reason = "BANG!!! You hit a tree!";
-      } else if (rockCollision) {
-        reason = "BANG!!! You hit a rock!";
-      } else if (pos.z < -195) {
-        reason = "You reached the end of the slope!";
-      } else if (Math.abs(pos.x) > 120) {
-        reason = "You went off the mountain!";
-      } else if (!isInAir && pos.y < terrainHeightAtPosition - fallThreshold) {
-        reason = "You fell off the terrain!";
-      }
-      
-      showGameOver(reason);
-    }
-  }
-  
   // Return updated state variables
   return result;
 }


### PR DESCRIPTION
## What
- Move snowman tree/rock/bounds/end-of-run checks into `src/snowman/collision.ts`.
- Keep `src/snowman/index.ts` as the public `updateSnowman` orchestration layer.
- Update the architecture note for the R3 snowman split.

## Behavior preserved / Verification
- Collision conditions, test-mode logging, game-over reasons, and rock/tree jump-clearance rules are moved without intended behavior changes.
- `npm run typecheck`
- `npm run lint` (0 errors, existing 27 warnings)
- `npm run test:verify`
- `npm test`
- `npm run build`
- `npm run test:browser` (87/87)
- `git diff --check`

## Stacking
- Base: `refactor/r3-10-snowman-physics`
- Next: R3.12 extracts `src/snowman/test-hooks.ts`

🤖 Generated with Codex