### PR TITLE
feat(lighting): hemisphere fill light for snow/rock shaping (#18)

### DIFF
--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -157,7 +157,18 @@ export function setupScene() {
   // Intensities are pre-multiplied by Math.PI to preserve the original r134
   // brightness under three.js physically-correct lighting (forced on since the
   // r165 removal of `useLegacyLights`); see the renderer setup note above.
-  scene.add(new THREE.AmbientLight(0xffffff, 0.5 * Math.PI));
+  //
+  // A HemisphereLight (issue #18) takes over most of the old flat AmbientLight as
+  // the scene fill: pale sky-blue from above, a cooler snow-bounce from below.
+  // Unlike a uniform ambient it shades by surface orientation, so the procedural
+  // snow/rock normal maps and slope shading (issue #17) actually read in the
+  // shadows instead of being washed flat. A small ambient floor remains so nothing
+  // goes pure black. The up-facing fill (ambient + hemi*sky ≈ 0.5) is held near the
+  // old 0.5*pi so directly-lit white snow doesn't clip any harder under the legacy
+  // no-tone-mapping pipeline — the change is in the *direction-dependence* and tint
+  // of the fill, not its peak brightness.
+  scene.add(new THREE.AmbientLight(0xffffff, 0.15 * Math.PI));
+  scene.add(new THREE.HemisphereLight(0xcfe2f7, 0x9aa7b6, 0.45 * Math.PI));
   const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8 * Math.PI);
   directionalLight.position.set(50, 100, 50);
   directionalLight.castShadow = true;


### PR DESCRIPTION
**Stage 3 of the mountain-visuals pass (issue #18).** Stacked on #167 (base = `feat/rock-snow-texture`).

Replaces most of the flat `AmbientLight` with a `HemisphereLight` (pale sky-blue from above, cooler snow-bounce from below) in `src/game/scene-setup.ts`.

### Why
A uniform ambient fills shadows evenly, which **washes out** the procedural snow/rock normal maps and slope shading added in #166/#167. Hemisphere fill shades by surface orientation, so that micro-relief and the slope/snow tinting actually read in shadow. This is the lighting half of the visuals work — #17 underwhelms without it.

### What changed
- `AmbientLight 0.5*pi` → `AmbientLight 0.15*pi` (a floor so nothing is pure black) **+** `HemisphereLight(0xcfe2f7 sky, 0x9aa7b6 ground, 0.45*pi)`.
- Directional sun light unchanged.

### Guardrails respected
- **Brightness-neutral by design** — the up-facing fill (`ambient + hemi*sky ≈ 0.5`) is held near the old `0.5*pi`, so directly-lit white snow doesn't clip any harder under the legacy no-tone-mapping pipeline. The change is in the *direction-dependence and tint* of the fill, not its peak.
- Intensities stay pre-multiplied by `Math.PI` (physically-correct lighting convention from the r165 `useLegacyLights` removal).
- No gameplay/physics/test-seam changes.

### Verification
- `npm run lint` clean, `npm run build` green, `test:verify` 18/18, browser **87/87, 7/7 suites**.
- No automated luminance gate exists (the e2e helpers observe game state, not pixels), so this was verified functionally; eyeball-tunable colours/intensities if the on-device look wants adjusting.

Last in the stack: trees (bark + foliage). Snowman polish stays out of scope (tracked under #162 / #53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)