### PR TITLE
docs: plan expressive snowman — flex, scarf & crash shatter (#53)

### DIFF
--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -376,9 +376,14 @@ self-terminates when `update()` returns false.
 > **Overlay timing (user-visible, flag this for review).** The `#gameOverOverlay` is 70%
 > black and would dim the wipeout. Proposal: on a **crash**, delay showing the overlay by
 > ~700 ms (a `setTimeout`) so the shatter plays at full brightness, then fade it in;
-> **finish** stays immediate (unchanged). Alternative if we want zero timing change: show
-> the overlay immediately and accept the dimmed shatter behind it. Pick one in review —
-> see Open Questions §11.
+> **finish** stays immediate (unchanged). **If implemented with `setTimeout`, the timer id
+> MUST be stored (e.g. a module-scoped `crashOverlayTimer`) and cleared in `resetSnowman`/
+> `restartGame` (§8.4).** `showGameOver` has already set `gameActive = false` while the
+> Reset control stays visible (and tests call the restart helpers directly), so a
+> reset/restart *before* the timer fires would otherwise re-show `#gameOverOverlay` over
+> the fresh run or strand it inactive behind a stale overlay. Alternative if we want zero
+> timing change: show the overlay immediately and accept the dimmed shatter behind it. Pick
+> one in review — see Open Questions §11.
 
 ### 7.5 `reset()`
 
@@ -398,7 +403,12 @@ Minimal, localized edits:
 
 1. **Construct once** near the avalanche setup: `const debris = new SnowmanDebris();
    debris.setTerrainFunction(Snow.getTerrainHeight);` (store on `state` like
-   `state.avalanche`).
+   `state.avalanche`). Because `state` is **module-scoped** and we add no new `window.*`
+   bridge, expose a read seam on the **existing** `window.testHooks` surface so the browser
+   test can observe debris without reaching `state`:
+   `window.testHooks.isDebrisActive = () => !!state.debris && state.debris.active;` — a
+   deliberate test hook like the collision hooks (`window.testHooks.forceTreeCollision`),
+   **not** a per-module namespace bridge, so it stays within the sanctioned test seam.
 2. **Per frame**, after the existing `updateSnowman(delta)` + splash, call
    `Flex.update(snowman, delta, motionFromUpdateResult)`. (The wrapper already has the
    `UpdateResult` in scope — `player`/the return value — so `speed`, `technique`,
@@ -435,7 +445,10 @@ Minimal, localized edits:
    crash-only overlay delay (§7.4).
 4. **In `resetSnowman()` and `restartGame()`**: call `state.debris?.reset(scene)` and
    `Flex.reset(snowman)` before re-initializing the camera, so the fragments are gone and
-   the snowman is visible and back to neutral pose.
+   the snowman is visible and back to neutral pose. **If the crash-only overlay delay
+   (§7.4) is implemented, also `clearTimeout(crashOverlayTimer)` and null it here** — a
+   restart inside the ~700 ms window must not let the pending callback re-show
+   `#gameOverOverlay` over the fresh run.
 5. **`src/main.ts`**: add `import './debris.js';` / `import './snowman-flex.js';` (the
    `.js` specifier resolving to `.ts`, per the repo import convention) so they join the
    bundle graph; the orchestrator imports the named exports directly.
@@ -453,7 +466,7 @@ already runs in `showGameOver`; the debris is independent of it.
 | **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
 | **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes **only debris-owned** geometry/material and re-shows the snowman with its original assets intact (assert the snowman's geometry/material were NOT disposed across a shatter→reset cycle). Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
 | **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); stays **finite** for a `{ speed: 0, delta: 0 }` frame (no NaN); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
-| **Browser** | Set `window.testHooks.debrisEnabled = true` (the §8.3 opt-in that re-enables shatter under `?test=`), then force a tree collision (`window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + `state.debris.active` immediately after; assert restart re-shows the snowman. Every other suite leaves the flag unset, so debris stays off for them and the e2e reset spec. | extend `tests/browser-tests.js` |
+| **Browser** | Set `window.testHooks.debrisEnabled = true` (the §8.3 opt-in that re-enables shatter under `?test=`), then force a tree collision (`window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + `window.testHooks.isDebrisActive()` (the read seam from §8.1 — `state` is module-scoped, so the test reads through `testHooks`, never `state.debris`) immediately after; assert restart re-shows the snowman. Every other suite leaves the flag unset, so debris stays off for them and the e2e reset spec. | extend `tests/browser-tests.js` |
 | **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
 
 Docs to update in the same PR (Roadmap guardrail): `ARCHITECTURE.md` (new modules in the
@@ -489,6 +502,11 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
       `_testShowGameOverOverride` still short-circuits the unit path.
 - [ ] Debris settle loop repaints via the injected `render` callback (animate() has
       stopped after game over) — fragments are actually drawn, not just updated off-screen.
+- [ ] Debris active state is read in tests via the `window.testHooks.isDebrisActive()`
+      seam, not module-scoped `state.debris` (no new `window.*` bridge added).
+- [ ] If the crash overlay delay is used, its `setTimeout` id is stored and
+      `clearTimeout`'d in `resetSnowman`/`restartGame` — a restart inside the delay window
+      can't re-show or strand `#gameOverOverlay`.
 - [ ] Shatter loop branches on `part.isMesh` — Group parts (arms, PR-C scarf tail) are
       traversed or replaced with a generic chunk, never `part.geometry.clone()`'d directly.
 - [ ] `Flex.update` is NaN-safe on a zero-speed/zero-delta frame (epsilon-guarded
@@ -518,8 +536,9 @@ wipeout work first, and quarantines the fiddly scarf so it can't hold them up.
 
 ## 13. Open questions (for the maintainer)
 
-1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4),
-   or keep the overlay immediate and accept a dimmed shatter? (Recommend the short delay.)
+1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4;
+   the delay timer must be stored and cleared on reset/restart), or keep the overlay
+   immediate and accept a dimmed shatter? (Recommend the short delay.)
 2. **Fragment fidelity** — owned clones of the distinctive *mesh* parts (hat, nose read
    clearly; clone with `geometry.clone()`/`material.clone()` so disposal is safe — §7.2)
    vs. generic snow-ball chunks (cheaper, uniform, trivially debris-owned)? Note the arms

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -136,7 +136,7 @@ showGameOver(reason)
    │       ├─ spawn debris-owned fragment chunks (own geometry/material) with burst velocities
    │       ├─ Snow puff burst at impact
    │       └─ start own rAF settle loop (gravity + ground bounce + tumble, repaint each tick, ~2.5s)
-   │     EffectsModule.addShake(impactScaledBySpeed)   // reuse existing juice
+   │     (crash thud deferred — addShake can't render after animate() stops; do it in the debris render callback, §7.2 step 4)
    │     (#gameOverOverlay shows immediately as today — dimmed shatter; ~700ms delay is opt-in polish, §7.4)
    └─ … existing overlay / score / result logic unchanged
 ```
@@ -362,8 +362,16 @@ export class SnowmanDebris {
 3. **Snow puff.** Fire a one-shot burst from the existing snow-splash texture/material at
    the impact point (a dozen-ish sprites with the same gravity/fade as `updateSnowSplash`),
    so the break-up is wrapped in a cloud of powder — the "balls with snow splashing" ask.
-4. **Juice.** `EffectsModule.addShake(clamp(impactSpeed * k))` for a crash thud (already
-   `prefers-reduced-motion`-aware inside effects).
+4. **Juice (deferred — see caveat).** A crash thud via camera shake is desirable, but
+   **`EffectsModule.addShake()` will NOT render after a crash**: it only *queues* shake for
+   `EffectsModule.tickCamera()`, which runs in the normal `animate()` render path —
+   and `showGameOver` has already stopped that loop (§7.4), while the later
+   `EffectsModule.reset()` clears the queued impulse anyway. So a bare `addShake` here is
+   dead. To actually render a thud, the **debris settle loop's `render` callback must apply
+   its own decaying shake offset to `camera.position` before `renderer.render(...)` and
+   revert it after** (the same apply-then-revert pattern the main loop uses, but driven by
+   the debris rAF). PR B **ships without the shake** to keep the change small; this is
+   captured as a clear follow-up.
 5. Start the settle loop (§7.4).
 
 ### 7.3 Per-fragment physics (cosmetic, terrain-aware)
@@ -468,7 +476,9 @@ Minimal, localized edits:
        reducedMotion: !!reduced,
        render: () => renderer.render(scene, camera), // §7.4: animate() has stopped
      });
-     if (EffectsModule) EffectsModule.addShake(/* impact ∝ speed */);
+     // NB: no EffectsModule.addShake() here — animate() has stopped, so tickCamera()
+     // never applies it and EffectsModule.reset() below would clear it (§7.2 step 4).
+     // A crash thud must be rendered inside the debris render callback instead (follow-up).
    }
    ```
 
@@ -514,7 +524,7 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
 - **Fragment cap** ≈24 chunks + ≈12 puff sprites; reuse the snow-splash material. One-shot,
   disposed on reset — no steady-state cost during normal play (debris only exists post-crash).
 - **`prefers-reduced-motion`**: flex → rigid; shatter → hide snowman + single small puff,
-  no flying tumble, no `addShake` (effects already honors it).
+  no flying tumble. (No crash shake regardless — it's deferred, §7.2 step 4.)
 - **Mobile**: the settle loop is short and low-count; gate fragment sub-cracking behind a
   simple device/perf check if needed (optional, can follow the roadmap's perf-scaling item).
 

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -82,11 +82,14 @@ These come straight from the Roadmap "Guardrails" and `PHYSICS.md` §6:
 4. **Respect `prefers-reduced-motion`** — reduced motion skips the flying-fragment
    tumble and the lingering jiggle; it still hides the snowman and shows a single small
    snow puff so the crash still reads, but with no large motion.
-5. **Gate on test mode.** When `window.isTestMode` is set or `_testShowGameOverOverride`
-   intercepts, skip the shatter entirely so headless/browser suites and the e2e reset
-   spec are unaffected (the reset-flake spec already fights overlay z-order — see the
-   `e2e-reset-flake-overlay` note; the debris must not add a new moving cover over
-   `#resetBtn`).
+5. **Gate on test mode — with an explicit opt-in.** By default, when `window.isTestMode`
+   is set (or `_testShowGameOverOverride` intercepts) the shatter is skipped, so headless/
+   browser suites and the e2e reset spec are unaffected (the reset-flake spec already
+   fights overlay z-order — see the `e2e-reset-flake-overlay` note; the debris must not add
+   a new moving cover over `#resetBtn`). But a blanket `!isTestMode` gate would make the
+   shatter path itself **untestable** in the browser harness (which always runs under
+   `?test=`), so the gate also honors an explicit `window.testHooks.debrisEnabled` opt-in
+   that the dedicated debris test sets and every other suite leaves unset (§8.3, §9).
 6. **Behavior-preserving for the finish.** A successful finish must look exactly as it
    does today (result screen, ghost, medal). Shatter is crash-only.
 
@@ -124,12 +127,14 @@ On crash:
 
 ```
 showGameOver(reason)
-   ├─ if reason is a CRASH and !testMode and !reducedMotion-skip:
-   │     Debris.shatter(scene, snowman, velocity, getTerrainHeight)
+   ├─ if reason is a CRASH and debris-allowed (default; opt-in under ?test=):
+   │     Debris.shatter(scene, snowman, velocity, { reducedMotion, render })
+   │       │   (terrain comes from an earlier setTerrainFunction(); render =
+   │       │    () => renderer.render(scene, camera) since animate() has stopped)
    │       ├─ hide snowman group
    │       ├─ spawn debris-owned fragment chunks (own geometry/material) with burst velocities
    │       ├─ Snow puff burst at impact
-   │       └─ start own rAF settle loop (gravity + ground bounce + tumble, ~2.5s)
+   │       └─ start own rAF settle loop (gravity + ground bounce + tumble, repaint each tick, ~2.5s)
    │     EffectsModule.addShake(impactScaledBySpeed)   // reuse existing juice
    │     (optionally) delay #gameOverOverlay ~700ms so the wipeout is the star
    └─ … existing overlay / score / result logic unchanged
@@ -277,7 +282,11 @@ false.
 ```ts
 export class SnowmanDebris {
   setTerrainFunction(fn: (x: number, z: number) => number): void;
-  shatter(scene, snowman, velocity, opts?: { reducedMotion?: boolean }): void;
+  // `render` repaints the canvas each settle tick — REQUIRED: showGameOver has already
+  // set gameActive=false, so animate() is no longer rendering (§7.4). The orchestrator
+  // passes () => renderer.render(scene, camera).
+  shatter(scene, snowman, velocity,
+          opts?: { reducedMotion?: boolean; render?: () => void }): void;
   update(dt: number): boolean;   // returns true while still settling
   reset(scene): void;            // dispose fragments, re-show snowman
   get active(): boolean;
@@ -347,13 +356,22 @@ short on restart).
 
 ### 7.4 Settle loop & the `gameActive` interaction
 
-`showGameOver` sets `state.gameActive = false`, which halts `animate()`. Rather than
-complicate the main loop's gating, **`SnowmanDebris` runs its own `requestAnimationFrame`
-loop** while settling (the avalanche-style `update(dt)` ticked from a private rAF). It
-renders via a small callback the orchestrator hands in (it already owns `renderer`,
-`scene`, `camera`), or — simpler — the orchestrator keeps calling
-`renderer.render(scene, camera)` from the debris tick. The loop self-terminates when
-`update()` returns false. This keeps the change to the main loop near-zero.
+`showGameOver` sets `state.gameActive = false`, which halts `animate()` — so **after the
+crash frame nothing repaints the canvas**. `SnowmanDebris` therefore runs its own
+`requestAnimationFrame` loop while settling (the avalanche-style `update(dt)` ticked from a
+private rAF) **and must repaint each tick itself**: `shatter()` takes a `render` callback
+(§7.1) and the orchestrator passes `() => renderer.render(scene, camera)` (it owns
+`renderer`/`scene`/`camera`). Without that callback the fragments would update but the
+frozen canvas would never show them — exactly the gap the explicit `render` param closes.
+The camera stays where the crash left it (the camera manager isn't ticking); if we later
+want it to track the debris, the same callback is the place to nudge it. The loop
+self-terminates when `update()` returns false.
+
+> **Alternative considered:** keep the main `animate()` loop alive on a `state.debrisActive`
+> flag instead of a private rAF. Rejected as the default because it spreads debris state
+> into the main-loop gating; the self-contained loop + injected `render` keeps the
+> orchestrator change to ~3 lines. (It also means the test path needs an explicit opt-in
+> rather than riding the live loop — see §3 / §9.)
 
 > **Overlay timing (user-visible, flag this for review).** The `#gameOverOverlay` is 70%
 > black and would dim the wipeout. Proposal: on a **crash**, delay showing the overlay by
@@ -395,9 +413,19 @@ Minimal, localized edits:
    ```ts
    const isFinish = reason === "You reached the end of the slope!";
    const crash = !isFinish;
-   if (crash && !window.isTestMode && state.debris) {
+   // Off under ?test= by DEFAULT (protects the e2e reset-flake + headless suites), but
+   // the dedicated debris browser test opts in via window.testHooks.debrisEnabled so the
+   // real shatter path is still covered (§9). _testShowGameOverOverride already
+   // short-circuited above for the unit-level mocks. Gating on isTestMode alone would
+   // make the live game UNtestable here — that's why the opt-in exists.
+   const allowDebris = !window.isTestMode ||
+     !!(window.testHooks && window.testHooks.debrisEnabled);
+   if (crash && allowDebris && state.debris) {
      const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-     state.debris.shatter(scene, snowman, velocity, { reducedMotion: !!reduced });
+     state.debris.shatter(scene, snowman, velocity, {
+       reducedMotion: !!reduced,
+       render: () => renderer.render(scene, camera), // §7.4: animate() has stopped
+     });
      if (EffectsModule) EffectsModule.addShake(/* impact ∝ speed */);
    }
    ```
@@ -425,7 +453,7 @@ already runs in `showGameOver`; the debris is independent of it.
 | **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
 | **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes **only debris-owned** geometry/material and re-shows the snowman with its original assets intact (assert the snowman's geometry/material were NOT disposed across a shatter→reset cycle). Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
 | **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); stays **finite** for a `{ speed: 0, delta: 0 }` frame (no NaN); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
-| **Browser** | Force a tree collision (existing `window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + debris active immediately after; assert restart re-shows the snowman. | extend `tests/browser-tests.js` |
+| **Browser** | Set `window.testHooks.debrisEnabled = true` (the §8.3 opt-in that re-enables shatter under `?test=`), then force a tree collision (`window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + `state.debris.active` immediately after; assert restart re-shows the snowman. Every other suite leaves the flag unset, so debris stays off for them and the e2e reset spec. | extend `tests/browser-tests.js` |
 | **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
 
 Docs to update in the same PR (Roadmap guardrail): `ARCHITECTURE.md` (new modules in the
@@ -456,7 +484,11 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
       cycles (watch heap in the browser test).
 - [ ] Debris does **not** render over `#resetBtn` / `#gameOverOverlay` interactive
       elements (guards the known e2e reset flake).
-- [ ] Test mode / `_testShowGameOverOverride` path skips shatter entirely.
+- [ ] Under `?test=`, shatter is off by default (protects the e2e reset spec) but the
+      dedicated debris browser test re-enables it via `window.testHooks.debrisEnabled`;
+      `_testShowGameOverOverride` still short-circuits the unit path.
+- [ ] Debris settle loop repaints via the injected `render` callback (animate() has
+      stopped after game over) — fragments are actually drawn, not just updated off-screen.
 - [ ] Shatter loop branches on `part.isMesh` — Group parts (arms, PR-C scarf tail) are
       traversed or replaced with a generic chunk, never `part.geometry.clone()`'d directly.
 - [ ] `Flex.update` is NaN-safe on a zero-speed/zero-delta frame (epsilon-guarded

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -13,15 +13,19 @@
 
 Three user-visible upgrades, in rising order of risk:
 
-1. **Scarf** — give the snowman a red knitted scarf around the neck, with a tail that
-   trails in the wind. (Pure model geometry.)
-2. **Flexible / "wiggly" snowman** — the body squashes, stretches, and jiggles as it
-   skis: head bob, scarf trailing on velocity, a settle-bounce on landing, lean into
-   carves. Makes the snowman read as *alive* rather than a rigid stack of spheres.
-3. **Breaks down on impact** — on a **crash** (tree / rock / off-mountain / fell-off /
+1. **Flexible / "wiggly" snowman** — the body squashes, stretches, and jiggles as it
+   skis: head bob, a settle-bounce on landing, lean into carves. Makes the snowman read
+   as *alive* rather than a rigid stack of spheres.
+2. **Breaks down on impact** — on a **crash** (tree / rock / off-mountain / fell-off /
    avalanche burial — *not* a finish), the snowman bursts apart: the three balls, hat,
-   nose, arms, buttons, and scarf fly off as tumbling fragments while a puff of snow
-   splashes out. The classic SkiFree-style wipeout.
+   nose, arms, and buttons fly off as tumbling fragments while a puff of snow splashes
+   out. The classic SkiFree-style wipeout.
+3. **Scarf** *(optional follow-up — see §12 PR C)* — a red knitted scarf around the neck
+   with a tail that trails in the wind. **Deferred out of the core work**: the
+   overlapping neck geometry and trailing tail are the fiddliest, most iteration-prone
+   piece of #53, so it's quarantined into its own PR. The flex animator and shatter
+   system are both built to pick the scarf up automatically once it exists, so A/B don't
+   depend on it and it can land later or be dropped.
 
 **The single hard constraint:** none of this may touch the deterministic skiing
 physics. Flex and shatter are *cosmetic* layers that live **outside** the
@@ -95,11 +99,11 @@ Two new files + small, surgical edits to three existing ones.
 ```
 NEW  src/debris.ts        SnowmanDebris: shatter fragments + snow-puff burst + own
                           settle loop, terrain-aware, disposable. (class, like avalanche)
-NEW  src/snowman-flex.ts  Flex: cosmetic squash/stretch/jiggle/scarf-trail animator.
-                          Pure function over (group, dt, motion) — no physics.
+NEW  src/snowman-flex.ts  Flex: cosmetic squash/stretch/jiggle animator (scarf-trail
+                          branch is dormant until PR C). Pure fn over (group, dt, motion).
 
-EDIT src/snowman.ts       createSnowman(): tag parts into group.userData.parts {…};
-                          add the scarf geometry. NO change to updateSnowman.
+EDIT src/snowman.ts       createSnowman(): tag parts into group.userData.parts {…}.
+                          (Scarf geometry is the optional PR C.) NO change to updateSnowman.
 EDIT src/snowglider.ts    main loop calls Flex.update(...) each frame after physics;
                           showGameOver() triggers Debris.shatter() on crash reasons;
                           resetSnowman()/restartGame() call Debris.reset() + Flex.reset().
@@ -133,7 +137,7 @@ showGameOver(reason)
 
 ---
 
-## 5. Feature 1 — Tag the model & add the scarf (`src/snowman.ts`)
+## 5. Tag the model (`src/snowman.ts`)
 
 ### 5.1 Part registry
 
@@ -150,7 +154,9 @@ group.userData.parts = {
   button1, button2, button3,
   leftArmGroup, rightArmGroup,
   hatBase, hatTop,
-  scarf, scarfTail,                // added below
+  // scarf, scarfTail — added by the optional scarf follow-up (PR C). Both the flex
+  // animator and the shatter system treat these as present-or-absent, so the registry
+  // simply gains two keys when PR C lands; nothing in A/B depends on them existing.
 };
 // Remember neutral local transforms so flex can animate as deltas and reset cleanly.
 group.userData.parts.base = recordBaseTransforms(group.userData.parts);
@@ -161,11 +167,14 @@ object so the flex animator can express everything as an offset from neutral and
 `Flex.reset()` can snap exactly back (no drift across runs). This is the same discipline
 the ski-pose code already uses with `leftSkiBaseX`/`rightSkiBaseX`.
 
-### 5.2 Scarf geometry
+### 5.2 Scarf geometry — *optional follow-up (PR C), NOT in the core work*
 
-A simple, cheap scarf: a flattened torus (the wrap) at the neck seam (~`y = 6.2`, between
-the `middle` top and the `head`) plus a short two-segment tail hanging over the front in
-red wool. Keep it low-poly (matches the rest of the model) and `castShadow = true`:
+Deferred because the overlapping neck geometry + a trailing tail is the fiddliest,
+highest-risk piece of #53. Captured here as a ready reference for PR C; A and B ship
+scarf-free. A simple, cheap scarf: a flattened torus (the wrap) at the neck seam
+(~`y = 6.2`, between the `middle` top and the `head`) plus a short two-segment tail
+hanging over the front in red wool. Keep it low-poly (matches the rest of the model) and
+`castShadow = true`:
 
 ```ts
 const scarfMaterial = new THREE.MeshStandardMaterial({ color: 0xCC2222, roughness: 1.0 });
@@ -183,8 +192,9 @@ group.add(scarfTail);
 ```
 
 This is additive geometry only — it does not touch physics, collision radius, or the
-spawn pose, so terrain/physics tests are unaffected. The DOM smoke test gets one new
-assertion (§8).
+spawn pose, so terrain/physics tests are unaffected. PR C adds the two `scarf`/`scarfTail`
+keys to the part registry plus one DOM-smoke assertion; until it lands, the flex and
+shatter modules simply run scarf-free.
 
 ---
 
@@ -199,7 +209,7 @@ amount of state (jiggle phase, settle spring) on `snowman.userData.flex`.
 export interface FlexMotion {
   speed: number;        // currentSpeed from UpdateResult
   technique: string;    // 'carve' | 'skid' | 'tuck' | … (for lean styling)
-  turnRate: number;     // signed: velocity.x / speed, drives lean + scarf swing
+  turnRate: number;     // signed: velocity.x / speed, drives lean (+ scarf swing in PR C)
   justLanded: boolean;  // landingForce > threshold → settle bounce
   landingForce: number;
   isInAir: boolean;
@@ -224,8 +234,10 @@ reset cleanly):
 - **Carve lean.** On `carve`/`parallel`, lean the upper balls + hat into the turn
   (`turnRate`-scaled, clamped) — a *cosmetic* lean layered on top of the kernel's
   existing body tilt, addressing the "flexible" ask without spine math.
-- **Scarf trail.** Swing `scarfTail` opposite to travel/turn (trails behind) with a sine
-  flutter scaled by speed; in air it lifts. Cheap, sells "wind."
+- **Scarf trail** *(only when the scarf exists — PR C)*. If `parts.scarfTail` is present,
+  swing it opposite to travel/turn (trails behind) with a sine flutter scaled by speed; in
+  air it lifts. Guarded so the animator is a no-op on the scarf when it's absent — A ships
+  without this branch active.
 
 **Reduced motion:** `Flex.update` early-returns to base transforms (no jiggle/lean), so
 the snowman is simply rigid — identical silhouette, no motion.
@@ -364,7 +376,7 @@ already runs in `showGameOver`; the debris is independent of it.
 | Layer | What | Where |
 |-------|------|-------|
 | **Physics invariant** | Unchanged — assert no regression. Because the kernel is untouched, `npm run test:verify` must stay green **without** regenerating `snowman_baseline.js`. This is itself the proof that flex/shatter didn't leak into physics. | `tests/verification/physics_invariant_harness.js` (run, don't edit) |
-| **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists and a `scarf` mesh is present. | `tests/verification/dom_smoke_test.js` (extend) |
+| **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
 | **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes and re-shows. Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
 | **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
 | **Browser** | Force a tree collision (existing `window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + debris active immediately after; assert restart re-shows the snowman. | extend `tests/browser-tests.js` |
@@ -399,20 +411,26 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
 - [ ] Test mode / `_testShowGameOverOverride` path skips shatter entirely.
 - [ ] No new `window.*` per-module bridge; modules `import` directly and are imported by
       `main.ts`.
-- [ ] Scarf doesn't alter collision radius, spawn pose, or terrain tests.
+- [ ] *(PR C only)* Scarf doesn't alter collision radius, spawn pose, or terrain tests.
 
 ## 12. Suggested PR breakdown (mergeable, low-risk first)
 
-1. **PR A — Scarf + part registry + flex** (no game-over changes): add scarf geometry,
-   `userData.parts`, `src/snowman-flex.ts`, wire `Flex.update`/`Flex.reset`. Lowest risk;
-   ships the "scarf + flexible" half of #53 on its own. Tests: DOM smoke + flex unit +
-   verify-green.
+1. **PR A — Part registry + flex** (no game-over changes, **no scarf**): add the
+   `userData.parts` registry and `src/snowman-flex.ts`, wire `Flex.update`/`Flex.reset`.
+   Lowest risk; ships the "flexible/wiggly" half of #53 on its own. Tests: DOM smoke +
+   flex unit + verify-green.
 2. **PR B — Crash shatter**: `src/debris.ts`, the `showGameOver` crash branch, the
    reset/restart cleanup, the optional overlay delay. Ships "breaks down on impact."
    Tests: debris unit + browser crash test + e2e.
+3. **PR C — Scarf (optional follow-up)**: add the scarf/tail geometry (§5.2), the two
+   `scarf`/`scarfTail` keys in the registry, the flex scarf-trail branch (§6), and a DOM-
+   smoke assertion. **Quarantined on purpose** — the overlapping neck geometry / trailing
+   tail is the riskiest, most iteration-prone piece, and A/B don't depend on it (both
+   treat the scarf as present-or-absent). Can land any time after A, or be dropped without
+   affecting A/B.
 
-Splitting this way keeps each PR's blast radius small and lets the expressive-pose work
-land even if the shatter timing needs iteration.
+Splitting this way keeps each PR's blast radius small, lands the expressive-pose and
+wipeout work first, and quarantines the fiddly scarf so it can't hold them up.
 
 ## 13. Open questions (for the maintainer)
 
@@ -421,5 +439,7 @@ land even if the shatter timing needs iteration.
 2. **Fragment fidelity** — clone the actual parts (hat, nose, arms read clearly) vs.
    generic snow-ball chunks (cheaper, more uniform)? (Recommend cloning the distinctive
    parts + cracking the 3 balls into chunks.)
-3. **Scope of #53** — close #53 with A+B, or keep it open for follow-on polish
-   (snowballing-downhill after wipeout, celebratory finish animation)?
+3. **Scope of #53** — close #53 once A+B+C land, or close with A+B (flex + wipeout) and
+   track the scarf (PR C) + further polish (snowballing-downhill after wipeout,
+   celebratory finish animation) as follow-ups? The scarf is now explicitly a follow-up,
+   so A+B alone are a coherent shippable slice.

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -327,10 +327,17 @@ export class SnowmanDebris {
    Three.js `Object3D.clone()` *shares* the source `geometry`/`material` by reference, so
    disposing the fragment in `reset()` (§7.5) would dispose the still-hidden snowman's
    originals and the next run would re-show it with freed buffers. Pick one of:
-   - **(preferred) generic fragment assets** — spawn a small pool of generic snow-ball
-     chunks from geometry/materials the debris system *owns* and creates once, sized/tinted
-     from the part. Nothing references the snowman's assets, so disposal is unambiguous and
-     the three balls cracking into 2–3 chunks each falls out naturally.
+   - **(preferred) generic fragment assets** — generic snow-ball chunks from geometry/
+     materials the debris system *owns*, sized/tinted from the part. Nothing references the
+     snowman's assets, so disposal is unambiguous and the three balls cracking into 2–3
+     chunks each falls out naturally. **Allocate these per shatter** (and dispose them in
+     `reset()`, §7.5), *not* once at construction — `reset()` runs on every restart and
+     disposes all debris-owned geometry/material, so a constructor-owned pool would be
+     freed after the first crash and the next crash would reuse disposed buffers. (If a
+     persistent pool is ever preferred for GC churn, it must be kept alive until a single
+     final `dispose()` and **not** touched by per-run `reset()`.) The shipped `debris.ts`
+     allocates per shatter — `shatter()` calls `reset()` first, then creates fresh owned
+     assets — so this is consistent.
    - **owned clones** — if a fragment must mirror a distinctive *mesh* part (hat, nose,
      buttons, eyes), clone with explicit ownership:
      `mesh = new THREE.Mesh(part.geometry.clone(), part.material.clone())` (cloning the mesh

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -147,10 +147,14 @@ At the end of `createSnowman`, alongside the existing ski refs, register every a
 
 ```ts
 // Cosmetic part registry — consumed by snowman-flex.ts (jiggle) and debris.ts (shatter).
-// INVARIANT: every value here is a renderable Object3D. The shatter path iterates this
-// object and reads each value's world transform / geometry / material, so it must never
-// contain a non-renderable entry (snapshots, flags, counters). Storing meshes (not
-// indices) keeps both modules decoupled from child order.
+// INVARIANT: every value here is a renderable Object3D — but NOT necessarily a Mesh.
+// leftArmGroup/rightArmGroup (and the PR-C scarfTail) are THREE.Group (createBranchArm()
+// returns a Group, src/snowman.ts:157), which have no .geometry/.material. So the shatter
+// loop MUST branch on type (§7.2): own-clone a Mesh's geometry/material directly, but for
+// a Group traverse to its child meshes (or spawn a generic chunk at the group's world
+// transform). The registry must still never hold a non-renderable entry (snapshots, flags,
+// counters) — that's why base transforms live in the separate partBaseTransforms map below.
+// Storing Object3Ds (not indices) keeps both modules decoupled from child order.
 group.userData.parts = {
   bottom, middle, head,            // the three snow balls
   leftEye, rightEye, nose,
@@ -218,7 +222,7 @@ amount of state (jiggle phase, settle spring) on `snowman.userData.flex`.
 export interface FlexMotion {
   speed: number;        // currentSpeed from UpdateResult
   technique: string;    // 'carve' | 'skid' | 'tuck' | … (for lean styling)
-  turnRate: number;     // signed: velocity.x / speed, drives lean (+ scarf swing in PR C)
+  turnRate: number;     // signed, zero-speed-guarded (0 when speed≈0), drives lean (+ scarf swing in PR C)
   justLanded: boolean;  // landingForce > threshold → settle bounce
   landingForce: number;
   isInAir: boolean;
@@ -250,6 +254,11 @@ reset cleanly):
 
 **Reduced motion:** `Flex.update` early-returns to base transforms (no jiggle/lean), so
 the snowman is simply rigid — identical silhouette, no motion.
+
+**Robustness:** `Flex.update` must stay finite on a zero-speed/zero-delta first frame —
+it treats `turnRate` as `0` when `speed ≈ 0` (§8) and clamps every output, so a `0/0`
+can never write a NaN rotation/scale onto the snowman. The flex-unit test asserts finite
+transforms for a `{ speed: 0 }` motion input.
 
 **Why a separate module, not inside `updateSnowman`:** keeps the physics kernel and its
 frozen baseline byte-identical (§3.1), and keeps R3's planned `snowman/pose.ts` split
@@ -291,10 +300,16 @@ export class SnowmanDebris {
      chunks from geometry/materials the debris system *owns* and creates once, sized/tinted
      from the part. Nothing references the snowman's assets, so disposal is unambiguous and
      the three balls cracking into 2–3 chunks each falls out naturally.
-   - **owned clones** — if a fragment must mirror a distinctive part (hat/nose/arms), clone
-     with explicit ownership: `mesh = new THREE.Mesh(part.geometry.clone(), part.material.clone())`
-     (clone-the-mesh alone is insufficient). Track these as "owned" so `reset()` disposes
-     only them.
+   - **owned clones** — if a fragment must mirror a distinctive *mesh* part (hat, nose,
+     buttons, eyes), clone with explicit ownership:
+     `mesh = new THREE.Mesh(part.geometry.clone(), part.material.clone())` (cloning the mesh
+     alone is insufficient — it keeps the shared buffers). Track these as "owned" so
+     `reset()` disposes only them.
+   - **Group parts** — `leftArmGroup`/`rightArmGroup` (and the PR-C `scarfTail`) are
+     `THREE.Group`s with **no `.geometry`/`.material`**, so a blind `part.geometry.clone()`
+     would throw or skip the arms. The loop must branch on `part.isMesh`: for a Group,
+     either traverse it and own-clone each child mesh into one fragment group, or (simpler)
+     spawn a single generic stick/snow chunk at the group's **world** transform.
 
    Either way, tag each fragment's geometry/material as debris-owned (e.g. push into an
    `ownedResources` set) so `reset()` disposes **exactly** what the debris system created
@@ -369,7 +384,11 @@ Minimal, localized edits:
 2. **Per frame**, after the existing `updateSnowman(delta)` + splash, call
    `Flex.update(snowman, delta, motionFromUpdateResult)`. (The wrapper already has the
    `UpdateResult` in scope — `player`/the return value — so `speed`, `technique`,
-   `justLanded`, `landingForce`, `isInAir` are in hand; `turnRate = velocity.x / speed`.)
+   `justLanded`, `landingForce`, `isInAir` are in hand.) Derive turn rate with a
+   **zero-speed guard**: `turnRate = speed > 1e-3 ? velocity.x / speed : 0`. On the first
+   frame after start/restart `speed` can be `0` (and `delta` `0`), so an unguarded
+   `velocity.x / speed` is `0/0 = NaN`; that NaN would flow into the lean/scarf rotations
+   and scales and corrupt the visible snowman until the next reset.
 3. **In `showGameOver(reason)`**, *after* the `_testShowGameOverOverride` early return and
    setting `gameActive = false`, add a crash branch:
 
@@ -405,7 +424,7 @@ already runs in `showGameOver`; the debris is independent of it.
 | **Physics invariant** | Unchanged — assert no regression. Because the kernel is untouched, `npm run test:verify` must stay green **without** regenerating `snowman_baseline.js`. This is itself the proof that flex/shatter didn't leak into physics. | `tests/verification/physics_invariant_harness.js` (run, don't edit) |
 | **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
 | **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes **only debris-owned** geometry/material and re-shows the snowman with its original assets intact (assert the snowman's geometry/material were NOT disposed across a shatter→reset cycle). Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
-| **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
+| **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); stays **finite** for a `{ speed: 0, delta: 0 }` frame (no NaN); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
 | **Browser** | Force a tree collision (existing `window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + debris active immediately after; assert restart re-shows the snowman. | extend `tests/browser-tests.js` |
 | **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
 
@@ -438,6 +457,10 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
 - [ ] Debris does **not** render over `#resetBtn` / `#gameOverOverlay` interactive
       elements (guards the known e2e reset flake).
 - [ ] Test mode / `_testShowGameOverOverride` path skips shatter entirely.
+- [ ] Shatter loop branches on `part.isMesh` — Group parts (arms, PR-C scarf tail) are
+      traversed or replaced with a generic chunk, never `part.geometry.clone()`'d directly.
+- [ ] `Flex.update` is NaN-safe on a zero-speed/zero-delta frame (epsilon-guarded
+      `turnRate`, clamped outputs); no NaN rotation/scale ever reaches the snowman.
 - [ ] No new `window.*` per-module bridge; modules `import` directly and are imported by
       `main.ts`.
 - [ ] *(PR C only)* Scarf doesn't alter collision radius, spawn pose, or terrain tests.
@@ -465,10 +488,12 @@ wipeout work first, and quarantines the fiddly scarf so it can't hold them up.
 
 1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4),
    or keep the overlay immediate and accept a dimmed shatter? (Recommend the short delay.)
-2. **Fragment fidelity** — owned clones of the distinctive parts (hat, nose, arms read
+2. **Fragment fidelity** — owned clones of the distinctive *mesh* parts (hat, nose read
    clearly; clone with `geometry.clone()`/`material.clone()` so disposal is safe — §7.2)
-   vs. generic snow-ball chunks (cheaper, uniform, trivially debris-owned)? (Recommend
-   owned clones for the distinctive parts + generic chunks for the 3 balls.)
+   vs. generic snow-ball chunks (cheaper, uniform, trivially debris-owned)? Note the arms
+   are `THREE.Group`s, so "fidelity" there means traversing/cloning their child meshes
+   (§7.2 Group-parts bullet), not a single `geometry.clone()`. (Recommend owned clones for
+   the distinctive mesh parts + generic chunks for the 3 balls and the arms.)
 3. **Scope of #53** — close #53 once A+B+C land, or close with A+B (flex + wipeout) and
    track the scarf (PR C) + further polish (snowballing-downhill after wipeout,
    celebratory finish animation) as follow-ups? The scarf is now explicitly a follow-up,

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -137,7 +137,7 @@ showGameOver(reason)
    │       ├─ Snow puff burst at impact
    │       └─ start own rAF settle loop (gravity + ground bounce + tumble, repaint each tick, ~2.5s)
    │     EffectsModule.addShake(impactScaledBySpeed)   // reuse existing juice
-   │     (optionally) delay #gameOverOverlay ~700ms so the wipeout is the star
+   │     (#gameOverOverlay shows immediately as today — dimmed shatter; ~700ms delay is opt-in polish, §7.4)
    └─ … existing overlay / score / result logic unchanged
 ```
 
@@ -396,17 +396,19 @@ self-terminates when `update()` returns false.
 > orchestrator change to ~3 lines. (It also means the test path needs an explicit opt-in
 > rather than riding the live loop — see §3 / §9.)
 
-> **Overlay timing (user-visible, flag this for review).** The `#gameOverOverlay` is 70%
-> black and would dim the wipeout. Proposal: on a **crash**, delay showing the overlay by
-> ~700 ms (a `setTimeout`) so the shatter plays at full brightness, then fade it in;
-> **finish** stays immediate (unchanged). **If implemented with `setTimeout`, the timer id
-> MUST be stored (e.g. a module-scoped `crashOverlayTimer`) and cleared in `resetSnowman`/
-> `restartGame` (§8.4).** `showGameOver` has already set `gameActive = false` while the
-> Reset control stays visible (and tests call the restart helpers directly), so a
-> reset/restart *before* the timer fires would otherwise re-show `#gameOverOverlay` over
-> the fresh run or strand it inactive behind a stale overlay. Alternative if we want zero
-> timing change: show the overlay immediately and accept the dimmed shatter behind it. Pick
-> one in review — see Open Questions §11.
+> **Overlay timing (RESOLVED — PR B ships the overlay immediate; delay is opt-in polish).**
+> The `#gameOverOverlay` is 70% black and dims the wipeout. A `setTimeout` delay (~700 ms
+> before showing the overlay on a **crash**) makes the shatter pop, but it drags in real
+> race complexity: the timer must be stored (`crashOverlayTimer`) and cleared on
+> reset/restart, **and** the cancel path must *re-arm the run* — `resetSnowman()` (the
+> visible `#resetBtn`, and the e2e reset spec) only resets physics; it does **not** set
+> `gameActive = true` or restart `animate()` (that's `restartGame()`), so cancelling the
+> timer alone would leave the fresh run frozen behind a cancelled overlay. **PR B therefore
+> ships the overlay immediate (zero timing change, `finish` and crash both unchanged from
+> today)** — the shatter still renders via the debris loop, just dimmed behind the overlay —
+> which sidesteps the timer, the re-arm, and the e2e-reset-flake interaction entirely. The
+> delay is kept as opt-in polish (§11 Q1) with the two requirements above if anyone enables
+> it later.
 
 ### 7.5 `reset()`
 
@@ -464,14 +466,16 @@ Minimal, localized edits:
    ```
 
    Everything else in `showGameOver` (best-time, login prompt, leaderboard, result
-   screen, `EffectsModule.reset()`, overlay) is unchanged — except the optional
-   crash-only overlay delay (§7.4).
+   screen, `EffectsModule.reset()`, overlay) is unchanged — the overlay shows immediately
+   as today (the ~700 ms delay is opt-in polish, §7.4).
 4. **In `resetSnowman()` and `restartGame()`**: call `state.debris?.reset(scene)` and
    `Flex.reset(snowman)` before re-initializing the camera, so the fragments are gone and
-   the snowman is visible and back to neutral pose. **If the crash-only overlay delay
-   (§7.4) is implemented, also `clearTimeout(crashOverlayTimer)` and null it here** — a
-   restart inside the ~700 ms window must not let the pending callback re-show
-   `#gameOverOverlay` over the fresh run.
+   the snowman is visible and back to neutral pose. **(Opt-in delay only — dormant in PR B,
+   which ships the overlay immediate.)** If the crash overlay delay (§7.4) is ever enabled,
+   `clearTimeout(crashOverlayTimer)` and null it here **and re-arm the run** — because
+   `resetSnowman()` does not set `gameActive`/restart `animate()` on its own, the bare
+   Reset path must route through `restartGame()` (or replicate its re-arm) when it cancels a
+   pending overlay, or the run is stranded inactive behind the cancelled overlay.
 5. **`src/main.ts`**: add `import './debris.js';` / `import './snowman-flex.js';` (the
    `.js` specifier resolving to `.ts`, per the repo import convention) so they join the
    bundle graph; the orchestrator imports the named exports directly.
@@ -527,9 +531,10 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
       stopped after game over) — fragments are actually drawn, not just updated off-screen.
 - [ ] Debris active state is read in tests via the `window.testHooks.isDebrisActive()`
       seam, not module-scoped `state.debris` (no new `window.*` bridge added).
-- [ ] If the crash overlay delay is used, its `setTimeout` id is stored and
-      `clearTimeout`'d in `resetSnowman`/`restartGame` — a restart inside the delay window
-      can't re-show or strand `#gameOverOverlay`.
+- [ ] PR B ships the overlay **immediate** (no delay/timer). If the opt-in delay is ever
+      added, its `setTimeout` id is stored and `clearTimeout`'d in `resetSnowman`/
+      `restartGame`, **and** the cancel path re-arms the run (routes through `restartGame`)
+      so a Reset in the window can't re-show *or* strand `#gameOverOverlay`.
 - [ ] Shatter loop iterates `userData.shatterRoots` (top-level pieces), branches on
       `part.isMesh` — Group parts (`headGroup`, arms, PR-C scarf tail) are traversed or
       replaced with a generic chunk, never `part.geometry.clone()`'d directly; accessories
@@ -551,8 +556,8 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
    Lowest risk; ships the "flexible/wiggly" half of #53 on its own. Tests: DOM smoke +
    flex unit + verify-green.
 2. **PR B — Crash shatter**: `src/debris.ts`, the `showGameOver` crash branch, the
-   reset/restart cleanup, the optional overlay delay. Ships "breaks down on impact."
-   Tests: debris unit + browser crash test + e2e.
+   reset/restart cleanup. Overlay stays immediate (the delay is deferred polish). Ships
+   "breaks down on impact." Tests: debris unit + browser crash test + e2e.
 3. **PR C — Scarf (optional follow-up)**: add the scarf/tail geometry (§5.2), the two
    `scarf`/`scarfTail` keys in the registry, the flex scarf-trail branch (§6), and a DOM-
    smoke assertion. **Quarantined on purpose** — the overlapping neck geometry / trailing
@@ -565,9 +570,10 @@ wipeout work first, and quarantines the fiddly scarf so it can't hold them up.
 
 ## 13. Open questions (for the maintainer)
 
-1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4;
-   the delay timer must be stored and cleared on reset/restart), or keep the overlay
-   immediate and accept a dimmed shatter? (Recommend the short delay.)
+1. **Overlay timing** — PR B ships the overlay **immediate** (dimmed shatter, zero race
+   risk). Worth adding the ~700 ms delay as later polish for a brighter wipeout? It needs
+   the cancel-timer **and** re-arm handling (§7.4/§8.4) and must dodge the e2e reset flake.
+   (Recommend immediate for now; revisit once the wipeout itself is tuned.)
 2. **Fragment fidelity** — owned clones of the distinctive *mesh* parts (hat, nose read
    clearly; clone with `geometry.clone()`/`material.clone()` so disposal is safe — §7.2)
    vs. generic snow-ball chunks (cheaper, uniform, trivially debris-owned)? Note the arms

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -1,0 +1,425 @@
+# SnowGlider — Expressive Snowman: Flex, Scarf & Crash Shatter
+
+> Implementation proposal for **[issue #53](https://github.com/den-run-ai/snowglider/issues/53)**
+> — *"more realistic snowman: scarf, flexible, breaks down on impact"* — and Roadmap
+> **Finding #11 (Personality & fail-state fun)** / **P2 (Make it memorable)**. This is a
+> design/plan doc in the spirit of [`REFACTORING_SNOWGLIDER_SNOWMAN.md`](REFACTORING_SNOWGLIDER_SNOWMAN.md):
+> it specifies the modules, the data flow, the code seams, and a mergeable PR sequence
+> so the actual implementation PR(s) are mechanical.
+
+---
+
+## 1. Goal
+
+Three user-visible upgrades, in rising order of risk:
+
+1. **Scarf** — give the snowman a red knitted scarf around the neck, with a tail that
+   trails in the wind. (Pure model geometry.)
+2. **Flexible / "wiggly" snowman** — the body squashes, stretches, and jiggles as it
+   skis: head bob, scarf trailing on velocity, a settle-bounce on landing, lean into
+   carves. Makes the snowman read as *alive* rather than a rigid stack of spheres.
+3. **Breaks down on impact** — on a **crash** (tree / rock / off-mountain / fell-off /
+   avalanche burial — *not* a finish), the snowman bursts apart: the three balls, hat,
+   nose, arms, buttons, and scarf fly off as tumbling fragments while a puff of snow
+   splashes out. The classic SkiFree-style wipeout.
+
+**The single hard constraint:** none of this may touch the deterministic skiing
+physics. Flex and shatter are *cosmetic* layers that live **outside** the
+`Snowman.updateSnowman` kernel, so the physics-invariant harness and the frozen
+`snowman_baseline.js` stay byte-identical and need **no** regeneration. See §3.
+
+---
+
+## 2. How it maps to the codebase today
+
+Relevant facts established from the current source (`main`):
+
+- `Snowman.createSnowman(scene)` (`src/snowman.ts:100`) builds one `THREE.Group` of
+  named-but-untagged children: `bottom`/`middle`/`head` spheres, `leftEye`/`rightEye`,
+  `nose`, three buttons, two `createBranchArm` groups, `hatBase`/`hatTop`, and
+  `leftSki`/`rightSki`. Only the skis are currently stashed on `group.userData`
+  (`leftSki`, `rightSki`, `leftSkiBaseX`, `rightSkiBaseX`).
+- The **only** cosmetic pose code today lives *inside* `updateSnowman` (the ski-wedge /
+  parallel-angulation block, `src/snowman.ts:631-649`). It is guarded by
+  `if (snowman.userData && snowman.userData.leftSki && …)`, so in the headless physics
+  harness — where the snowman stub has no `leftSki` — the branch is skipped and the
+  trajectory is unaffected. **We will not add to this block.** New flex animation goes
+  in a *separate* cosmetic function the orchestrator calls after physics (§5).
+- `showGameOver(reason)` (`src/snowglider.ts:729`) is the single chokepoint for every
+  end-of-run, crash and finish alike, including the avalanche-burial call from the main
+  loop (`src/snowglider.ts:647`). It early-returns through
+  `window._testShowGameOverOverride` and otherwise sets `state.gameActive = false`
+  (which stops `animate()`), then shows the `#gameOverOverlay` (a 70%-opaque black DOM
+  layer over the canvas). The finish is identified by the load-bearing string
+  `"You reached the end of the slope!"`.
+- `restartGame()` (`src/snowglider.ts:894`) and `resetSnowman()` (`:436`) re-arm a run;
+  both must clean up any debris and restore the snowman.
+- Prior art for the patterns we need: `AvalancheSystem` (`src/avalanche.ts`) for a
+  self-contained physics body system with terrain-aware ground collision and a `reset()`
+  that **disposes** geometry/material; `Snow.createSnowSplash`/`updateSnowSplash`
+  (`src/snow.ts`) for a pooled snow-particle burst; `EffectsModule` (`src/effects.ts`)
+  for the `prefers-reduced-motion` opt-out (`src/effects.ts:64`) and `addShake`.
+
+---
+
+## 3. Design principles & guardrails (non-negotiable)
+
+These come straight from the Roadmap "Guardrails" and `PHYSICS.md` §6:
+
+1. **Do not edit the `updateSnowman` physics math.** No new force, no new branch in the
+   grounded/air integration, no constant change. Flex + shatter are cosmetic and run
+   from the orchestrator, never from the kernel. ⇒ `physics_invariant_harness.js` stays
+   green with **no baseline regeneration**, and `PHYSICS.md` needs no physics edits.
+2. **Cosmetic state lives on `snowman.userData` or in the new modules**, never in the
+   `updateSnowman` argument contract (keeps the typed signature and the verification
+   wrapper untouched).
+3. **Dispose every THREE object** the shatter creates on `reset()` (geometry +
+   material), mirroring `AvalancheSystem.reset()`. No per-run leak.
+4. **Respect `prefers-reduced-motion`** — reduced motion skips the flying-fragment
+   tumble and the lingering jiggle; it still hides the snowman and shows a single small
+   snow puff so the crash still reads, but with no large motion.
+5. **Gate on test mode.** When `window.isTestMode` is set or `_testShowGameOverOverride`
+   intercepts, skip the shatter entirely so headless/browser suites and the e2e reset
+   spec are unaffected (the reset-flake spec already fights overlay z-order — see the
+   `e2e-reset-flake-overlay` note; the debris must not add a new moving cover over
+   `#resetBtn`).
+6. **Behavior-preserving for the finish.** A successful finish must look exactly as it
+   does today (result screen, ghost, medal). Shatter is crash-only.
+
+---
+
+## 4. Architecture overview
+
+Two new files + small, surgical edits to three existing ones.
+
+```
+NEW  src/debris.ts        SnowmanDebris: shatter fragments + snow-puff burst + own
+                          settle loop, terrain-aware, disposable. (class, like avalanche)
+NEW  src/snowman-flex.ts  Flex: cosmetic squash/stretch/jiggle/scarf-trail animator.
+                          Pure function over (group, dt, motion) — no physics.
+
+EDIT src/snowman.ts       createSnowman(): tag parts into group.userData.parts {…};
+                          add the scarf geometry. NO change to updateSnowman.
+EDIT src/snowglider.ts    main loop calls Flex.update(...) each frame after physics;
+                          showGameOver() triggers Debris.shatter() on crash reasons;
+                          resetSnowman()/restartGame() call Debris.reset() + Flex.reset().
+EDIT src/main.ts          import the two new modules so they join the bundle graph.
+```
+
+Data flow per frame (grounded run):
+
+```
+updateSnowman(delta)  →  pos/velocity/technique   (UNCHANGED kernel)
+        │
+        ├─ Flex.update(snowman, delta, { speed, technique, turnRate, justLanded, isInAir })
+        │     └─ writes child-mesh scale/position/rotation only (cosmetic)
+        └─ render
+```
+
+On crash:
+
+```
+showGameOver(reason)
+   ├─ if reason is a CRASH and !testMode and !reducedMotion-skip:
+   │     Debris.shatter(scene, snowman, velocity, getTerrainHeight)
+   │       ├─ hide snowman group
+   │       ├─ spawn fragments (cloned/parented parts) with burst velocities
+   │       ├─ Snow puff burst at impact
+   │       └─ start own rAF settle loop (gravity + ground bounce + tumble, ~2.5s)
+   │     EffectsModule.addShake(impactScaledBySpeed)   // reuse existing juice
+   │     (optionally) delay #gameOverOverlay ~700ms so the wipeout is the star
+   └─ … existing overlay / score / result logic unchanged
+```
+
+---
+
+## 5. Feature 1 — Tag the model & add the scarf (`src/snowman.ts`)
+
+### 5.1 Part registry
+
+At the end of `createSnowman`, alongside the existing ski refs, register every animatable
+/ shatterable part so both new modules address them by name instead of fishing through
+`group.children`:
+
+```ts
+// Cosmetic part registry — consumed by snowman-flex.ts (jiggle) and debris.ts (shatter).
+// Storing meshes (not indices) keeps both modules decoupled from child order.
+group.userData.parts = {
+  bottom, middle, head,            // the three snow balls
+  leftEye, rightEye, nose,
+  button1, button2, button3,
+  leftArmGroup, rightArmGroup,
+  hatBase, hatTop,
+  scarf, scarfTail,                // added below
+};
+// Remember neutral local transforms so flex can animate as deltas and reset cleanly.
+group.userData.parts.base = recordBaseTransforms(group.userData.parts);
+```
+
+`recordBaseTransforms` snapshots each part's `position`/`scale`/`rotation` into a plain
+object so the flex animator can express everything as an offset from neutral and
+`Flex.reset()` can snap exactly back (no drift across runs). This is the same discipline
+the ski-pose code already uses with `leftSkiBaseX`/`rightSkiBaseX`.
+
+### 5.2 Scarf geometry
+
+A simple, cheap scarf: a flattened torus (the wrap) at the neck seam (~`y = 6.2`, between
+the `middle` top and the `head`) plus a short two-segment tail hanging over the front in
+red wool. Keep it low-poly (matches the rest of the model) and `castShadow = true`:
+
+```ts
+const scarfMaterial = new THREE.MeshStandardMaterial({ color: 0xCC2222, roughness: 1.0 });
+const scarf = new THREE.Mesh(new THREE.TorusGeometry(1.05, 0.28, 8, 16), scarfMaterial);
+scarf.position.y = 6.2; scarf.rotation.x = Math.PI / 2; scarf.castShadow = true;
+group.add(scarf);
+
+// Tail: a short box draped down the front, pivoted at the neck so flex can swing it.
+const scarfTail = new THREE.Group();
+const tailSeg = new THREE.Mesh(new THREE.BoxGeometry(0.5, 1.4, 0.18), scarfMaterial);
+tailSeg.position.y = -0.7; tailSeg.castShadow = true;
+scarfTail.add(tailSeg);
+scarfTail.position.set(0.35, 6.1, 1.0);
+group.add(scarfTail);
+```
+
+This is additive geometry only — it does not touch physics, collision radius, or the
+spawn pose, so terrain/physics tests are unaffected. The DOM smoke test gets one new
+assertion (§8).
+
+---
+
+## 6. Feature 2 — Flexibility / wiggle (`src/snowman-flex.ts`)
+
+A **pure cosmetic** animator, called from `animate()` *after* `updateSnowman`. It reads
+the per-frame motion the kernel already returns (speed, technique, justLanded, isInAir)
+plus the snowman's own turn rate, and writes only child-mesh transforms. It holds a tiny
+amount of state (jiggle phase, settle spring) on `snowman.userData.flex`.
+
+```ts
+export interface FlexMotion {
+  speed: number;        // currentSpeed from UpdateResult
+  technique: string;    // 'carve' | 'skid' | 'tuck' | … (for lean styling)
+  turnRate: number;     // signed: velocity.x / speed, drives lean + scarf swing
+  justLanded: boolean;  // landingForce > threshold → settle bounce
+  landingForce: number;
+  isInAir: boolean;
+}
+
+export const Flex = {
+  update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void { /* … */ },
+  reset(snowman: THREE.Object3D): void { /* snap all parts to base, clear state */ },
+};
+```
+
+Effects, all expressed as offsets from the recorded base transforms (so they compose and
+reset cleanly):
+
+- **Idle breathing / jiggle.** A low-amplitude sine on each ball's vertical scale
+  (squash↔stretch, conserving volume by widening as it shortens), phase-offset per ball
+  so the stack ripples. Amplitude scales gently with speed.
+- **Head bob & lag.** The head lags the body heading by a frame-smoothed amount and bobs
+  on bumps (driven by `justLanded`/terrain change), so it feels weighty.
+- **Landing settle.** On `justLanded` with meaningful `landingForce`, kick a critically-
+  damped spring on the whole stack's vertical scale → a satisfying *squash-and-recover*.
+- **Carve lean.** On `carve`/`parallel`, lean the upper balls + hat into the turn
+  (`turnRate`-scaled, clamped) — a *cosmetic* lean layered on top of the kernel's
+  existing body tilt, addressing the "flexible" ask without spine math.
+- **Scarf trail.** Swing `scarfTail` opposite to travel/turn (trails behind) with a sine
+  flutter scaled by speed; in air it lifts. Cheap, sells "wind."
+
+**Reduced motion:** `Flex.update` early-returns to base transforms (no jiggle/lean), so
+the snowman is simply rigid — identical silhouette, no motion.
+
+**Why a separate module, not inside `updateSnowman`:** keeps the physics kernel and its
+frozen baseline byte-identical (§3.1), and keeps R3's planned `snowman/pose.ts` split
+clean — this is exactly the cosmetic-pose concern R3 wants out of the kernel anyway.
+
+---
+
+## 7. Feature 3 — Crash shatter (`src/debris.ts`)
+
+A self-contained `SnowmanDebris` class, modeled on `AvalancheSystem`: terrain-aware,
+disposable, owns its own settle loop so it can animate **after** `state.gameActive` flips
+false.
+
+### 7.1 API
+
+```ts
+export class SnowmanDebris {
+  setTerrainFunction(fn: (x: number, z: number) => number): void;
+  shatter(scene, snowman, velocity, opts?: { reducedMotion?: boolean }): void;
+  update(dt: number): boolean;   // returns true while still settling
+  reset(scene): void;            // dispose fragments, re-show snowman
+  get active(): boolean;
+}
+```
+
+### 7.2 `shatter()`
+
+1. **Hide** the live snowman group (`snowman.visible = false`) — we replace it with
+   free-flying fragments so the original stays intact for the next run (cheaper + safer
+   than detaching real children).
+2. **Spawn fragments.** For each shatterable part in `userData.parts`, create a
+   lightweight fragment: reuse the part's geometry+material (clone the mesh, or better,
+   spawn a few generic snow-ball chunks sized from the part) positioned at the part's
+   current **world** transform. Give each:
+   - initial velocity = inherited snowman `velocity` (×~0.6) **+** an outward radial
+     burst (`6–11` u/s) **+** an upward pop (`4–8` u/s), scaled by impact speed;
+   - a random angular velocity (`THREE.Vector3`) for tumbling;
+   - a `radius` for ground collision.
+   The three balls additionally crack into 2–3 sub-chunks each so it reads as
+   "balls breaking," per the issue. Cap total fragments (≈24) for perf.
+3. **Snow puff.** Fire a one-shot burst from the existing snow-splash texture/material at
+   the impact point (a dozen-ish sprites with the same gravity/fade as `updateSnowSplash`),
+   so the break-up is wrapped in a cloud of powder — the "balls with snow splashing" ask.
+4. **Juice.** `EffectsModule.addShake(clamp(impactSpeed * k))` for a crash thud (already
+   `prefers-reduced-motion`-aware inside effects).
+5. Start the settle loop (§7.4).
+
+### 7.3 Per-fragment physics (cosmetic, terrain-aware)
+
+Same shape as the avalanche boulder integrator, simplified:
+
+```
+gravity = 18 ; bounce = 0.35 ; friction = 0.9
+vel.y -= gravity * dt ; pos += vel * dt ; rotate by angularVel * dt
+floorY = getTerrainHeight(pos.x, pos.z)        // requires setTerrainFunction()
+if (pos.y < floorY + radius):
+    pos.y = floorY + radius
+    vel.y *= -bounce
+    vel.x *= friction ; vel.z *= friction
+    angularVel *= friction
+```
+
+Fragments settle and stop within ~2–2.5 s, then the loop ends (or `reset()` cuts it
+short on restart).
+
+### 7.4 Settle loop & the `gameActive` interaction
+
+`showGameOver` sets `state.gameActive = false`, which halts `animate()`. Rather than
+complicate the main loop's gating, **`SnowmanDebris` runs its own `requestAnimationFrame`
+loop** while settling (the avalanche-style `update(dt)` ticked from a private rAF). It
+renders via a small callback the orchestrator hands in (it already owns `renderer`,
+`scene`, `camera`), or — simpler — the orchestrator keeps calling
+`renderer.render(scene, camera)` from the debris tick. The loop self-terminates when
+`update()` returns false. This keeps the change to the main loop near-zero.
+
+> **Overlay timing (user-visible, flag this for review).** The `#gameOverOverlay` is 70%
+> black and would dim the wipeout. Proposal: on a **crash**, delay showing the overlay by
+> ~700 ms (a `setTimeout`) so the shatter plays at full brightness, then fade it in;
+> **finish** stays immediate (unchanged). Alternative if we want zero timing change: show
+> the overlay immediately and accept the dimmed shatter behind it. Pick one in review —
+> see Open Questions §11.
+
+### 7.5 `reset()`
+
+Mirror `AvalancheSystem.reset()`: remove every fragment + puff sprite from the scene,
+`geometry.dispose()` / `material.dispose()` on anything we cloned, clear arrays, stop the
+private rAF, and set `snowman.visible = true`. Called from both `resetSnowman()` and
+`restartGame()` so a new run always starts from a clean, visible snowman.
+
+---
+
+## 8. Game-loop & lifecycle integration (`src/snowglider.ts`)
+
+Minimal, localized edits:
+
+1. **Construct once** near the avalanche setup: `const debris = new SnowmanDebris();
+   debris.setTerrainFunction(Snow.getTerrainHeight);` (store on `state` like
+   `state.avalanche`).
+2. **Per frame**, after the existing `updateSnowman(delta)` + splash, call
+   `Flex.update(snowman, delta, motionFromUpdateResult)`. (The wrapper already has the
+   `UpdateResult` in scope — `player`/the return value — so `speed`, `technique`,
+   `justLanded`, `landingForce`, `isInAir` are in hand; `turnRate = velocity.x / speed`.)
+3. **In `showGameOver(reason)`**, *after* the `_testShowGameOverOverride` early return and
+   setting `gameActive = false`, add a crash branch:
+
+   ```ts
+   const isFinish = reason === "You reached the end of the slope!";
+   const crash = !isFinish;
+   if (crash && !window.isTestMode && state.debris) {
+     const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+     state.debris.shatter(scene, snowman, velocity, { reducedMotion: !!reduced });
+     if (EffectsModule) EffectsModule.addShake(/* impact ∝ speed */);
+   }
+   ```
+
+   Everything else in `showGameOver` (best-time, login prompt, leaderboard, result
+   screen, `EffectsModule.reset()`, overlay) is unchanged — except the optional
+   crash-only overlay delay (§7.4).
+4. **In `resetSnowman()` and `restartGame()`**: call `state.debris?.reset(scene)` and
+   `Flex.reset(snowman)` before re-initializing the camera, so the fragments are gone and
+   the snowman is visible and back to neutral pose.
+5. **`src/main.ts`**: add `import './debris.js';` / `import './snowman-flex.js';` (the
+   `.js` specifier resolving to `.ts`, per the repo import convention) so they join the
+   bundle graph; the orchestrator imports the named exports directly.
+
+No new `window.*` globals (respects the no-per-module-bridge rule). `EffectsModule.reset()`
+already runs in `showGameOver`; the debris is independent of it.
+
+---
+
+## 9. Testing plan
+
+| Layer | What | Where |
+|-------|------|-------|
+| **Physics invariant** | Unchanged — assert no regression. Because the kernel is untouched, `npm run test:verify` must stay green **without** regenerating `snowman_baseline.js`. This is itself the proof that flex/shatter didn't leak into physics. | `tests/verification/physics_invariant_harness.js` (run, don't edit) |
+| **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists and a `scarf` mesh is present. | `tests/verification/dom_smoke_test.js` (extend) |
+| **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes and re-shows. Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
+| **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
+| **Browser** | Force a tree collision (existing `window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + debris active immediately after; assert restart re-shows the snowman. | extend `tests/browser-tests.js` |
+| **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
+
+Docs to update in the same PR (Roadmap guardrail): `ARCHITECTURE.md` (new modules in the
+export table + loop step), `ROADMAP.md` (#53 / Finding #11 → ◐), `CHANGELOG.md`. `PHYSICS.md`
+needs **no** change (kernel untouched) — explicitly note that in the PR description.
+
+---
+
+## 10. Performance & accessibility
+
+- **Fragment cap** ≈24 chunks + ≈12 puff sprites; reuse the snow-splash material. One-shot,
+  disposed on reset — no steady-state cost during normal play (debris only exists post-crash).
+- **`prefers-reduced-motion`**: flex → rigid; shatter → hide snowman + single small puff,
+  no flying tumble, no `addShake` (effects already honors it).
+- **Mobile**: the settle loop is short and low-count; gate fragment sub-cracking behind a
+  simple device/perf check if needed (optional, can follow the roadmap's perf-scaling item).
+
+---
+
+## 11. Risks & review checklist
+
+- [ ] `npm run test:verify` green with **no** `snowman_baseline.js` change → proves the
+      physics kernel is untouched (the load-bearing invariant).
+- [ ] Finish flow visually unchanged (no shatter on `"You reached the end of the slope!"`).
+- [ ] Every cloned geometry/material disposed on `reset()`; no leak across repeated
+      crash→restart cycles (watch heap in the browser test).
+- [ ] Debris does **not** render over `#resetBtn` / `#gameOverOverlay` interactive
+      elements (guards the known e2e reset flake).
+- [ ] Test mode / `_testShowGameOverOverride` path skips shatter entirely.
+- [ ] No new `window.*` per-module bridge; modules `import` directly and are imported by
+      `main.ts`.
+- [ ] Scarf doesn't alter collision radius, spawn pose, or terrain tests.
+
+## 12. Suggested PR breakdown (mergeable, low-risk first)
+
+1. **PR A — Scarf + part registry + flex** (no game-over changes): add scarf geometry,
+   `userData.parts`, `src/snowman-flex.ts`, wire `Flex.update`/`Flex.reset`. Lowest risk;
+   ships the "scarf + flexible" half of #53 on its own. Tests: DOM smoke + flex unit +
+   verify-green.
+2. **PR B — Crash shatter**: `src/debris.ts`, the `showGameOver` crash branch, the
+   reset/restart cleanup, the optional overlay delay. Ships "breaks down on impact."
+   Tests: debris unit + browser crash test + e2e.
+
+Splitting this way keeps each PR's blast radius small and lets the expressive-pose work
+land even if the shatter timing needs iteration.
+
+## 13. Open questions (for the maintainer)
+
+1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4),
+   or keep the overlay immediate and accept a dimmed shatter? (Recommend the short delay.)
+2. **Fragment fidelity** — clone the actual parts (hat, nose, arms read clearly) vs.
+   generic snow-ball chunks (cheaper, more uniform)? (Recommend cloning the distinctive
+   parts + cracking the 3 balls into chunks.)
+3. **Scope of #53** — close #53 with A+B, or keep it open for follow-on polish
+   (snowballing-downhill after wipeout, celebratory finish animation)?

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -17,9 +17,12 @@ Three user-visible upgrades, in rising order of risk:
    skis: head bob, a settle-bounce on landing, lean into carves. Makes the snowman read
    as *alive* rather than a rigid stack of spheres.
 2. **Breaks down on impact** — on a **crash** (tree / rock / off-mountain / fell-off /
-   avalanche burial — *not* a finish), the snowman bursts apart: the three balls, hat,
-   nose, arms, and buttons fly off as tumbling fragments while a puff of snow splashes
-   out. The classic SkiFree-style wipeout.
+   avalanche burial — *not* a finish), the snowman bursts apart: the three balls, arms,
+   and buttons fly off as separate tumbling fragments and the **head cluster (head + face +
+   hat) breaks off as one unit**, everything bursting into snow chunks wrapped in a puff of
+   snow. The classic SkiFree-style wipeout. *(Letting the hat and nose fly off as
+   recognizable individual pieces — separate shatter roots + cloning their real part meshes
+   instead of generic chunks — is a documented fidelity follow-up; see §5.1 / §7.2.)*
 3. **Scarf** *(optional follow-up — see §12 PR C)* — a red knitted scarf around the neck
    with a tail that trails in the wind. **Deferred out of the core work**: the
    overlapping neck geometry and trailing tail are the fiddliest, most iteration-prone
@@ -181,6 +184,16 @@ group.userData.parts = {
 // `part.isMesh` (§7.2): own-clone a Mesh directly, but traverse a Group to its child meshes
 // (or spawn a generic chunk at the group's world transform). Every entry is a renderable
 // Object3D.
+//
+// TRADE-OFF (bot review): listing `headGroup` (not its members) means the head, face, and
+// hat break off as ONE cluster fragment rather than the hat/nose flying off as separate
+// recognizable pieces. The shipped PR B spawns generic snow chunks per root, so the whole
+// snowman (head cluster included) bursts into snow — consistent, and the user's core ask
+// ("balls breaking + snow splash") is met. Letting the hat/nose fly off as recognizable
+// individual pieces is a documented FIDELITY FOLLOW-UP: list `nose`/`hatBase`/`hatTop`
+// (and `head`/`leftEye`/`rightEye`) here in place of `headGroup`, and have §7.2 own-CLONE
+// each distinctive mesh (so a black hat / orange nose fly, not white chunks). Deferred to
+// keep PR B small and the head-bob cluster intact.
 group.userData.shatterRoots = [
   bottom, middle, headGroup,
   leftArmGroup, rightArmGroup,
@@ -446,9 +459,16 @@ Minimal, localized edits:
    `state.avalanche`). Because `state` is **module-scoped** and we add no new `window.*`
    bridge, expose a read seam on the **existing** `window.testHooks` surface so the browser
    test can observe debris without reaching `state`:
+   `if (!window.testHooks) window.testHooks = {};`
    `window.testHooks.isDebrisActive = () => !!state.debris && state.debris.active;` — a
    deliberate test hook like the collision hooks (`window.testHooks.forceTreeCollision`),
    **not** a per-module namespace bridge, so it stays within the sanctioned test seam.
+   **Guard the create and install it from/after the `Snowman.addTestHooks(...)` path, NOT
+   at this construct step** — at construction `window.testHooks` may not exist yet (it's
+   created lazily by `addTestHooks` or the `animate()` fallback), so a bare
+   `window.testHooks.isDebrisActive = …` would throw during module init in a normal run.
+   (The shipped PR B installs it right after the eager `addTestHooks` call, guarded — see
+   `src/snowglider.ts`.)
 2. **Per frame**, after the existing `updateSnowman(delta)` + splash, call
    `Flex.update(snowman, delta, motionFromUpdateResult)`. (The wrapper already has the
    `UpdateResult` in scope — `player`/the return value — so `speed`, `technique`,

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -127,7 +127,7 @@ showGameOver(reason)
    ├─ if reason is a CRASH and !testMode and !reducedMotion-skip:
    │     Debris.shatter(scene, snowman, velocity, getTerrainHeight)
    │       ├─ hide snowman group
-   │       ├─ spawn fragments (cloned/parented parts) with burst velocities
+   │       ├─ spawn debris-owned fragment chunks (own geometry/material) with burst velocities
    │       ├─ Snow puff burst at impact
    │       └─ start own rAF settle loop (gravity + ground bounce + tumble, ~2.5s)
    │     EffectsModule.addShake(impactScaledBySpeed)   // reuse existing juice
@@ -147,7 +147,10 @@ At the end of `createSnowman`, alongside the existing ski refs, register every a
 
 ```ts
 // Cosmetic part registry — consumed by snowman-flex.ts (jiggle) and debris.ts (shatter).
-// Storing meshes (not indices) keeps both modules decoupled from child order.
+// INVARIANT: every value here is a renderable Object3D. The shatter path iterates this
+// object and reads each value's world transform / geometry / material, so it must never
+// contain a non-renderable entry (snapshots, flags, counters). Storing meshes (not
+// indices) keeps both modules decoupled from child order.
 group.userData.parts = {
   bottom, middle, head,            // the three snow balls
   leftEye, rightEye, nose,
@@ -158,14 +161,20 @@ group.userData.parts = {
   // animator and the shatter system treat these as present-or-absent, so the registry
   // simply gains two keys when PR C lands; nothing in A/B depends on them existing.
 };
-// Remember neutral local transforms so flex can animate as deltas and reset cleanly.
-group.userData.parts.base = recordBaseTransforms(group.userData.parts);
+// Neutral local transforms live in a SEPARATE map (not on .parts) precisely so the
+// shatter loop above can treat every .parts value as a renderable Object3D. A snapshot
+// stashed under parts.base would be a plain transform record, and a generic
+// `for (const p of Object.values(parts)) p.geometry…/p.getWorldPosition…` would throw on
+// it. Keyed by the same names so flex can pair part↔base.
+group.userData.partBaseTransforms = recordBaseTransforms(group.userData.parts);
 ```
 
 `recordBaseTransforms` snapshots each part's `position`/`scale`/`rotation` into a plain
 object so the flex animator can express everything as an offset from neutral and
-`Flex.reset()` can snap exactly back (no drift across runs). This is the same discipline
-the ski-pose code already uses with `leftSkiBaseX`/`rightSkiBaseX`.
+`Flex.reset()` can snap exactly back (no drift across runs). Keeping it off `.parts`
+(under `userData.partBaseTransforms`) is what lets the shatter code blindly iterate the
+registry. This is the same discipline the ski-pose code already uses with
+`leftSkiBaseX`/`rightSkiBaseX`.
 
 ### 5.2 Scarf geometry — *optional follow-up (PR C), NOT in the core work*
 
@@ -272,9 +281,24 @@ export class SnowmanDebris {
    free-flying fragments so the original stays intact for the next run (cheaper + safer
    than detaching real children).
 2. **Spawn fragments.** For each shatterable part in `userData.parts`, create a
-   lightweight fragment: reuse the part's geometry+material (clone the mesh, or better,
-   spawn a few generic snow-ball chunks sized from the part) positioned at the part's
-   current **world** transform. Give each:
+   lightweight fragment positioned at the part's current **world** transform. **Resource
+   ownership is load-bearing for the crash→restart cycle:** the snowman is only *hidden*
+   (step 1), so its geometry/material must survive. A bare `part.clone()` is **not safe** —
+   Three.js `Object3D.clone()` *shares* the source `geometry`/`material` by reference, so
+   disposing the fragment in `reset()` (§7.5) would dispose the still-hidden snowman's
+   originals and the next run would re-show it with freed buffers. Pick one of:
+   - **(preferred) generic fragment assets** — spawn a small pool of generic snow-ball
+     chunks from geometry/materials the debris system *owns* and creates once, sized/tinted
+     from the part. Nothing references the snowman's assets, so disposal is unambiguous and
+     the three balls cracking into 2–3 chunks each falls out naturally.
+   - **owned clones** — if a fragment must mirror a distinctive part (hat/nose/arms), clone
+     with explicit ownership: `mesh = new THREE.Mesh(part.geometry.clone(), part.material.clone())`
+     (clone-the-mesh alone is insufficient). Track these as "owned" so `reset()` disposes
+     only them.
+
+   Either way, tag each fragment's geometry/material as debris-owned (e.g. push into an
+   `ownedResources` set) so `reset()` disposes **exactly** what the debris system created
+   and never anything still wired to the snowman. Give each fragment:
    - initial velocity = inherited snowman `velocity` (×~0.6) **+** an outward radial
      burst (`6–11` u/s) **+** an upward pop (`4–8` u/s), scaled by impact speed;
    - a random angular velocity (`THREE.Vector3`) for tumbling;
@@ -326,9 +350,12 @@ renders via a small callback the orchestrator hands in (it already owns `rendere
 ### 7.5 `reset()`
 
 Mirror `AvalancheSystem.reset()`: remove every fragment + puff sprite from the scene,
-`geometry.dispose()` / `material.dispose()` on anything we cloned, clear arrays, stop the
-private rAF, and set `snowman.visible = true`. Called from both `resetSnowman()` and
-`restartGame()` so a new run always starts from a clean, visible snowman.
+then `geometry.dispose()` / `material.dispose()` **only on debris-owned resources** (the
+`ownedResources` set from §7.2 — never the snowman's shared geometry/material, or the
+re-shown snowman would render with freed buffers), clear arrays, stop the private rAF, and
+set `snowman.visible = true`. Called from both `resetSnowman()` and `restartGame()` so a
+new run always starts from a clean, visible snowman. The repeated crash→restart heap-leak
+check in §11 is what guards this.
 
 ---
 
@@ -377,7 +404,7 @@ already runs in `showGameOver`; the debris is independent of it.
 |-------|------|-------|
 | **Physics invariant** | Unchanged — assert no regression. Because the kernel is untouched, `npm run test:verify` must stay green **without** regenerating `snowman_baseline.js`. This is itself the proof that flex/shatter didn't leak into physics. | `tests/verification/physics_invariant_harness.js` (run, don't edit) |
 | **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
-| **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes and re-shows. Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
+| **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes **only debris-owned** geometry/material and re-shows the snowman with its original assets intact (assert the snowman's geometry/material were NOT disposed across a shatter→reset cycle). Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
 | **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
 | **Browser** | Force a tree collision (existing `window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + debris active immediately after; assert restart re-shows the snowman. | extend `tests/browser-tests.js` |
 | **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
@@ -404,8 +431,10 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
 - [ ] `npm run test:verify` green with **no** `snowman_baseline.js` change → proves the
       physics kernel is untouched (the load-bearing invariant).
 - [ ] Finish flow visually unchanged (no shatter on `"You reached the end of the slope!"`).
-- [ ] Every cloned geometry/material disposed on `reset()`; no leak across repeated
-      crash→restart cycles (watch heap in the browser test).
+- [ ] `reset()` disposes only debris-**owned** geometry/material (the `ownedResources`
+      set), never the snowman's shared assets; after a crash→restart the re-shown snowman
+      still renders (no freed-buffer artifacts). No leak across repeated crash→restart
+      cycles (watch heap in the browser test).
 - [ ] Debris does **not** render over `#resetBtn` / `#gameOverOverlay` interactive
       elements (guards the known e2e reset flake).
 - [ ] Test mode / `_testShowGameOverOverride` path skips shatter entirely.
@@ -436,9 +465,10 @@ wipeout work first, and quarantines the fiddly scarf so it can't hold them up.
 
 1. **Overlay timing** — delay the crash overlay ~700 ms so the wipeout is visible (§7.4),
    or keep the overlay immediate and accept a dimmed shatter? (Recommend the short delay.)
-2. **Fragment fidelity** — clone the actual parts (hat, nose, arms read clearly) vs.
-   generic snow-ball chunks (cheaper, more uniform)? (Recommend cloning the distinctive
-   parts + cracking the 3 balls into chunks.)
+2. **Fragment fidelity** — owned clones of the distinctive parts (hat, nose, arms read
+   clearly; clone with `geometry.clone()`/`material.clone()` so disposal is safe — §7.2)
+   vs. generic snow-ball chunks (cheaper, uniform, trivially debris-owned)? (Recommend
+   owned clones for the distinctive parts + generic chunks for the 3 balls.)
 3. **Scope of #53** — close #53 once A+B+C land, or close with A+B (flex + wipeout) and
    track the scarf (PR C) + further polish (snowballing-downhill after wipeout,
    celebratory finish animation) as follow-ups? The scarf is now explicitly a follow-up,

--- a/docs/SNOWMAN_SHATTER_PLAN.md
+++ b/docs/SNOWMAN_SHATTER_PLAN.md
@@ -105,8 +105,9 @@ NEW  src/debris.ts        SnowmanDebris: shatter fragments + snow-puff burst + o
 NEW  src/snowman-flex.ts  Flex: cosmetic squash/stretch/jiggle animator (scarf-trail
                           branch is dormant until PR C). Pure fn over (group, dt, motion).
 
-EDIT src/snowman.ts       createSnowman(): tag parts into group.userData.parts {…}.
-                          (Scarf geometry is the optional PR C.) NO change to updateSnowman.
+EDIT src/snowman.ts       createSnowman(): add headGroup cluster (parent face/hat under the
+                          head so they bob together), tag flex parts + shatterRoots on
+                          group.userData. (Scarf = PR C.) NO change to updateSnowman.
 EDIT src/snowglider.ts    main loop calls Flex.update(...) each frame after physics;
                           showGameOver() triggers Debris.shatter() on crash reasons;
                           resetSnowman()/restartGame() call Debris.reset() + Flex.reset().
@@ -146,35 +147,51 @@ showGameOver(reason)
 
 ### 5.1 Part registry
 
-At the end of `createSnowman`, alongside the existing ski refs, register every animatable
-/ shatterable part so both new modules address them by name instead of fishing through
-`group.children`:
+At the end of `createSnowman`, register the animatable parts so flex and debris address
+them by name instead of fishing through `group.children`.
+
+**Head cluster (so the face/hat bob *with* the head).** In the current model the
+`leftEye`/`rightEye`/`nose`/`hatBase`/`hatTop` are **siblings** of the `head` mesh, not its
+children (`src/snowman.ts:120-139`, `:231-240`). So a head bob/lag/rotation applied to
+`head` alone would slide the face and hat off it. Fix in `createSnowman`: parent the head
+mesh **and** its accessories into a `headGroup` pivoted at the neck/head centre (re-base the
+children's `y` relative to that pivot so they render identically at rest). Flex then bobs/
+leans the **group** (face+hat move together) and applies squash only to the inner `head`
+mesh. Purely structural — visually identical at rest, no physics/collision impact — and it
+doubles as a clean shatter unit (the head breaks off as one piece).
 
 ```ts
-// Cosmetic part registry — consumed by snowman-flex.ts (jiggle) and debris.ts (shatter).
-// INVARIANT: every value here is a renderable Object3D — but NOT necessarily a Mesh.
-// leftArmGroup/rightArmGroup (and the PR-C scarfTail) are THREE.Group (createBranchArm()
-// returns a Group, src/snowman.ts:157), which have no .geometry/.material. So the shatter
-// loop MUST branch on type (§7.2): own-clone a Mesh's geometry/material directly, but for
-// a Group traverse to its child meshes (or spawn a generic chunk at the group's world
-// transform). The registry must still never hold a non-renderable entry (snapshots, flags,
-// counters) — that's why base transforms live in the separate partBaseTransforms map below.
-// Storing Object3Ds (not indices) keeps both modules decoupled from child order.
+// FLEX registry — fine-grained animatable refs (snowman-flex.ts). Values are renderable
+// Object3Ds; headGroup is the neck-pivoted cluster (head mesh + eyes + nose + hat).
 group.userData.parts = {
-  bottom, middle, head,            // the three snow balls
-  leftEye, rightEye, nose,
+  bottom, middle,                  // lower two snow balls
+  headGroup, head,                 // head cluster + the inner head mesh (squash target)
+  leftEye, rightEye, nose,         // ride inside headGroup
   button1, button2, button3,
   leftArmGroup, rightArmGroup,
-  hatBase, hatTop,
-  // scarf, scarfTail — added by the optional scarf follow-up (PR C). Both the flex
-  // animator and the shatter system treat these as present-or-absent, so the registry
-  // simply gains two keys when PR C lands; nothing in A/B depends on them existing.
+  hatBase, hatTop,                 // ride inside headGroup
+  // scarf, scarfTail — added by the optional scarf follow-up (PR C). Both flex and shatter
+  // treat these as present-or-absent; the registry just gains two keys when PR C lands.
 };
-// Neutral local transforms live in a SEPARATE map (not on .parts) precisely so the
-// shatter loop above can treat every .parts value as a renderable Object3D. A snapshot
-// stashed under parts.base would be a plain transform record, and a generic
-// `for (const p of Object.values(parts)) p.geometry…/p.getWorldPosition…` would throw on
-// it. Keyed by the same names so flex can pair part↔base.
+
+// SHATTER roots — the flat list of TOP-LEVEL rigid pieces debris.ts flings, so accessories
+// ride with their cluster and are never double-spawned (iterating the fine-grained flex
+// registry would fling the eyes/nose/hat AND the headGroup they live in). The head cluster
+// + arms are THREE.Groups (no .geometry/.material), so the shatter loop MUST branch on
+// `part.isMesh` (§7.2): own-clone a Mesh directly, but traverse a Group to its child meshes
+// (or spawn a generic chunk at the group's world transform). Every entry is a renderable
+// Object3D.
+group.userData.shatterRoots = [
+  bottom, middle, headGroup,
+  leftArmGroup, rightArmGroup,
+  button1, button2, button3,
+  // + scarfTail when PR C lands
+];
+
+// Neutral local transforms live in a SEPARATE map (not on .parts / .shatterRoots) so both
+// loops can treat every registry value as a renderable Object3D — a transform snapshot
+// stashed among the parts would make a generic `p.geometry…/p.getWorldPosition…` loop
+// throw. Keyed by the same names so flex can pair part↔base.
 group.userData.partBaseTransforms = recordBaseTransforms(group.userData.parts);
 ```
 
@@ -245,8 +262,11 @@ reset cleanly):
 - **Idle breathing / jiggle.** A low-amplitude sine on each ball's vertical scale
   (squash↔stretch, conserving volume by widening as it shortens), phase-offset per ball
   so the stack ripples. Amplitude scales gently with speed.
-- **Head bob & lag.** The head lags the body heading by a frame-smoothed amount and bobs
-  on bumps (driven by `justLanded`/terrain change), so it feels weighty.
+- **Head bob & lag.** Bob/lean the **`headGroup`** (the neck-pivoted cluster, §5.1) so the
+  face and hat move *with* the head — never the bare `head` mesh, which would shed the
+  accessories. The cluster lags the body heading by a frame-smoothed amount and bobs on
+  bumps (`justLanded`/terrain change), so it feels weighty; squash (above) stays on the
+  inner `head` mesh.
 - **Landing settle.** On `justLanded` with meaningful `landingForce`, kick a critically-
   damped spring on the whole stack's vertical scale → a satisfying *squash-and-recover*.
 - **Carve lean.** On `carve`/`parallel`, lean the upper balls + hat into the turn
@@ -298,8 +318,10 @@ export class SnowmanDebris {
 1. **Hide** the live snowman group (`snowman.visible = false`) — we replace it with
    free-flying fragments so the original stays intact for the next run (cheaper + safer
    than detaching real children).
-2. **Spawn fragments.** For each shatterable part in `userData.parts`, create a
-   lightweight fragment positioned at the part's current **world** transform. **Resource
+2. **Spawn fragments.** For each root in `userData.shatterRoots` (the top-level pieces from
+   §5.1 — *not* the fine-grained flex `parts`, or the eyes/nose/hat would be flung twice:
+   once on their own and once inside `headGroup`), create a lightweight fragment positioned
+   at the root's current **world** transform. **Resource
    ownership is load-bearing for the crash→restart cycle:** the snowman is only *hidden*
    (step 1), so its geometry/material must survive. A bare `part.clone()` is **not safe** —
    Three.js `Object3D.clone()` *shares* the source `geometry`/`material` by reference, so
@@ -314,11 +336,12 @@ export class SnowmanDebris {
      `mesh = new THREE.Mesh(part.geometry.clone(), part.material.clone())` (cloning the mesh
      alone is insufficient — it keeps the shared buffers). Track these as "owned" so
      `reset()` disposes only them.
-   - **Group parts** — `leftArmGroup`/`rightArmGroup` (and the PR-C `scarfTail`) are
-     `THREE.Group`s with **no `.geometry`/`.material`**, so a blind `part.geometry.clone()`
-     would throw or skip the arms. The loop must branch on `part.isMesh`: for a Group,
-     either traverse it and own-clone each child mesh into one fragment group, or (simpler)
-     spawn a single generic stick/snow chunk at the group's **world** transform.
+   - **Group parts** — `headGroup`, `leftArmGroup`/`rightArmGroup` (and the PR-C `scarfTail`)
+     are `THREE.Group`s with **no `.geometry`/`.material`**, so a blind `part.geometry.clone()`
+     would throw or skip them. The loop must branch on `part.isMesh`: for a Group, either
+     traverse it and own-clone each child mesh into one fragment group (the head cluster flies
+     intact — face + hat included), or (simpler, for the arms) spawn a single generic
+     stick/snow chunk at the group's **world** transform.
 
    Either way, tag each fragment's geometry/material as debris-owned (e.g. push into an
    `ownedResources` set) so `reset()` disposes **exactly** what the debris system created
@@ -466,7 +489,7 @@ already runs in `showGameOver`; the debris is independent of it.
 | **DOM smoke** | `createSnowman` still builds; assert the new `userData.parts` registry exists. (The `scarf`-present assertion is added by PR C.) | `tests/verification/dom_smoke_test.js` (extend) |
 | **Debris unit** | Headless with a mocked `THREE` + deterministic terrain fn: `shatter()` spawns N fragments and hides the snowman; `update(dt)` applies gravity and converges (fragments rest at/above terrain, loop returns false within ~2.5 s); `reset()` disposes **only debris-owned** geometry/material and re-shows the snowman with its original assets intact (assert the snowman's geometry/material were NOT disposed across a shatter→reset cycle). Mirror the existing `avalanche-tests.js` harness. | new `tests/debris-tests.js` + `npm` script |
 | **Flex unit** | `Flex.update` only mutates child transforms and is bounded (clamped lean, returns to base when idle / reduced-motion); stays **finite** for a `{ speed: 0, delta: 0 }` frame (no NaN); `Flex.reset` restores base transforms exactly. | new `tests/snowman-flex-tests.js` |
-| **Browser** | Set `window.testHooks.debrisEnabled = true` (the §8.3 opt-in that re-enables shatter under `?test=`), then force a tree collision (`window.testHooks.forceTreeCollision`) and assert `snowman.visible === false` + `window.testHooks.isDebrisActive()` (the read seam from §8.1 — `state` is module-scoped, so the test reads through `testHooks`, never `state.debris`) immediately after; assert restart re-shows the snowman. Every other suite leaves the flag unset, so debris stays off for them and the e2e reset spec. | extend `tests/browser-tests.js` |
+| **Browser** | In a `try/finally` (so the flag can't leak), set `window.testHooks.debrisEnabled = true` (the §8.3 opt-in that re-enables shatter under `?test=`), force a tree collision (`window.testHooks.forceTreeCollision`), and assert `snowman.visible === false` + `window.testHooks.isDebrisActive()` (the §8.1 read seam — `state` is module-scoped, so read through `testHooks`, never `state.debris`); assert restart re-shows the snowman. The `finally` restores the flag to its prior value: `browser-tests.js` runs cases **sequentially in one page** and later cases call `forceTreeCollision`, so a leaked flag would hand them an unexpected shatter (hidden snowman / stray debris rAF). Equivalently, run this case on its own page. | extend `tests/browser-tests.js` |
 | **E2E** | Reuse the reset spec's "coast → crash" but assert the wipeout doesn't block `#resetBtn` (debris must not cover the button; keep overlay z-order intact). Watch the known reset-flake (see memory `e2e-reset-flake-overlay`). | `tests/e2e/` |
 
 Docs to update in the same PR (Roadmap guardrail): `ARCHITECTURE.md` (new modules in the
@@ -507,8 +530,14 @@ needs **no** change (kernel untouched) — explicitly note that in the PR descri
 - [ ] If the crash overlay delay is used, its `setTimeout` id is stored and
       `clearTimeout`'d in `resetSnowman`/`restartGame` — a restart inside the delay window
       can't re-show or strand `#gameOverOverlay`.
-- [ ] Shatter loop branches on `part.isMesh` — Group parts (arms, PR-C scarf tail) are
-      traversed or replaced with a generic chunk, never `part.geometry.clone()`'d directly.
+- [ ] Shatter loop iterates `userData.shatterRoots` (top-level pieces), branches on
+      `part.isMesh` — Group parts (`headGroup`, arms, PR-C scarf tail) are traversed or
+      replaced with a generic chunk, never `part.geometry.clone()`'d directly; accessories
+      are not double-spawned.
+- [ ] Head bob/lag transforms `headGroup` (face + hat ride along), never the bare `head`
+      mesh; squash stays on the inner head mesh. Face/hat never detach during normal skiing.
+- [ ] The `debrisEnabled` opt-in is scoped (try/finally restores prior value, or isolated
+      page) so it can't leak into later sequential browser cases that call `forceTreeCollision`.
 - [ ] `Flex.update` is NaN-safe on a zero-speed/zero-delta frame (epsilon-guarded
       `turnRate`, clamped outputs); no NaN rotation/scale ever reaches the snowman.
 - [ ] No new `window.*` per-module bridge; modules `import` directly and are imported by


### PR DESCRIPTION
## Summary

Implementation **proposal** (design doc, not code yet) for **#53** — *"more realistic snowman: scarf, flexible, breaks down on impact"* — and Roadmap **Finding #11 (Personality & fail-state fun) / P2**. Adds `docs/SNOWMAN_SHATTER_PLAN.md` specifying the modules, data-flow seams, and a mergeable PR sequence so the implementation PRs are mechanical.

Follows the repo's planning-doc convention (cf. `docs/REFACTORING_SNOWGLIDER_SNOWMAN.md`).

## What it proposes

Two new **cosmetic** modules + surgical edits to three existing files:

- **`src/snowman-flex.ts`** — flexible/"wiggly" snowman: squash/stretch jiggle, head bob, landing settle-bounce, carve lean. Called from the orchestrator *after* physics.
- **`src/debris.ts`** — `SnowmanDebris` (modeled on `AvalancheSystem`): on a **crash** (not a finish) the three balls + hat/nose/arms/buttons burst into terrain-aware tumbling fragments wrapped in a snow-puff burst, with its own settle loop so it animates after `gameActive` flips false.

## The hard constraint it's designed around

**The `Snowman.updateSnowman` physics kernel is untouched.** Flex and shatter are cosmetic layers run from the orchestrator, so the physics-invariant harness and the frozen `snowman_baseline.js` stay byte-identical — **no baseline regeneration, no `PHYSICS.md` change**. That green-with-no-baseline-change is itself the proof the kernel didn't move.

Other guardrails baked in: route everything through the single `showGameOver(reason)` chokepoint (covers avalanche burial), gate on `window.isTestMode`/`_testShowGameOverOverride`, honor `prefers-reduced-motion`, dispose all THREE objects on reset, and keep debris off the `#resetBtn`/overlay (guards the known e2e reset flake). No new `window.*` bridges.

## Suggested PR breakdown

1. **PR A — Part registry + flex** (no game-over changes, **no scarf**) — lowest risk; ships "flexible/wiggly" on its own.
2. **PR B — Crash shatter** — `src/debris.ts` + the `showGameOver` crash branch + reset/restart cleanup. Ships "breaks down on impact."
3. **PR C — Scarf (optional follow-up)** — quarantined on purpose: the overlapping neck geometry / trailing tail is the riskiest, most iteration-prone piece. A/B treat the scarf as present-or-absent, so C just adds two registry keys + geometry later, or is dropped, without affecting A/B.

## Open questions (in the doc)

1. Delay the crash overlay ~700ms so the wipeout is visible at full brightness (recommended) vs. immediate?
2. Clone the distinctive parts (hat/nose/arms read clearly) vs. generic snow-ball chunks?
3. Close #53 with A+B and track scarf (C) + further polish as follow-ups?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
