### PR TITLE
feat(audio): swap background track to skullbeatz_bad_cat.mp3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 - Provide visual feedback for touch controls on mobile devices
 - Automatically detect device type to enable appropriate controls
 ## Audio Implementation (ENABLED — simplified native HTML5)
-- **Audio is enabled** via `AUDIO_ENABLED = true` in `src/audio.ts`. The current implementation is the simplified, dependency-free native HTML5 `<audio>` approach: a single background-music track (`assets/drum_loop_are_you_heaven.wav`), two state variables (`muted`, `initialized`), loaded on first play, with no visibility-change handling (the browser manages it). Howler.js and Three.js Audio were both removed.
+- **Audio is enabled** via `AUDIO_ENABLED = true` in `src/audio.ts`. The current implementation is the simplified, dependency-free native HTML5 `<audio>` approach: a single background-music track (`assets/skullbeatz_bad_cat.mp3`), two state variables (`muted`, `initialized`), loaded on first play, with no visibility-change handling (the browser manages it). Howler.js and Three.js Audio were both removed.
 - To disable: set `AUDIO_ENABLED = false` in `src/audio.ts` (all public methods early-exit).
 - The previous Howler.js API surface is kept as no-op/Promise stubs for backward compatibility (`preloadAudio`, `playPreloadedAudio`, `resumeAudioContext`, `changeTrack`, `addAudioListener`, …), so the existing callers in `index.html` keep working without change.
 - **Caveats:** the in-page audio control button CSS is still commented out in `index.html`, and while desktop and the automated suite pass, mobile playback (iOS Safari silent switch, Android Chrome) is **not yet verified on real devices** — test thoroughly there before relying on it.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:scores && npm run test:start-menu && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:scores && npm run test:start-menu && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/physics-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -21,6 +21,7 @@
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
+    "test:audio-asset": "node tests/audio-asset-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:browser": "node tests/puppeteer-runner.js",

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -15,7 +15,7 @@
 //
 // Design principles:
 // 1. Native HTML5 Audio element - no library dependencies
-// 2. Single track only (drum_loop) - no track switching complexity
+// 2. Single track only (bad_cat) - no track switching complexity
 // 3. Only 2 state variables - muted and initialized
 // 4. No pre-loading - load when user clicks play
 // 5. No visibility change handling - let browser manage it
@@ -48,7 +48,7 @@ export const AudioModule = (function() {
   let muted = false;
   let initialized = false;
 
-  const AUDIO_PATH = 'assets/drum_loop_are_you_heaven.wav';
+  const AUDIO_PATH = 'assets/skullbeatz_bad_cat.mp3';
 
   // Load mute preference from localStorage
   function loadPreferences() {
@@ -200,7 +200,7 @@ export const AudioModule = (function() {
         disabled: false,
         muted,
         playing: audio ? !audio.paused : false,
-        currentTrack: 'drum_loop'
+        currentTrack: 'bad_cat'
       };
     },
 
@@ -210,7 +210,7 @@ export const AudioModule = (function() {
 
     // Compatibility stubs for existing code. preloadAudio accepts (and ignores) a
     // track name for parity with the old Howler API surface — the boot
-    // script-loader still calls preloadAudio('drum_loop').
+    // script-loader still calls preloadAudio('bad_cat').
     preloadAudio: function(_track?: string) { return Promise.resolve(); },
     playPreloadedAudio: function() { return this.startAudio(); },
     resumeAudioContext: function() { return Promise.resolve(); },

--- a/src/boot/script-loader.ts
+++ b/src/boot/script-loader.ts
@@ -140,7 +140,7 @@ import { AudioModule } from '../audio.js';
   function preloadAudio() {
     setTimeout(() => {
       if (AudioModule && typeof AudioModule.preloadAudio === 'function') {
-        AudioModule.preloadAudio('drum_loop')
+        AudioModule.preloadAudio('bad_cat')
           .then(() => {
             console.log("Audio pre-loaded and ready for user interaction");
           })

--- a/tests/audio-asset-tests.js
+++ b/tests/audio-asset-tests.js
@@ -1,0 +1,63 @@
+// audio-asset-tests.js
+// Deterministic, dependency-free guard that the background-music asset wired into
+// src/audio.ts actually ships and is a decodable audio file. This is the headless
+// half of "is decoding/playing OK?": Node can't open an audio device or run the
+// browser media pipeline, but it CAN prove (a) the file AUDIO_PATH points at
+// exists, (b) it is real bytes (not an empty file or a ~130-byte Git-LFS pointer
+// stub), and (c) it carries a valid MP3 header — the same magic bytes a browser
+// decoder keys off. Actual audio output stays a manual/browser check
+// (tests/audio-tests.js exercises the AudioModule API surface in a real browser).
+// Run via the `test:audio-asset` npm script (`node tests/audio-asset-tests.js`).
+
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS ✅' : 'FAIL ❌'}: ${name}`);
+  if (condition) pass++; else fail++;
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// AUDIO_PATH is the single source of truth in src/audio.ts; parse it straight from
+// source so this test breaks the moment the wired path and the shipped asset diverge.
+const audioSrc = fs.readFileSync(path.join(repoRoot, 'src/audio.ts'), 'utf8');
+const match = audioSrc.match(/const AUDIO_PATH\s*=\s*['"]([^'"]+)['"]/);
+check('src/audio.ts declares an AUDIO_PATH constant', !!match);
+
+if (match) {
+  const audioPath = match[1];
+  console.log(`  AUDIO_PATH = ${audioPath}`);
+  const abs = path.join(repoRoot, audioPath);
+
+  const exists = fs.existsSync(abs);
+  check(`referenced asset exists on disk (${audioPath})`, exists);
+
+  if (exists) {
+    const buf = fs.readFileSync(abs);
+
+    // A real track is megabytes; an empty file or a ~130-byte Git-LFS pointer is not.
+    check('asset is non-trivially sized (> 64 KB of real audio)', buf.length > 64 * 1024);
+
+    // Git-LFS pointer files are small UTF-8 text starting with this header line.
+    const head = buf.slice(0, 64).toString('utf8');
+    check('asset is real bytes, not a Git-LFS pointer stub',
+      !head.startsWith('version https://git-lfs'));
+
+    // Decoder-recognisable MP3: either an ID3v2 tag ("ID3") or a raw MPEG audio
+    // frame sync (11 set bits: 0xFF then the top 3 bits of the next byte).
+    const isID3 = buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33; // "ID3"
+    const isFrameSync = buf[0] === 0xFF && (buf[1] & 0xE0) === 0xE0;
+    check('asset carries a valid MP3 header (ID3 tag or MPEG frame sync)', isID3 || isFrameSync);
+
+    // The extension must match the bytes so the browser selects the right decoder;
+    // new Audio(AUDIO_PATH) relies on the server MIME / file extension.
+    check('asset uses the .mp3 extension expected by the audio/mpeg decoder',
+      path.extname(audioPath).toLowerCase() === '.mp3');
+  }
+}
+
+console.log(`\nAUDIO ASSET TOTAL: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tests/audio-tests.js
+++ b/tests/audio-tests.js
@@ -106,9 +106,9 @@ import { AudioModule } from '../src/audio.js';
       );
       
       assert(
-        status.currentTrack === 'drum_loop',
+        status.currentTrack === 'bad_cat',
         'Current Track',
-        'Default track is drum_loop'
+        'Default track is bad_cat'
       );
     }
     
@@ -186,7 +186,7 @@ import { AudioModule } from '../src/audio.js';
       });
       
       // preloadAudio should return a promise
-      const result = AudioModule.preloadAudio('drum_loop');
+      const result = AudioModule.preloadAudio('bad_cat');
       assert(
         result instanceof Promise,
         'preloadAudio Promise',


### PR DESCRIPTION
## Summary
Replace the default drum loop with **`assets/skullbeatz_bad_cat.mp3`** for the single background-music slot in the native HTML5 audio module.

- `src/audio.ts`: point `AUDIO_PATH` at `assets/skullbeatz_bad_cat.mp3`; rename the internal track label `drum_loop` → `bad_cat` (status + comments).
- `src/boot/script-loader.ts`, `tests/audio-tests.js`: follow the relabel.
- `CLAUDE.md`: update the documented track name.

The `.mp3` was already committed in `assets/` (the repo has no `.gitattributes`, so media are plain git blobs despite the docs mentioning LFS).

## New test
Adds `tests/audio-asset-tests.js`, wired into `npm test` as `test:audio-asset` — a deterministic, dependency-free guard that the asset wired into `AUDIO_PATH` actually ships and is decodable. It parses `AUDIO_PATH` from source, then asserts the file exists, is real bytes (not an empty file or a Git-LFS pointer stub), carries a valid MP3 header (ID3 tag or MPEG frame sync), and uses the `.mp3` extension. Actual audio output stays a manual/browser check (headless Node has no audio device).

## Verification
- `test:audio-asset`: 6/6 pass
- Full `npm test`: exit 0
- `eslint`: 0 errors (pre-existing `any` warnings only) · `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)