### PR TITLE
feat(sky): golden-hour↔midday sun cycle, re-integrated onto game/* + #181 baseline (#163)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,32 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Golden-hour ↔ midday sun cycle (#163)
+- The atmospheric sky (#2) now **gently breathes between the static midday and a
+  low, warm golden hour and back** on a 90 s loop, so the light feels alive without
+  re-balancing how snow reads. It is a **bounded atmospheric layer on top of the
+  settled static snow-lighting look** (#181 / [`SNOW_RENDERING.md`](SNOW_RENDERING.md)),
+  not a readability pass — re-integrated onto the `src/game/*` structure that the old
+  PR predated.
+- **Captures the merged static state as its bright endpoint.** At setup
+  `Sky.applyAtmosphericSky(scene, directionalLight)` snapshots the directional sun's
+  position/colour/intensity, the Preetham `sunPosition`/`exposure`, and the fog /
+  background, then drives **only** those toward warmer, dimmer golden-hour values and
+  back. Midday and every frozen state are a **bit-for-bit copy** of that snapshot.
+- **Stays in its lane.** The cycle never touches the `HemisphereLight` (the snow's
+  cool-shadow fill), the `AmbientLight`, snow albedo/vertex tint, or terrain — so the
+  warm-sun / cool-shadow snow form is preserved and the mountain is never washed warm
+  or pushed back toward the old `0.5 * Math.PI` ambient whiteout. Advanced by
+  `Sky.update(delta)` in `game/main-loop.ts`; **frozen at midday** under
+  `prefers-reduced-motion` and the `SUN_CYCLE_ENABLED` switch.
+- **Low-sun guard.** The golden-hour sun is held at `SUN_ELEV_MIN = 14°` while the
+  periodic `sin(x*0.2)*cos(z*0.3)` terrain ridge survives (issue #188: `12–15°` until
+  fBm/domain-warp terrain lands; `8°` only after). Purely visual — the physics-invariant
+  harness stays byte-identical. Covered by `tests/sky-cycle-tests.js`
+  (`npm run test:sky`): captured-midday equality, reduced-motion / disabled freeze,
+  hemisphere & ambient untouched, sun above the horizon, warmer/dimmer golden hour,
+  monotonic half-cycles, and periodicity.
+
 ### Snow rendering & lighting guide (docs)
 - Added [`docs/SNOW_RENDERING.md`](SNOW_RENDERING.md) plus
   `docs/snow-lighting-model.svg`, versioning the rationale behind the snow-lighting

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,7 +114,7 @@ A skiing game lives on speed readability and mountain atmosphere.
 
 - **Shipped:** speed-based FOV (widens at speed), camera shake on hard landings / avalanche proximity, a **visible sky** — a Preetham atmospheric sky with a sun aligned to the directional light, plus horizon distance fog so terrain reads with depth instead of hard-cutting at the far plane (**#2**, `src/sky.ts`) — a **cinematic intro fly-over** of the mountain at game start (**#51**, `src/intro.ts`): a wide establishing shot that sweeps down the course and settles into the gameplay pose, skippable and disabled under test/automation/reduced-motion — a **de-striped, smooth-shaded snow surface** (diagonal texture stripes removed + render-only *smoothed shading normals* so the bumpy terrain stops reading as grey bands + softer light + snow-capped rocks; physics height field untouched; **#17**, `src/mountains.ts`), and **temporary ski tracks** that fade behind the skis (**#17**, `src/snowtracks.ts`).
 - **Remaining (○):** a real **snow-accumulation model** (persistent `SnowDepthField`: snowfall raises depth, skis compact tracks, tracks refill over time — visual-only first, fed into the terrain material; the current ski tracks are transient feedback, not accumulation); replacing the periodic `sin(x*0.2)*cos(z*0.3)` terrain ridge with layered fBm/domain-warp so the geometry itself stops banding (a separate terrain PR — touches the height contract + physics tests); weather variation and a day→sunset→night skybox; stronger slope contrast and obstacle silhouettes; and depth cues.
-- **Open issues:** lighting/shadows and snow/tree/rock/snowman textures (**#17** snow surface + dynamic trails now ◐ partial). Intro fly-over (**#51**) ✅ shipped (`src/intro.ts`). Visible sky (**#2**) is ◐ partial — static sky shipped; clouds / day-night cycle remain.
+- **Open issues:** lighting/shadows and snow/tree/rock/snowman textures (**#17** snow surface + dynamic trails now ◐ partial). Intro fly-over (**#51**) ✅ shipped (`src/intro.ts`). Visible sky (**#2**) is ◐ partial — static sky + a bounded golden-hour↔midday sun cycle (#163) shipped; clouds / full night path remain.
 
 ### 8. Audio consistency and completion — ○ open
 
@@ -333,7 +333,7 @@ Many recommendations align with the maintainer's backlog, which is a good sign t
 | Gyro/tilt controls | #24 | ○ open |
 | Lighting and shadows | #18 | ○ open |
 | Textures (snow, trees, rocks, snowman) | #17 | ◐ partial — snow-surface texture (grid-line fix → isotropic powder), snow-capped rocks, tree bark/foliage, and dynamic ski trails shipped (`src/mountains.ts`, `src/trees.ts`, `src/snowtracks.ts`); snowman texture open |
-| Visible sky | #2 | ◐ partial — atmospheric sky + sun + horizon fog shipped (`src/sky.ts`); clouds / day-night cycle open |
+| Visible sky | #2 | ◐ partial — atmospheric sky + sun + horizon fog + a bounded golden-hour↔midday **sun cycle** shipped (`src/sky.ts`, #163); clouds / full night path open |
 
 ### Infrastructure, tooling & exploratory
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -30,6 +30,7 @@
     "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",
     "test:share-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-menu-tests.js",
     "test:audio-asset": "node tests/audio-asset-tests.js",
+    "test:sky": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sky-cycle-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -7,6 +7,7 @@
 
 import { Controls } from '../controls.js';
 import { Snow } from '../snow.js';
+import { Sky } from '../sky.js';
 import { Snowman } from '../snowman.js';
 import { Flex } from '../snowman-flex.js';
 import { CourseModule } from '../course.js';
@@ -114,6 +115,10 @@ export function createMainLoop(deps: MainLoopDeps) {
       // the skis that fresh snow covers back over. Purely cosmetic — reads position
       // only, never the physics state.
       state.snowTrails?.update(delta, snowman, player.isInAir);
+
+      // Advance the golden-hour↔midday sun cycle (sun position/colour, sky
+      // exposure, fog). Purely atmospheric; a no-op under reduced motion. (#163)
+      Sky.update(delta);
 
       // --- Course progress: split timing, progress HUD, ghost racing ---
       if (CourseModule) {

--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -187,10 +187,15 @@ export function setupScene() {
   scene.add(directionalLight);
 
   // --- Sky & fog ---
-  // Preetham atmospheric sky + sun, with horizon-tinted distance fog (issue #2).
-  // The sun direction is the directional light's position so the visible sun and
-  // the cast shadows agree. (Sky.applyGradientSky is a lighter-weight fallback.)
-  Sky.applyAtmosphericSky(scene, directionalLight.position);
+  // Preetham atmospheric sky + sun, with horizon-tinted distance fog (issue #2),
+  // plus the Tier 3 golden-hour↔midday sun cycle (#163). The directional light's
+  // current position/colour/intensity (set just above) are captured as the static
+  // midday endpoint, then the cycle drives it (so the visible sun and cast shadows
+  // track together) and the sky/fog; it is advanced by `Sky.update(delta)` in the
+  // main loop and freezes at the captured midday under prefers-reduced-motion. The
+  // HemisphereLight/AmbientLight are intentionally not handed to the cycle — it must
+  // not touch the snow's cool-shadow fill. (Sky.applyGradientSky is a fallback.)
+  Sky.applyAtmosphericSky(scene, directionalLight);
 
   // --- Create main game objects ---
   // Store terrain in a global for precise object positioning

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -285,23 +285,204 @@ function createAtmosphericSky(sunDirection: THREE.Vector3): THREE.Mesh {
   return sky;
 }
 
+// --- Tier 3: sun cycle (golden hour ↔ midday) -----------------------------
+//
+// A bounded atmospheric layer on top of the *settled static snow-lighting look*
+// (issues #17/#18 — see docs/SNOW_RENDERING.md). It is NOT a snow-readability
+// pass: it only sweeps the sun between the captured static midday and a low,
+// warm golden hour and back, so the light feels alive without re-balancing how
+// snow reads. Full night is intentionally skipped (it needs stars/moon + a dark
+// path, tracked under #2).
+//
+// What it drives, in lockstep: the directional light (position so shadows track
+// the sun, plus a warm→white colour and a dimmer-at-golden-hour intensity), the
+// Preetham `sunPosition`/`exposure` uniforms, and the fog/background tint.
+//
+// What it must NEVER touch (snow form lives here, not in the cycle): the
+// HemisphereLight (the cool-shadow fill), the AmbientLight, snow albedo/vertex
+// tint, and terrain normals/height. The midday endpoint is captured from the
+// merged static scene at setup — never hardcoded — so `prefers-reduced-motion`
+// and the `SUN_CYCLE_ENABLED` switch reproduce the approved static sky exactly.
+
+const SUN_CYCLE_ENABLED = true;
+const CYCLE_DURATION_S = 90;          // one full midday → golden → midday loop
+
+// Low-sun guard. The terrain still has the periodic `sin(x*0.2)*cos(z*0.3)`
+// ridge that bands under a hard low sun, so the golden-hour sun is held at a
+// safe elevation (issue #188: 12–15° until fBm/domain-warp terrain lands; 8° is
+// only allowed once that ridge is gone or visually proven safe).
+const SUN_ELEV_MIN_DEG = 14;
+
+// Golden-hour endpoints (the midday endpoints are captured at setup). All stay
+// bounded under the static guide so golden hour is warmer/dimmer than midday and
+// never brightens past it.
+const GOLDEN_DIR_COLOR = new THREE.Color(0xffc89e);     // warm low sun
+const GOLDEN_DIR_INTENSITY_FACTOR = 0.8;                // × captured midday intensity (dimmer)
+const GOLDEN_EXPOSURE = 0.38;                           // < captured midday exposure
+const GOLDEN_FOG_COLOR = new THREE.Color(0xe6dcc8);     // warm pale haze, still soft
+
+interface SunCycle {
+  material: THREE.ShaderMaterial;
+  fog: THREE.Fog;
+  scene: THREE.Scene;
+  directionalLight: THREE.DirectionalLight;
+  enabled: boolean;
+  reducedMotion: boolean;
+  elapsed: number;
+  // Captured static-midday snapshot (the cycle's bright endpoint).
+  midday: {
+    sunDir: THREE.Vector3;   // unit
+    distance: number;
+    azimuth: number;         // radians
+    elevation: number;       // radians
+    dirColor: THREE.Color;
+    dirIntensity: number;
+    exposure: number;
+    fogColor: THREE.Color;
+    bgColor: THREE.Color;
+  };
+}
+
+let cycle: SunCycle | null = null;
+
 /**
- * Apply the Tier 2 Preetham atmospheric sky (with a sun) and matching distance
- * fog. `sunDirection` should be the scene's directional-light direction so the
- * visible sun and the cast shadows agree (magnitude is ignored).
+ * Cycle progress `p` for an elapsed time. `p = 1` is the captured static midday,
+ * `p = 0` is golden hour. First load (`elapsed = 0`) starts at midday and the
+ * curve eases smoothly between the two endpoints with period `CYCLE_DURATION_S`.
+ * Pure + exported for headless tests.
  */
-function applyAtmosphericSky(scene: THREE.Scene, sunDirection: THREE.Vector3): void {
+function cycleProgress(elapsed: number): number {
+  const phase = ((elapsed + CYCLE_DURATION_S / 2) % CYCLE_DURATION_S) / CYCLE_DURATION_S;
+  return (1 - Math.cos(2 * Math.PI * phase)) / 2;
+}
+
+/** Unit sun direction for a cycle progress `p`, swept from the captured midday. */
+function sunDirAt(c: SunCycle, p: number): THREE.Vector3 {
+  const elev = THREE.MathUtils.lerp(
+    THREE.MathUtils.degToRad(SUN_ELEV_MIN_DEG),
+    c.midday.elevation,
+    p
+  );
+  const az = c.midday.azimuth; // azimuth fixed to the captured static sun
+  const cosE = Math.cos(elev);
+  return new THREE.Vector3(cosE * Math.sin(az), Math.sin(elev), cosE * Math.cos(az));
+}
+
+/** Drive the live scene objects to the captured static-midday endpoint exactly. */
+function applyMidday(c: SunCycle): void {
+  const m = c.midday;
+  c.material.uniforms.sunPosition.value.copy(m.sunDir);
+  c.material.uniforms.exposure.value = m.exposure;
+  c.directionalLight.position.copy(m.sunDir).multiplyScalar(m.distance);
+  c.directionalLight.intensity = m.dirIntensity;
+  c.directionalLight.color.copy(m.dirColor);
+  c.fog.color.copy(m.fogColor);
+  if (c.scene.background instanceof THREE.Color) c.scene.background.copy(m.bgColor);
+}
+
+/** Drive the live scene objects for a cycle progress `p` (golden → captured midday). */
+function applyProgress(c: SunCycle, p: number): void {
+  // Snap to the exact captured snapshot at (or imperceptibly close to) midday so
+  // the frozen/midpoint state is a bit-for-bit copy, not a trig/lerp rebuild.
+  if (p >= 1 - 1e-9) { applyMidday(c); return; }
+
+  const m = c.midday;
+  const sunDir = sunDirAt(c, p);
+  c.material.uniforms.sunPosition.value.copy(sunDir);
+  c.material.uniforms.exposure.value = THREE.MathUtils.lerp(GOLDEN_EXPOSURE, m.exposure, p);
+  c.directionalLight.position.copy(sunDir).multiplyScalar(m.distance);
+  c.directionalLight.intensity = THREE.MathUtils.lerp(
+    m.dirIntensity * GOLDEN_DIR_INTENSITY_FACTOR,
+    m.dirIntensity,
+    p
+  );
+  c.directionalLight.color.lerpColors(GOLDEN_DIR_COLOR, m.dirColor, p);
+  c.fog.color.lerpColors(GOLDEN_FOG_COLOR, m.fogColor, p);
+  if (c.scene.background instanceof THREE.Color) {
+    c.scene.background.lerpColors(GOLDEN_FOG_COLOR, m.bgColor, p);
+  }
+}
+
+/** Options to force the freeze paths in headless tests; production passes none. */
+export interface AtmosphericSkyOptions {
+  enabled?: boolean;
+  reducedMotion?: boolean;
+}
+
+function detectReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Apply the Tier 2 Preetham atmospheric sky (with a sun) + the Tier 3 sun cycle
+ * and matching distance fog. `directionalLight` is the scene's static key light:
+ * its current position/colour/intensity are captured as the bright *midday*
+ * endpoint, and the cycle then drives it (and the sky/fog) so the visible sun and
+ * the cast shadows stay in sync. Call `Sky.update(dt)` each frame to animate it;
+ * it freezes at the captured midday under `prefers-reduced-motion` or when the
+ * cycle is disabled, reproducing the static sky exactly. The HemisphereLight and
+ * AmbientLight are deliberately not passed in — the cycle must not touch them.
+ */
+function applyAtmosphericSky(
+  scene: THREE.Scene,
+  directionalLight: THREE.DirectionalLight,
+  options: AtmosphericSkyOptions = {}
+): void {
   scene.background = new THREE.Color(ATMOSPHERE_FOG_COLOR);
-  scene.fog = new THREE.Fog(ATMOSPHERE_FOG_COLOR, FOG_NEAR, FOG_FAR);
-  scene.add(createAtmosphericSky(sunDirection));
+  const fog = new THREE.Fog(ATMOSPHERE_FOG_COLOR, FOG_NEAR, FOG_FAR);
+  scene.fog = fog;
+
+  const sky = createAtmosphericSky(directionalLight.position);
+  scene.add(sky);
+  const material = sky.material as THREE.ShaderMaterial;
+
+  // Capture the merged static state as the bright midday endpoint.
+  const pos = directionalLight.position.clone();
+  const horiz = Math.hypot(pos.x, pos.z);
+  cycle = {
+    material,
+    fog,
+    scene,
+    directionalLight,
+    enabled: options.enabled ?? SUN_CYCLE_ENABLED,
+    reducedMotion: options.reducedMotion ?? detectReducedMotion(),
+    elapsed: 0,
+    midday: {
+      sunDir: pos.clone().normalize(),
+      distance: pos.length(),
+      azimuth: Math.atan2(pos.x, pos.z),
+      elevation: Math.atan2(pos.y, horiz),
+      dirColor: directionalLight.color.clone(),
+      dirIntensity: directionalLight.intensity,
+      exposure: material.uniforms.exposure.value as number,
+      fogColor: fog.color.clone(),
+      bgColor: (scene.background as THREE.Color).clone()
+    }
+  };
+
+  // First load is the captured static midday (a bit-for-bit copy).
+  applyMidday(cycle);
+}
+
+/** Advance the sun cycle by `dt` seconds. No-op when frozen (reduced motion / disabled). */
+function update(dt: number): void {
+  if (!cycle || !cycle.enabled || cycle.reducedMotion) return;
+  cycle.elapsed += dt;
+  applyProgress(cycle, cycleProgress(cycle.elapsed));
 }
 
 export const Sky = {
   applyGradientSky,
   applyAtmosphericSky,
+  update,
+  cycleProgress,
   ZENITH_COLOR,
   HORIZON_COLOR,
   ATMOSPHERE_FOG_COLOR,
   FOG_NEAR,
-  FOG_FAR
+  FOG_FAR,
+  CYCLE_DURATION_S,
+  SUN_ELEV_MIN_DEG
 };

--- a/tests/sky-cycle-tests.js
+++ b/tests/sky-cycle-tests.js
@@ -1,0 +1,225 @@
+/**
+ * Headless tests for the Tier 3 sun cycle in src/sky.ts (issue #163, contract in
+ * issue #188). The cycle is a *bounded atmospheric layer*: it captures the merged
+ * static-midday lighting at setup and only sweeps the directional sun, the sky
+ * exposure, and the fog/background between that captured midday and a low, warm
+ * golden hour. It must never touch the HemisphereLight, the AmbientLight, snow
+ * albedo, or terrain.
+ *
+ * Runs against the REAL src/sky.ts and real three.js from npm — three's
+ * Light/Color/Fog/ShaderMaterial constructors need no WebGL context, so the cycle
+ * drives a real scene headless under Node.
+ *
+ * Run with the .js -> .ts resolve hook:
+ *   node --import ./tests/loaders/register-ts-resolve.mjs tests/sky-cycle-tests.js
+ */
+
+const assert = require('node:assert');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  PASS ✅: ${name}`);
+}
+
+(async () => {
+  const THREE = await import('three');
+  const { Sky } = await import('../src/sky.js');
+
+  // The merged static lighting from src/game/scene-setup.ts (post-#181). The cycle
+  // must capture THESE at runtime — never the old pre-#181 0.8π/0.5π constants.
+  const STATIC_AMB_INTENSITY = 0.26 * Math.PI;
+  const STATIC_HEMI_INTENSITY = 0.62 * Math.PI;
+  const STATIC_DIR_INTENSITY = 0.5 * Math.PI;
+  const OLD_WHITEOUT_AMBIENT = 0.5 * Math.PI; // the value the cycle must never approach
+
+  /** Build a scene with the exact static lights scene-setup creates. */
+  function makeScene() {
+    const scene = new THREE.Scene();
+    const ambient = new THREE.AmbientLight(0xffffff, STATIC_AMB_INTENSITY);
+    const hemisphere = new THREE.HemisphereLight(0xdcebfb, 0xbcc7d4, STATIC_HEMI_INTENSITY);
+    const directional = new THREE.DirectionalLight(0xffffff, STATIC_DIR_INTENSITY);
+    directional.position.set(50, 100, 50);
+    scene.add(ambient);
+    scene.add(hemisphere);
+    scene.add(directional);
+    return { scene, ambient, hemisphere, directional };
+  }
+
+  /** Read every value the cycle is allowed to drive, off the live scene objects. */
+  function liveState(scene, directional) {
+    const sky = scene.children.find((c) => c.name === 'AtmosphericSky');
+    const u = sky.material.uniforms;
+    return {
+      sunPos: u.sunPosition.value.clone(),
+      exposure: u.exposure.value,
+      dirPos: directional.position.clone(),
+      dirIntensity: directional.intensity,
+      dirColor: directional.color.getHex(),
+      fog: scene.fog.color.getHex(),
+      bg: scene.background.getHex()
+    };
+  }
+
+  function assertStateEqual(a, b, msg) {
+    assert.ok(a.sunPos.distanceTo(b.sunPos) < 1e-12, `${msg}: sunPosition`);
+    assert.strictEqual(a.exposure, b.exposure, `${msg}: exposure`);
+    assert.ok(a.dirPos.distanceTo(b.dirPos) < 1e-12, `${msg}: dir position`);
+    assert.strictEqual(a.dirIntensity, b.dirIntensity, `${msg}: dir intensity`);
+    assert.strictEqual(a.dirColor, b.dirColor, `${msg}: dir colour`);
+    assert.strictEqual(a.fog, b.fog, `${msg}: fog colour`);
+    assert.strictEqual(a.bg, b.bg, `${msg}: background colour`);
+  }
+
+  console.log('--- Sun cycle (sky.ts) ---');
+
+  // -------------------------------------------------------------------------
+  test('midday == captured static snapshot (captured, not hardcoded old constants)', () => {
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    const captured = liveState(scene, directional);
+
+    // It captured the STATIC scene values, not the old #163 hardcoded 0.8π/0.5π.
+    assert.strictEqual(captured.dirIntensity, STATIC_DIR_INTENSITY, 'captured the static 0.5π directional');
+    assert.notStrictEqual(captured.dirIntensity, 0.8 * Math.PI, 'did not revert to the old 0.8π');
+    assert.strictEqual(captured.dirColor, 0xffffff, 'midday sun is white');
+    // Midday sun direction is the normalized static (50,100,50).
+    const expected = new THREE.Vector3(50, 100, 50).normalize();
+    assert.ok(captured.sunPos.distanceTo(expected) < 1e-9, 'sun direction == static light');
+
+    // After a full period the live state returns to that exact captured snapshot.
+    Sky.update(Sky.CYCLE_DURATION_S);
+    assertStateEqual(liveState(scene, directional), captured, 'after one full period');
+  });
+
+  // -------------------------------------------------------------------------
+  test('reduced-motion freeze leaves lights/fog/background/uniforms exactly static', () => {
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional, { reducedMotion: true });
+    const frozen = liveState(scene, directional);
+    for (let i = 0; i < 200; i++) Sky.update(0.5);
+    assertStateEqual(liveState(scene, directional), frozen, 'reduced-motion');
+  });
+
+  // -------------------------------------------------------------------------
+  test('SUN_CYCLE_ENABLED=false leaves lights/fog/background/uniforms exactly static', () => {
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional, { enabled: false });
+    const frozen = liveState(scene, directional);
+    for (let i = 0; i < 200; i++) Sky.update(0.5);
+    assertStateEqual(liveState(scene, directional), frozen, 'disabled');
+  });
+
+  // -------------------------------------------------------------------------
+  test('HemisphereLight is untouched across setup and updates', () => {
+    const { scene, hemisphere, directional } = makeScene();
+    const before = {
+      sky: hemisphere.color.getHex(),
+      ground: hemisphere.groundColor.getHex(),
+      intensity: hemisphere.intensity
+    };
+    Sky.applyAtmosphericSky(scene, directional);
+    for (let i = 0; i < 180; i++) Sky.update(0.5);
+    assert.strictEqual(hemisphere.color.getHex(), before.sky, 'hemi sky colour unchanged');
+    assert.strictEqual(hemisphere.groundColor.getHex(), before.ground, 'hemi ground colour unchanged');
+    assert.strictEqual(hemisphere.intensity, before.intensity, 'hemi intensity unchanged');
+    assert.strictEqual(before.intensity, STATIC_HEMI_INTENSITY, 'hemi stayed at the static 0.62π');
+  });
+
+  // -------------------------------------------------------------------------
+  test('AmbientLight stays static, under budget, and never moves toward the 0.5π whiteout', () => {
+    const { scene, ambient, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    for (let i = 0; i < 180; i++) {
+      Sky.update(0.5);
+      assert.strictEqual(ambient.intensity, STATIC_AMB_INTENSITY, 'ambient never animates');
+      assert.ok(ambient.intensity <= STATIC_AMB_INTENSITY, 'ambient under captured budget');
+      assert.ok(ambient.intensity < OLD_WHITEOUT_AMBIENT, 'ambient nowhere near the old whiteout value');
+      assert.strictEqual(ambient.color.getHex(), 0xffffff, 'ambient colour unchanged');
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  test('sun stays above the horizon (no night)', () => {
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    const minElevSin = Math.sin(THREE.MathUtils.degToRad(Sky.SUN_ELEV_MIN_DEG));
+    for (let e = 0; e <= Sky.CYCLE_DURATION_S * 2; e += 0.5) {
+      Sky.update(0.5);
+      assert.ok(directional.position.y > 0, `sun above horizon at e=${e}`);
+      const dir = scene.children.find((c) => c.name === 'AtmosphericSky').material.uniforms.sunPosition.value;
+      assert.ok(dir.y >= minElevSin - 1e-9, `sun elevation >= guard at e=${e}: ${dir.y}`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  test('golden hour is warmer and dimmer than midday', () => {
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    const midday = liveState(scene, directional);
+    // Half a period from midday is golden hour (cycleProgress(45) == 0).
+    assert.ok(Sky.cycleProgress(Sky.CYCLE_DURATION_S / 2) < 1e-9, 'half-period is golden hour');
+    Sky.update(Sky.CYCLE_DURATION_S / 2);
+    const golden = liveState(scene, directional);
+
+    assert.ok(golden.dirIntensity < midday.dirIntensity, 'golden dimmer than midday');
+    assert.ok(golden.exposure < midday.exposure, 'golden lower exposure than midday');
+    const c = new THREE.Color(golden.dirColor);
+    assert.ok(c.r > c.b, 'golden sun is warm (red > blue)');
+  });
+
+  // -------------------------------------------------------------------------
+  test('golden hour does not wash the whole mountain warm (fill stays static & cool)', () => {
+    const { scene, ambient, hemisphere, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    Sky.update(Sky.CYCLE_DURATION_S / 2); // to golden hour
+    // The skylight fill that lights most of the snow is unchanged, so the mountain
+    // is not globally tinted warm — only the direct sun warms.
+    assert.strictEqual(ambient.color.getHex(), 0xffffff, 'ambient still neutral');
+    assert.strictEqual(hemisphere.color.getHex(), 0xdcebfb, 'hemi sky still cool blue');
+    assert.strictEqual(hemisphere.groundColor.getHex(), 0xbcc7d4, 'hemi ground unchanged');
+  });
+
+  // -------------------------------------------------------------------------
+  test('brightness is monotonic on each half-cycle', () => {
+    // cycleProgress p: 1 at midday → 0 at golden → 1 at midday. Directional
+    // intensity and exposure are monotonic in p, so monotonic p ⇒ monotonic light.
+    const P = Sky.CYCLE_DURATION_S;
+    let prev = Sky.cycleProgress(0);
+    for (let e = 1; e <= P / 2; e++) {
+      const cur = Sky.cycleProgress(e);
+      assert.ok(cur <= prev + 1e-12, `descending midday→golden at e=${e}: ${prev}→${cur}`);
+      prev = cur;
+    }
+    prev = Sky.cycleProgress(P / 2);
+    for (let e = P / 2 + 1; e <= P; e++) {
+      const cur = Sky.cycleProgress(e);
+      assert.ok(cur >= prev - 1e-12, `ascending golden→midday at e=${e}: ${prev}→${cur}`);
+      prev = cur;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  test('cycle is periodic', () => {
+    for (let e = 0; e <= Sky.CYCLE_DURATION_S; e += 3) {
+      const a = Sky.cycleProgress(e);
+      const b = Sky.cycleProgress(e + Sky.CYCLE_DURATION_S);
+      assert.ok(Math.abs(a - b) < 1e-12, `cycleProgress periodic at e=${e}: ${a} vs ${b}`);
+    }
+    // And the driven live state is periodic too.
+    const { scene, directional } = makeScene();
+    Sky.applyAtmosphericSky(scene, directional);
+    Sky.update(20);
+    const at20 = liveState(scene, directional);
+    Sky.update(Sky.CYCLE_DURATION_S);
+    assertStateEqual(liveState(scene, directional), at20, 'live state periodic');
+  });
+
+  console.log(`\n==================================`);
+  console.log(`SKY CYCLE TESTS: ${passed} passed, 0 failed`);
+  process.exit(0);
+})().catch((e) => {
+  console.error('❌ SKY CYCLE TESTS FAILED:', e && e.message ? e.message : e);
+  process.exit(1);
+});


### PR DESCRIPTION
Re-integrates the Tier 3 golden-hour↔midday sun cycle (#2) onto the **current `src/game/*` structure** and the **settled static snow-lighting baseline (#181)**, per the reconciled landing plan in issue #188. The original PR predated the scene-setup refactor and animated the `AmbientLight` up toward the `0.5π` whiteout value — both reasons it could not merge as-is.

## What changed vs. the old PR
- **Captures the static baseline instead of hardcoding it.** `Sky.applyAtmosphericSky(scene, directionalLight)` snapshots the merged static midday at setup (directional position/colour/intensity, Preetham `sunPosition`/`exposure`, fog/background) and treats that as the bright endpoint. **Midday and every frozen state are a bit-for-bit copy** of the snapshot — not reconstructed from trig/lerp, not the old `0.8π`/`0.5π` constants.
- **Stays in its lane (issue #188 ownership contract).** The cycle drives **only** the directional sun, sky exposure, and fog/background. It **never touches** the `HemisphereLight` (the snow's cool-shadow fill), the `AmbientLight`, snow albedo/vertex tint, or terrain — so the warm-sun / cool-shadow snow form is preserved and the mountain is never washed warm or pushed back toward the ambient whiteout.
- **Cycle model.** 90 s cosine loop, first load = static midday → low warm golden hour → back. `SUN_ELEV_MIN = 14°` low-sun guard (the `12–15°` band the plan requires while the periodic `sin(x*0.2)*cos(z*0.3)` terrain ridge survives; `8°` only after fBm/domain-warp terrain lands).
- **Wiring moved to `game/*`.** Static lights + `applyAtmosphericSky` in `game/scene-setup.ts`; `Sky.update(delta)` per active frame in `game/main-loop.ts`. Frozen at midday under `prefers-reduced-motion` and the `SUN_CYCLE_ENABLED` switch.

## Tests / gates (all green locally)
- **`npm run test:sky`** (new `tests/sky-cycle-tests.js`, 10 checks): captured-midday equality (captured, not hardcoded), reduced-motion & disabled freeze == static snapshot, HemisphereLight untouched, ambient under the static budget / never toward `0.5π`, sun above horizon, warmer/dimmer golden hour without washing the mountain warm, monotonic half-cycles, periodicity.
- `npm run typecheck` ✓ · `npm run lint` ✓ (0 errors) · full `npm test` ✓ (incl. `test:sky`) · physics-invariant harness **byte-identical** ✓ · Puppeteer browser suite **89/0** ✓.

Depends on #181 (merged) and the docs guide #192 (merged). Step 5 of the #188 plan.

## Visual review (seeded in-game captures)
The low-sun guard (`SUN_ELEV_MIN = 14°`) keeps the periodic terrain ridge from banding; midday matches the approved post-#181 static look, golden hour is warmer/dimmer with cool-blue shadows preserved (no whiteout, no grey corduroy, no muddy neutral shadows).

| Midday (static endpoint) | Golden hour (low warm sun) |
|---|---|
| ![midday](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/sun-cycle-shots/sun-cycle-midday.png) | ![golden hour](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/sun-cycle-shots/sun-cycle-golden.png) |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
