### PR TITLE
fix(share): real social sharing — desktop platform menu + Instagram screenshot card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,18 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
   ```
 - Use the same `Authorization: Bearer $TOKEN` for other GitHub API calls (PR status, `commits/<sha>/check-runs`, comments).
 - Never echo the token into normal output, logs, or commits.
+- **Include screenshots in the PR for any user-visible / UI / visual change** (new
+  UI, layout, terrain/lighting/snowman visuals, share/result screens, etc.). Drive
+  the real app locally (vite dev server + puppeteer with `PUPPETEER_EXECUTABLE_PATH`
+  pointing at system Chrome — see [`tests/puppeteer-runner.js`](tests/puppeteer-runner.js))
+  to capture the actual rendered feature, and embed the image(s) in the PR body.
+  Show before/after when changing existing visuals.
+- **Do not commit screenshots/PNGs into the repo tree** (keep `main` text-only;
+  media uses Git LFS). Host PR screenshots off-tree and embed them by URL: push the
+  PNG(s) to a throwaway `assets/*` branch via the Git Data API (create blob →
+  tree → a parentless commit → `refs/heads/assets/<name>`), then embed
+  `https://raw.githubusercontent.com/<owner>/<repo>/assets/<name>/<file>.png`.
+  Confirm each raw URL returns HTTP 200 before relying on it in the PR body.
 
 ## Code Style Guidelines
 - **Indentation**: 2 spaces

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,44 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Social sharing — desktop platform menu + screenshot card
+- Fixes the original "Share Result" being useless for social on desktop. The
+  native Web Share API was the only path, but on macOS/desktop the OS share sheet
+  only lists system targets (AirDrop / Mail / Messages) — never social sites —
+  and Messages often opened with an empty body. The native sheet is still used on
+  mobile/touch (where it surfaces installed social apps), but desktop now gets an
+  explicit menu of web share-intent links.
+- `src/share.ts` additions:
+  - `buildShareLinks(data)` — deterministic, URL-encoded web share-intent links
+    for **X/Twitter, Facebook, LinkedIn, WhatsApp, Reddit, Telegram** (Facebook
+    and LinkedIn carry only the URL per their policy; the rest carry the brag
+    text too). `SHARE_PLATFORMS` drives the menu order/labels.
+  - `prefersNativeShare()` — true only on touch/mobile (where `navigator.share`
+    lists social apps and can file-share to Instagram), so desktop falls through
+    to the explicit menu.
+  - `shareImageFile(blob, data)` — shares a rendered run image via the native
+    file-share sheet (the only way to reach Instagram, which has no web
+    share-intent URL); returns `'unavailable'` so the caller can fall back to a
+    download. `copyShareMessage(data)` backs the explicit "Copy link" action.
+- New `src/share-card.ts` — the **screenshot + card overlay**: `captureGameFrame`
+  re-renders the live frame and reads it back as a PNG (enabled by
+  `preserveDrawingBuffer: true` on the renderer in `game/scene-setup.ts`), and
+  `composeShareCard` draws it as the background of a 1080×1350 (Instagram-portrait)
+  card with the time/branding overlaid. `buildShareCardBlob` + `downloadBlob`
+  tie it together; everything degrades to a gradient card if capture is
+  unavailable.
+- New `src/ui/share-menu.ts` — the hybrid result-screen control: a primary
+  **🔗 Share Result** button that calls the native sheet on mobile or toggles the
+  per-platform menu (social links + **📸 Save image (Instagram)** + **🔗 Copy
+  link**) on desktop. Every menu button stops `touchstart` propagation so
+  `controls.ts`'s document-level `preventDefault` can't kill its synthesized
+  click on mobile (same class of fix as #173). `course.ts` now receives the
+  `renderer`/`camera` (via `CourseModule.init`) to feed frame capture.
+- Tests: `tests/share-tests.js` extended to 54 checks (`buildShareLinks`,
+  `prefersNativeShare`, `shareImageFile`, `copyShareMessage`, `formatRunSeconds`);
+  `tests/verification/dom_smoke_test.js` updated for the menu UX (menu hidden →
+  opens on click, six platforms present, Copy link copies a stable public link).
+
 ### Intro fly-over — cinematic mountain establishing shot at game start (#51)
 - On the first real "Start Game" the camera now flies over the mountain before
   the run begins: a wide establishing shot high above the peak that sweeps down

--- a/src/course.ts
+++ b/src/course.ts
@@ -26,7 +26,8 @@
 // every edit is type-only/erasable, so esbuild (Vite) and Node's native
 // type-stripping both run it exactly as before.
 import * as THREE from 'three';
-import { buildResultShareData, shareResult } from './share.js';
+import { buildShareControls } from './ui/share-menu.js';
+import type { CaptureContext } from './share-card.js';
 
 /** Terrain sampler injected via {@link CourseModule.init}. */
 export type TerrainHeightFn = (x: number, z: number) => number;
@@ -54,6 +55,11 @@ export interface CourseInitOptions {
   scene: THREE.Scene;
   getTerrainHeight: TerrainHeightFn;
   createSnowman: CreateSnowmanFn;
+  // Optional renderer/camera so the result screen's "Save image" share can
+  // capture the live game frame (see src/share-card.ts). Omitted in headless
+  // tests, where the share card falls back to a gradient background.
+  renderer?: THREE.WebGLRenderer;
+  camera?: THREE.Camera;
 }
 
 /** Result of {@link medalFor}: which medal a finished run earned. */
@@ -101,6 +107,8 @@ export const CourseModule = (function () {
   let scene: THREE.Scene | null = null;
   let getTerrainHeight: TerrainHeightFn | null = null;
   let createSnowman: CreateSnowmanFn | null = null;
+  let renderer: THREE.WebGLRenderer | null = null;  // for share-image frame capture
+  let camera: THREE.Camera | null = null;
 
   let gateGroup: THREE.Group | null = null;        // container for all gate meshes
   let ghost: THREE.Object3D | null = null;         // ghost snowman group (or null)
@@ -379,6 +387,8 @@ export const CourseModule = (function () {
     scene = opts.scene;
     getTerrainHeight = opts.getTerrainHeight;
     createSnowman = opts.createSnowman;
+    renderer = opts.renderer ?? null;
+    camera = opts.camera ?? null;
 
     // Load persisted bests
     loadBests();
@@ -596,6 +606,7 @@ export const CourseModule = (function () {
 
     // Split table
     const table = document.createElement('div');
+    table.id = 'resultSplitTable';
     Object.assign(table.style, {
       display: 'grid', gridTemplateColumns: '1fr auto auto', gap: '4px 14px',
       fontSize: '13px', alignItems: 'center'
@@ -639,45 +650,24 @@ export const CourseModule = (function () {
     });
     panel.appendChild(table);
 
-    // Share button (native Web Share API + clipboard fallback). It is only ever
-    // built here, inside the finish result panel, so it appears solely on a valid
-    // successful finish and is cleaned up with the panel on restart.
-    panel.appendChild(buildShareButton(totalTime, isBest));
+    // Share controls (hybrid: native sheet on mobile, per-platform menu +
+    // screenshot card on desktop). Built only here, inside the finish result
+    // panel, so they appear solely on a valid successful finish and are cleaned
+    // up with the panel on restart. See src/ui/share-menu.ts.
+    panel.appendChild(buildShareControls({
+      time: totalTime,
+      isBest,
+      getCapture: getCaptureContext,
+    }));
 
     return panel;
   }
 
-  function buildShareButton(totalTime: number, isBest: boolean): HTMLButtonElement {
-    const btn = document.createElement('button');
-    btn.id = 'shareResultBtn';
-    btn.type = 'button';
-    const defaultLabel = '🔗 Share Result';
-    btn.textContent = defaultLabel;
-    Object.assign(btn.style, {
-      marginTop: '14px', width: '100%', padding: '10px 14px',
-      fontSize: '15px', fontWeight: '700', color: '#fff', cursor: 'pointer',
-      background: 'linear-gradient(90deg,#0984e3,#74b9ff)', border: 'none',
-      borderRadius: '10px', fontFamily: 'Arial, sans-serif',
-      touchAction: 'manipulation', userSelect: 'none'
-    });
-    btn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255,255,255,0.4)');
-
-    let busy = false;
-    btn.addEventListener('click', () => {
-      if (busy) return;
-      busy = true;
-      shareResult(buildResultShareData(totalTime, isBest)).then((outcome) => {
-        const label =
-          outcome === 'shared' ? '✅ Shared!' :
-          outcome === 'copied' ? '✅ Link copied!' :
-          outcome === 'unavailable' ? '⚠️ Sharing unavailable' :
-          defaultLabel; // 'cancelled' — user dismissed; restore quietly
-        if (label === defaultLabel) { busy = false; return; }
-        btn.textContent = label;
-        setTimeout(() => { btn.textContent = defaultLabel; busy = false; }, 1800);
-      }).catch(() => { busy = false; });
-    });
-    return btn;
+  /** Provide the live renderer/scene/camera for share-image capture, or null
+   *  (headless tests / pre-init) so the card uses its gradient fallback. */
+  function getCaptureContext(): CaptureContext | null {
+    if (!renderer || !scene || !camera) return null;
+    return { renderer, scene, camera };
   }
 
   return {

--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -67,7 +67,9 @@ export function setupScene() {
   // Sky background + distance fog are applied after the lights are set up
   // (see Sky.applyGradientSky below) so the gradient sky / horizon fog replace the
   // old flat `scene.background = Color(0x87CEEB)` (issue #2).
-  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  // preserveDrawingBuffer keeps the back buffer readable after a frame so the
+  // result screen's "Save image" share can capture it (src/share-card.ts).
+  const renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
   (renderer as any).outputColorSpace = THREECompat.LinearSRGBColorSpace;
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.shadowMap.enabled = true;
@@ -278,7 +280,9 @@ export function setupScene() {
       CourseModule.init({
         scene: scene,
         getTerrainHeight: Snow.getTerrainHeight,
-        createSnowman: Snowman.createSnowman
+        createSnowman: Snowman.createSnowman,
+        renderer: renderer,
+        camera: camera
       });
       console.log("Course module initialized (gates, splits, ghost)");
     } catch (e) {

--- a/src/share-card.ts
+++ b/src/share-card.ts
@@ -1,0 +1,207 @@
+// share-card.ts - Build a shareable run image: the final game frame with the
+// result (time + branding) composited on top.
+//
+// This is the "screenshot + card overlay" half of the social-sharing feature
+// (see docs/CHANGELOG.md). Instagram has no web share-intent URL, so the
+// only way to post a run there is to hand the user an image — on mobile through
+// the native file-share sheet, on desktop as a download they upload manually.
+//
+// Two steps, both defensive (they return null rather than throw, so a missing
+// canvas / WebGL context can never break the share menu):
+//   - captureGameFrame(ctx): renders one fresh frame and reads it back as a PNG
+//     data URL. Needs `preserveDrawingBuffer: true` on the renderer (set in
+//     game/scene-setup.ts) so the back buffer is still readable here.
+//   - composeShareCard(opts): draws that frame as the background of a portrait
+//     1080x1350 card (Instagram-friendly) and overlays the time/branding text.
+
+import * as THREE from 'three';
+import { formatRunSeconds } from './share.js';
+
+/** Renderer/scene/camera needed to grab the current game frame. */
+export interface CaptureContext {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.Camera;
+}
+
+/** Inputs for {@link composeShareCard}. */
+export interface ShareCardOptions {
+  /** PNG data URL of the game frame, or null to fall back to a gradient. */
+  frameDataUrl: string | null;
+  time: number;
+  isBest: boolean;
+  /** Public URL printed on the card (host shown, scheme stripped). */
+  url: string;
+}
+
+// Portrait 4:5 — the largest aspect Instagram shows in-feed without cropping.
+const CARD_W = 1080;
+const CARD_H = 1350;
+const PNG = 'image/png';
+
+/**
+ * Render one fresh frame and read the canvas back as a PNG data URL. Returns
+ * null if the renderer/canvas is missing or the read fails (e.g. a tainted or
+ * lost context), so callers degrade to a textual card.
+ */
+export function captureGameFrame(ctx: CaptureContext | null): string | null {
+  if (!ctx || !ctx.renderer || !ctx.scene || !ctx.camera) return null;
+  const canvas = ctx.renderer.domElement as HTMLCanvasElement | undefined;
+  if (!canvas || typeof canvas.toDataURL !== 'function') return null;
+  try {
+    // Re-render now so the back buffer holds the current frame regardless of
+    // whether the run loop is still drawing behind the result overlay.
+    ctx.renderer.render(ctx.scene, ctx.camera);
+    return canvas.toDataURL(PNG);
+  } catch {
+    return null;
+  }
+}
+
+/** Load an <img> from a data URL, resolving null on any failure. */
+function loadImage(src: string): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    try {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => resolve(null);
+      img.src = src;
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/** Draw `img` so it covers the whole target box, center-cropping the overflow. */
+function drawCover(
+  g: CanvasRenderingContext2D, img: HTMLImageElement,
+  dw: number, dh: number
+): void {
+  const scale = Math.max(dw / img.width, dh / img.height);
+  const w = img.width * scale;
+  const h = img.height * scale;
+  g.drawImage(img, (dw - w) / 2, (dh - h) / 2, w, h);
+}
+
+/**
+ * Compose the share card. Draws the game frame (or a gradient fallback) as the
+ * background, darkens the lower third for legibility, and overlays the time and
+ * branding. Returns a PNG Blob, or null if Canvas 2D isn't available. Never
+ * rejects.
+ */
+export async function composeShareCard(opts: ShareCardOptions): Promise<Blob | null> {
+  if (typeof document === 'undefined') return null;
+  let canvas: HTMLCanvasElement;
+  try {
+    canvas = document.createElement('canvas');
+  } catch {
+    return null;
+  }
+  canvas.width = CARD_W;
+  canvas.height = CARD_H;
+  const g = canvas.getContext('2d');
+  if (!g) return null;
+
+  // --- Background: captured frame (cover) or a sky-blue gradient fallback. ---
+  const frame = opts.frameDataUrl ? await loadImage(opts.frameDataUrl) : null;
+  if (frame && frame.width > 0 && frame.height > 0) {
+    drawCover(g, frame, CARD_W, CARD_H);
+  } else {
+    const sky = g.createLinearGradient(0, 0, 0, CARD_H);
+    sky.addColorStop(0, '#74b9ff');
+    sky.addColorStop(1, '#0984e3');
+    g.fillStyle = sky;
+    g.fillRect(0, 0, CARD_W, CARD_H);
+  }
+
+  // --- Scrims so text stays legible over any frame. ---
+  const top = g.createLinearGradient(0, 0, 0, 220);
+  top.addColorStop(0, 'rgba(8,16,32,0.72)');
+  top.addColorStop(1, 'rgba(8,16,32,0)');
+  g.fillStyle = top;
+  g.fillRect(0, 0, CARD_W, 220);
+
+  const bottom = g.createLinearGradient(0, CARD_H * 0.5, 0, CARD_H);
+  bottom.addColorStop(0, 'rgba(8,16,32,0)');
+  bottom.addColorStop(1, 'rgba(8,16,32,0.9)');
+  g.fillStyle = bottom;
+  g.fillRect(0, CARD_H * 0.5, CARD_W, CARD_H * 0.5);
+
+  // --- Text overlay. ---
+  const cx = CARD_W / 2;
+  const family = 'Arial, Helvetica, sans-serif';
+  g.textAlign = 'center';
+  g.textBaseline = 'alphabetic';
+
+  // Top brand.
+  g.fillStyle = '#ffffff';
+  g.font = `bold 60px ${family}`;
+  g.fillText('⛄ SnowGlider', cx, 110);
+
+  // Headline (best vs finish) + big time.
+  g.fillStyle = '#74b9ff';
+  g.font = `bold 54px ${family}`;
+  g.fillText(opts.isBest ? 'NEW PERSONAL BEST' : 'RUN COMPLETE', cx, CARD_H - 360);
+
+  g.fillStyle = '#ffffff';
+  g.font = `bold 200px ${family}`;
+  g.fillText(`${formatRunSeconds(opts.time)}s`, cx, CARD_H - 200);
+
+  g.font = `48px ${family}`;
+  g.fillStyle = '#dfe6e9';
+  g.fillText('Can you beat it?', cx, CARD_H - 130);
+
+  // Footer URL (host only, scheme stripped).
+  g.font = `bold 40px ${family}`;
+  g.fillStyle = '#74b9ff';
+  g.fillText(opts.url.replace(/^https?:\/\//, '').replace(/\/$/, ''), cx, CARD_H - 70);
+
+  return new Promise((resolve) => {
+    try {
+      canvas.toBlob((blob) => resolve(blob), PNG);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Convenience: capture the current frame and compose it into a share-card Blob.
+ * `ctx` may be null (e.g. in tests / before the renderer exists), in which case
+ * the card is drawn on the gradient fallback.
+ */
+export async function buildShareCardBlob(
+  ctx: CaptureContext | null,
+  time: number,
+  isBest: boolean,
+  url: string
+): Promise<Blob | null> {
+  const frameDataUrl = captureGameFrame(ctx);
+  return composeShareCard({ frameDataUrl, time, isBest, url });
+}
+
+/**
+ * Trigger a browser download of `blob`. Returns false when downloading isn't
+ * possible (no DOM / object URLs), so callers can surface a different fallback.
+ */
+export function downloadBlob(blob: Blob, filename = 'snowglider-run.png'): boolean {
+  if (typeof document === 'undefined' || typeof URL === 'undefined' ||
+      typeof URL.createObjectURL !== 'function') {
+    return false;
+  }
+  try {
+    const objectUrl = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = filename;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    // Revoke after the download has had a chance to start.
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 4000);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/share.ts
+++ b/src/share.ts
@@ -63,7 +63,12 @@ function currentHref(): string | null {
   return window.location.href;
 }
 
-function formatSeconds(time: number): string {
+/**
+ * Format a run clock to a sane 2-decimal seconds string. Exported so the share
+ * card ({@link ./share-card}) renders the exact same number as the copy here,
+ * with the same NaN/Infinity/negative guard.
+ */
+export function formatRunSeconds(time: number): string {
   // Guard against NaN/Infinity/negative clocks so the copy is always sane.
   const safe = Number.isFinite(time) && time > 0 ? time : 0;
   return safe.toFixed(2);
@@ -79,7 +84,7 @@ export function buildResultShareData(
   isNewBest: boolean,
   href?: string | null
 ): ResultShareData {
-  const seconds = formatSeconds(time);
+  const seconds = formatRunSeconds(time);
   const text = isNewBest
     ? `New SnowGlider personal best: ${seconds}s. Can you beat it?`
     : `I finished SnowGlider in ${seconds}s. Can you beat my run?`;
@@ -109,7 +114,10 @@ async function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
-function logShareEvent(method: ShareOutcome): void {
+/** How a share was attempted, for the best-effort Analytics event. */
+type ShareMethod = ShareOutcome | SharePlatform | 'image';
+
+function logShareEvent(method: ShareMethod): void {
   try {
     const fm = typeof window !== 'undefined' ? window.firebaseModules : undefined;
     if (fm && typeof fm.logEvent === 'function') {
@@ -118,6 +126,22 @@ function logShareEvent(method: ShareOutcome): void {
   } catch {
     /* Analytics is strictly best-effort; never let it break sharing. */
   }
+}
+
+/** Record that the player opened a specific platform's share intent. */
+export function logPlatformShare(platform: SharePlatform): void {
+  logShareEvent(platform);
+}
+
+/**
+ * Copy the run's "message + link" to the clipboard (the explicit "Copy link"
+ * action in the desktop menu). Resolves true on success; logs a best-effort
+ * Analytics event. Never rejects.
+ */
+export async function copyShareMessage(data: ResultShareData): Promise<boolean> {
+  const ok = await copyToClipboard(shareMessage(data));
+  if (ok) logShareEvent('copied');
+  return ok;
 }
 
 /**
@@ -144,4 +168,95 @@ export async function shareResult(data: ResultShareData): Promise<ShareOutcome> 
     return 'copied';
   }
   return 'unavailable';
+}
+
+// ---------------------------------------------------------------------------
+// Per-platform sharing (desktop). The native Web Share sheet is great on mobile
+// — it lists installed social apps — but on desktop it only surfaces OS targets
+// (AirDrop / Mail / Messages), never social sites. So on desktop we offer an
+// explicit menu of web "share intent" links instead. See docs/CHANGELOG.md.
+// ---------------------------------------------------------------------------
+
+/** A social platform we can hand off to via a public web share-intent URL. */
+export type SharePlatform = 'x' | 'facebook' | 'linkedin' | 'whatsapp' | 'reddit' | 'telegram';
+
+/** Display metadata for the desktop share menu, in presentation order. */
+export const SHARE_PLATFORMS: ReadonlyArray<{ key: SharePlatform; label: string; icon: string }> = [
+  { key: 'x', label: 'X', icon: '𝕏' },
+  { key: 'facebook', label: 'Facebook', icon: 'f' },
+  { key: 'linkedin', label: 'LinkedIn', icon: 'in' },
+  { key: 'whatsapp', label: 'WhatsApp', icon: '✆' },
+  { key: 'reddit', label: 'Reddit', icon: 'r/' },
+  { key: 'telegram', label: 'Telegram', icon: '✈' },
+];
+
+/**
+ * Build a web share-intent URL per platform for the given run. Pure and
+ * deterministic — every value is URL-encoded. Facebook and LinkedIn only accept
+ * a URL (they ignore any prefilled text per their own policy), so those carry
+ * just the link; the rest carry the brag text too.
+ */
+export function buildShareLinks(data: ResultShareData): Record<SharePlatform, string> {
+  const text = encodeURIComponent(data.text);
+  const url = encodeURIComponent(data.url);
+  const textAndUrl = encodeURIComponent(`${data.text} ${data.url}`);
+  return {
+    x: `https://twitter.com/intent/tweet?text=${text}&url=${url}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${url}`,
+    whatsapp: `https://wa.me/?text=${textAndUrl}`,
+    reddit: `https://www.reddit.com/submit?url=${url}&title=${text}`,
+    telegram: `https://t.me/share/url?url=${url}&text=${text}`,
+  };
+}
+
+/**
+ * Whether the native share sheet should be preferred over the explicit desktop
+ * menu. True only on touch / mobile devices, where `navigator.share` surfaces
+ * installed social apps (and `navigator.share({files})` can reach Instagram).
+ * On desktop the OS sheet is a dead end for social, so we return false and the
+ * caller shows the per-platform menu instead.
+ */
+export function prefersNativeShare(): boolean {
+  const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+  if (!nav || typeof nav.share !== 'function') return false;
+  const coarsePointer = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(pointer: coarse)').matches
+    : false;
+  const touch = typeof nav.maxTouchPoints === 'number' && nav.maxTouchPoints > 0;
+  // iPadOS Safari reports a "Macintosh" UA, so the touch check above catches it.
+  const mobileUA = /Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(nav.userAgent || '');
+  return coarsePointer || touch || mobileUA;
+}
+
+/**
+ * Share a rendered run image via the native file-share sheet (the only way to
+ * reach Instagram / Stories, which has no web share-intent URL). Returns
+ * 'unavailable' when file sharing isn't supported so the caller can fall back to
+ * downloading the PNG. Never rejects.
+ */
+export async function shareImageFile(
+  blob: Blob,
+  data: ResultShareData,
+  filename = 'snowglider-run.png'
+): Promise<ShareOutcome> {
+  const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+  if (!nav || typeof nav.share !== 'function' || typeof File === 'undefined') return 'unavailable';
+  let file: File;
+  try {
+    file = new File([blob], filename, { type: blob.type || 'image/png' });
+  } catch {
+    return 'unavailable';
+  }
+  // `canShare` gates files: if it exists and rejects them, native file share is
+  // unsupported here — fall back rather than throwing a TypeError on share().
+  if (typeof nav.canShare === 'function' && !nav.canShare({ files: [file] })) return 'unavailable';
+  try {
+    await nav.share({ files: [file], title: data.title, text: `${data.text} ${data.url}` });
+    logShareEvent('image');
+    return 'shared';
+  } catch (err) {
+    if (isUserCancel(err)) return 'cancelled';
+    return 'unavailable';
+  }
 }

--- a/src/ui/share-menu.ts
+++ b/src/ui/share-menu.ts
@@ -1,0 +1,199 @@
+// ui/share-menu.ts - The finish result screen's share controls.
+//
+// Hybrid by design (see docs/CHANGELOG.md): the native Web Share sheet is
+// the right thing on mobile/touch (it lists installed social apps and can reach
+// Instagram via file share), but on desktop it only surfaces OS targets and is a
+// dead end for social. So:
+//   - prefersNativeShare() (touch/mobile) -> the primary button calls the native
+//     sheet directly.
+//   - otherwise (desktop) -> the primary button toggles an explicit menu of
+//     per-platform web share-intent links, plus "Save image" (Instagram) and
+//     "Copy link".
+// The Instagram path is always image-based because Instagram has no web
+// share-intent URL: on mobile we file-share the PNG (the sheet shows Instagram /
+// Stories), on desktop we download it for the player to post manually.
+
+import {
+  buildResultShareData, shareResult, copyShareMessage, buildShareLinks,
+  SHARE_PLATFORMS, prefersNativeShare, shareImageFile, logPlatformShare,
+  type SharePlatform,
+} from '../share.js';
+import { buildShareCardBlob, downloadBlob, type CaptureContext } from '../share-card.js';
+
+/** Options for {@link buildShareControls}. */
+export interface ShareControlsOptions {
+  time: number;
+  isBest: boolean;
+  /**
+   * Supplies the renderer/scene/camera at click time so the share image can
+   * capture the live frame. Called lazily (the renderer always exists by the
+   * time the result screen is shown); may return null, in which case the card
+   * falls back to a gradient background.
+   */
+  getCapture?: () => CaptureContext | null;
+}
+
+const PRIMARY_LABEL = '🔗 Share Result';
+
+/** Stop in-overlay button taps from reaching controls.ts's document-level
+ *  touchstart handler, which preventDefaults and would kill the synthesized
+ *  click on mobile (see fix #173). */
+function defuseTouch(el: HTMLElement): void {
+  el.addEventListener('touchstart', (e) => { e.stopPropagation(); }, { passive: true });
+}
+
+function styleButton(btn: HTMLElement, primary: boolean): void {
+  Object.assign(btn.style, {
+    display: 'block', width: '100%', padding: primary ? '10px 14px' : '9px 12px',
+    fontSize: primary ? '15px' : '14px', fontWeight: '700', color: '#fff',
+    cursor: 'pointer', border: 'none', borderRadius: '10px',
+    fontFamily: 'Arial, sans-serif', touchAction: 'manipulation', userSelect: 'none',
+    background: primary
+      ? 'linear-gradient(90deg,#0984e3,#74b9ff)'
+      : 'rgba(255,255,255,0.12)',
+    marginTop: primary ? '14px' : '8px',
+  });
+  btn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255,255,255,0.4)');
+}
+
+/** Briefly swap a button's label to give feedback, then restore it. */
+function flash(btn: HTMLElement, label: string, restore: string, ms = 1800): void {
+  btn.textContent = label;
+  setTimeout(() => { btn.textContent = restore; }, ms);
+}
+
+/** Open a platform share-intent URL in a new tab (a real user-gesture click,
+ *  so it isn't popup-blocked). */
+function openIntent(url: string, platform: SharePlatform): void {
+  logPlatformShare(platform);
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
+
+function makeSocialRow(data: ReturnType<typeof buildResultShareData>): HTMLDivElement {
+  const links = buildShareLinks(data);
+  const row = document.createElement('div');
+  Object.assign(row.style, {
+    display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px', marginTop: '10px',
+  });
+  for (const { key, label, icon } of SHARE_PLATFORMS) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = `share-${key}-btn`;
+    btn.setAttribute('data-platform', key);
+    btn.title = `Share on ${label}`;
+    btn.setAttribute('aria-label', `Share on ${label}`);
+    btn.textContent = `${icon} ${label}`;
+    Object.assign(btn.style, {
+      padding: '8px 6px', fontSize: '13px', fontWeight: '700', color: '#fff',
+      cursor: 'pointer', border: 'none', borderRadius: '8px',
+      background: 'rgba(255,255,255,0.14)', fontFamily: 'Arial, sans-serif',
+      touchAction: 'manipulation', userSelect: 'none', whiteSpace: 'nowrap',
+      overflow: 'hidden', textOverflow: 'ellipsis',
+    });
+    btn.style.setProperty('-webkit-tap-highlight-color', 'rgba(255,255,255,0.4)');
+    defuseTouch(btn);
+    btn.addEventListener('click', () => openIntent(links[key], key));
+    row.appendChild(btn);
+  }
+  return row;
+}
+
+/**
+ * Build the share controls for the finish result panel: a primary "Share
+ * Result" button and (on desktop) a menu of per-platform links + image + copy.
+ * Returns a container the caller appends to the result panel.
+ */
+export function buildShareControls(opts: ShareControlsOptions): HTMLDivElement {
+  const container = document.createElement('div');
+  const data = buildResultShareData(opts.time, opts.isBest);
+
+  // --- Primary button (always present; id kept for tests/touch wiring). ---
+  const primary = document.createElement('button');
+  primary.id = 'shareResultBtn';
+  primary.type = 'button';
+  primary.textContent = PRIMARY_LABEL;
+  styleButton(primary, true);
+  defuseTouch(primary);
+
+  // --- Desktop menu (hidden until toggled). ---
+  const menu = document.createElement('div');
+  menu.id = 'shareMenu';
+  menu.style.display = 'none';
+  menu.appendChild(makeSocialRow(data));
+
+  const imageBtn = document.createElement('button');
+  imageBtn.id = 'shareImageBtn';
+  imageBtn.type = 'button';
+  const imageLabel = '📸 Save image (Instagram)';
+  imageBtn.textContent = imageLabel;
+  styleButton(imageBtn, false);
+  defuseTouch(imageBtn);
+
+  const copyBtn = document.createElement('button');
+  copyBtn.id = 'shareCopyBtn';
+  copyBtn.type = 'button';
+  const copyLabel = '🔗 Copy link';
+  copyBtn.textContent = copyLabel;
+  styleButton(copyBtn, false);
+  defuseTouch(copyBtn);
+
+  // Copy link lives in the (desktop) toggle menu next to the per-platform links.
+  menu.appendChild(copyBtn);
+
+  // --- Behaviour ---
+  let imageBusy = false;
+  async function handleImage(): Promise<void> {
+    if (imageBusy) return;
+    imageBusy = true;
+    imageBtn.textContent = '⏳ Building image…';
+    try {
+      const ctx = opts.getCapture ? opts.getCapture() : null;
+      const blob = await buildShareCardBlob(ctx, opts.time, opts.isBest, data.url);
+      if (!blob) { flash(imageBtn, '⚠️ Image unavailable', imageLabel); return; }
+      // Mobile: hand the PNG to the native sheet (reaches Instagram / Stories).
+      const outcome = prefersNativeShare() ? await shareImageFile(blob, data) : 'unavailable';
+      if (outcome === 'shared') { flash(imageBtn, '✅ Shared!', imageLabel); return; }
+      if (outcome === 'cancelled') { imageBtn.textContent = imageLabel; return; }
+      // Desktop (or no file share): download it to post manually.
+      flash(imageBtn, downloadBlob(blob) ? '✅ Image saved' : '⚠️ Image unavailable', imageLabel);
+    } finally {
+      imageBusy = false;
+    }
+  }
+  imageBtn.addEventListener('click', () => { void handleImage(); });
+
+  copyBtn.addEventListener('click', () => {
+    void copyShareMessage(data).then((ok) => {
+      flash(copyBtn, ok ? '✅ Copied!' : '⚠️ Copy failed', copyLabel);
+    });
+  });
+
+  let nativeBusy = false;
+  primary.addEventListener('click', () => {
+    if (prefersNativeShare()) {
+      // Mobile/touch: the OS sheet already lists social apps.
+      if (nativeBusy) return;
+      nativeBusy = true;
+      void shareResult(data).then((outcome) => {
+        if (outcome === 'shared') flash(primary, '✅ Shared!', PRIMARY_LABEL);
+        else if (outcome === 'copied') flash(primary, '✅ Link copied!', PRIMARY_LABEL);
+        else if (outcome === 'unavailable') flash(primary, '⚠️ Sharing unavailable', PRIMARY_LABEL);
+      }).finally(() => { nativeBusy = false; });
+      return;
+    }
+    // Desktop: reveal/hide the explicit per-platform menu.
+    const open = menu.style.display !== 'none';
+    menu.style.display = open ? 'none' : 'block';
+    primary.setAttribute('aria-expanded', String(!open));
+  });
+
+  container.appendChild(primary);
+  // The image/Instagram action stays visible on every device: it's the only way
+  // to reach the screenshot card (mobile -> native file share to Instagram /
+  // Stories; desktop -> PNG download), independent of the desktop link menu.
+  container.appendChild(imageBtn);
+  container.appendChild(menu);
+  return container;
+}

--- a/tests/share-tests.js
+++ b/tests/share-tests.js
@@ -25,7 +25,9 @@ function clearGlobal(name) {
 
 async function main() {
   const {
-    buildResultShareData, cleanShareUrl, shareMessage, shareResult
+    buildResultShareData, cleanShareUrl, shareMessage, shareResult,
+    buildShareLinks, prefersNativeShare, shareImageFile, copyShareMessage,
+    formatRunSeconds, SHARE_PLATFORMS
   } = await import('../src/share.ts');
 
   // ---- buildResultShareData: deterministic copy ----
@@ -121,6 +123,75 @@ async function main() {
   setGlobal('window', { firebaseModules: { logEvent: () => { throw new Error('analytics down'); } } });
   setGlobal('navigator', { clipboard: { writeText: async () => {} } });
   check('analytics failure does not break sharing', (await shareResult(data)) === 'copied');
+  clearGlobal('window');
+
+  // ---- formatRunSeconds: shared 2-decimal clock (also used by the share card) ----
+  console.log('\n--- formatRunSeconds ---');
+  check('formats to 2 decimals', formatRunSeconds(42.129) === '42.13');
+  check('guards NaN -> 0.00', formatRunSeconds(NaN) === '0.00');
+  check('guards negative -> 0.00', formatRunSeconds(-3) === '0.00');
+
+  // ---- buildShareLinks: per-platform web share-intent URLs ----
+  console.log('\n--- buildShareLinks ---');
+  // Pass a dirty href so the cleaned (?test stripped) url flows through the links.
+  const linkData = buildResultShareData(42.13, true, 'https://snowglider.ai/?test=unified&ref=tw');
+  const links = buildShareLinks(linkData);
+  const encUrl = encodeURIComponent('https://snowglider.ai/?ref=tw');
+  const encText = encodeURIComponent('New SnowGlider personal best: 42.13s. Can you beat it?');
+  const encTextUrl = encodeURIComponent('New SnowGlider personal best: 42.13s. Can you beat it? https://snowglider.ai/?ref=tw');
+  check('all six platforms present', Object.keys(links).length === 6 && SHARE_PLATFORMS.length === 6);
+  check('x/twitter intent carries cleaned url + text', links.x === `https://twitter.com/intent/tweet?text=${encText}&url=${encUrl}`);
+  check('facebook sharer carries only the url', links.facebook === `https://www.facebook.com/sharer/sharer.php?u=${encUrl}`);
+  check('linkedin carries only the url', links.linkedin === `https://www.linkedin.com/sharing/share-offsite/?url=${encUrl}`);
+  check('whatsapp carries text + url combined', links.whatsapp === `https://wa.me/?text=${encTextUrl}`);
+  check('reddit carries url + title', links.reddit === `https://www.reddit.com/submit?url=${encUrl}&title=${encText}`);
+  check('telegram carries url + text', links.telegram === `https://t.me/share/url?url=${encUrl}&text=${encText}`);
+  check('every intent is a valid https URL', Object.values(links).every((u) => {
+    try { return new URL(u).protocol === 'https:'; } catch { return false; }
+  }));
+
+  // ---- prefersNativeShare: native sheet only on touch/mobile ----
+  console.log('\n--- prefersNativeShare ---');
+  setGlobal('window', {});
+  setGlobal('navigator', {});
+  check('no navigator.share -> desktop menu (false)', prefersNativeShare() === false);
+  setGlobal('navigator', { share: async () => {}, userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)', maxTouchPoints: 0 });
+  check('desktop Safari (share, no touch) -> menu (false)', prefersNativeShare() === false);
+  setGlobal('navigator', { share: async () => {}, userAgent: 'Mozilla/5.0 (Macintosh)', maxTouchPoints: 5 });
+  check('touch device (maxTouchPoints>0) -> native (true)', prefersNativeShare() === true);
+  setGlobal('navigator', { share: async () => {}, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', maxTouchPoints: 0 });
+  check('mobile UA -> native (true)', prefersNativeShare() === true);
+  setGlobal('navigator', { share: async () => {}, userAgent: 'X', maxTouchPoints: 0 });
+  setGlobal('window', { matchMedia: (q) => ({ matches: q === '(pointer: coarse)' }) });
+  check('coarse pointer (matchMedia) -> native (true)', prefersNativeShare() === true);
+  clearGlobal('window');
+
+  // ---- copyShareMessage: explicit "Copy link" action ----
+  console.log('\n--- copyShareMessage ---');
+  let cm = null;
+  setGlobal('navigator', { clipboard: { writeText: async (t) => { cm = t; } } });
+  check('copyShareMessage writes the joined message + returns true',
+    (await copyShareMessage(data)) === true && cm === shareMessage(data));
+  setGlobal('navigator', {});
+  check('copyShareMessage with no clipboard returns false', (await copyShareMessage(data)) === false);
+
+  // ---- shareImageFile: native file share (the only path to Instagram) ----
+  console.log('\n--- shareImageFile ---');
+  const blob = new Blob(['fake-png'], { type: 'image/png' });
+  setGlobal('navigator', {});
+  check('no navigator.share -> image share unavailable', (await shareImageFile(blob, data)) === 'unavailable');
+  setGlobal('navigator', { share: async () => {}, canShare: () => false });
+  check('canShare rejects files -> unavailable', (await shareImageFile(blob, data)) === 'unavailable');
+  let sharedFiles = null;
+  setGlobal('navigator', { share: async (d) => { sharedFiles = d.files; }, canShare: () => true });
+  check('native file share succeeds -> shared', (await shareImageFile(blob, data)) === 'shared');
+  check('native file share receives a single File payload',
+    Array.isArray(sharedFiles) && sharedFiles.length === 1 && sharedFiles[0] instanceof File);
+  setGlobal('navigator', {
+    share: async () => { const e = new Error('cancel'); e.name = 'AbortError'; throw e; },
+    canShare: () => true
+  });
+  check('user cancels file share -> cancelled', (await shareImageFile(blob, data)) === 'cancelled');
 
   clearGlobal('navigator');
   clearGlobal('window');

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -121,21 +121,37 @@ async function main() {
   const ghostLast = ghostSaved[ghostSaved.length - 1];
   check('ghost final sample keeps real x (Gap 3, not snapped to 0)', Math.abs(ghostLast.x - 0) > 0.5 && ghostLast.z === cfg.FINISH_Z);
 
-  // Social sharing (CHANGELOG #157): the "Share Result" button is built
-  // only inside the finish result panel, so it appears solely on a valid finish.
+  // Social sharing (see docs/CHANGELOG.md): the result panel hosts a hybrid share
+  // control built only inside the finish result panel, so it appears solely on a
+  // valid finish. On desktop (no navigator.share under jsdom) the primary button
+  // toggles a menu of per-platform links + "Save image" + "Copy link".
   const shareBtn1 = panel1.querySelector('#shareResultBtn');
   check('finish result panel includes a Share button', !!shareBtn1);
   check('Share button is labelled "Share Result"', /Share Result/.test(shareBtn1 ? shareBtn1.textContent : ''));
 
-  // Clicking it uses the clipboard fallback (no navigator.share under jsdom) and
-  // reflects the outcome in the label. Install a clipboard spy via defineProperty
-  // because Node exposes a getter-only `navigator` global.
+  const shareMenu1 = panel1.querySelector('#shareMenu');
+  check('share menu is present but hidden until toggled', !!shareMenu1 && shareMenu1.style.display === 'none');
+  check('share menu lists all six social platforms',
+    shareMenu1 ? shareMenu1.querySelectorAll('[data-platform]').length === 6 : false);
+  check('share menu includes the Copy-link action', !!(shareMenu1 && shareMenu1.querySelector('#shareCopyBtn')));
+  // The Save-image (Instagram) action stays visible on every device, so it is a
+  // panel-level sibling of the toggle menu rather than inside it.
+  check('Save-image (Instagram) action is always visible', !!panel1.querySelector('#shareImageBtn'));
+
+  // Desktop: clicking the primary button reveals the explicit menu (jsdom has no
+  // navigator.share, so prefersNativeShare() is false and we don't open a sheet).
+  shareBtn1.click();
+  check('clicking Share Result opens the menu on desktop', shareMenu1.style.display === 'block');
+
+  // "Copy link" uses the clipboard fallback. Install a clipboard spy via
+  // defineProperty because Node exposes a getter-only `navigator` global.
   let clipboardText = null;
   Object.defineProperty(global, 'navigator', {
     value: { clipboard: { writeText: async (txt) => { clipboardText = txt; } } },
     configurable: true, writable: true
   });
-  shareBtn1.click();
+  const copyBtn1 = shareMenu1.querySelector('#shareCopyBtn');
+  copyBtn1.click();
   await new Promise((r) => setTimeout(r, 0));
   // The clipboard fallback writes "<message>\n<url>"; validate the URL line by
   // parsing it and checking the parsed origin (a substring/`includes` host check
@@ -149,8 +165,8 @@ async function main() {
       copiedToPublicSite = false;
     }
   }
-  check('clicking Share copies a stable public link', copiedToPublicSite);
-  check('Share button reflects the copied state', /copied/i.test(shareBtn1.textContent || ''));
+  check('Copy link copies a stable public link', copiedToPublicSite);
+  check('Copy link reflects the copied state', /copied/i.test(copyBtn1.textContent || ''));
   delete global.navigator;
 
   // Second run, faster: should read as a new record and a ghost should now exist + interpolate.
@@ -169,11 +185,11 @@ async function main() {
 
   // Gap 2 regression: after a personal best, reset() must reload bestSplits, so the
   // second run's result table shows real per-split deltas instead of the "—" placeholder.
-  // (Scope the check to the split table — the "X — new personal best!" line legitimately
-  // uses an em dash as a separator, so checking the whole panel would false-positive.
-  // The split table sits immediately before the Share button, which is appended last.)
+  // (Scope the check to the split table by id — the "X — new personal best!" line
+  // legitimately uses an em dash as a separator, so checking the whole panel would
+  // false-positive.)
   const EM_DASH = String.fromCharCode(0x2014);
-  const deltaTable = panel2.querySelector('#shareResultBtn').previousElementSibling;
+  const deltaTable = panel2.querySelector('#resultSplitTable');
   check('best-split deltas not stale after PB (Gap 2)',
     !!deltaTable && deltaTable.textContent.indexOf(EM_DASH) === -1);
 


### PR DESCRIPTION
## What & why

The finish screen's **Share Result** used only the native Web Share API. On macOS/desktop that opens the OS share sheet, which only lists system targets (AirDrop / Mail / Messages) — **never social sites** — and Messages often opened with an empty body (the issue reported against #157). This makes social sharing actually work.

**Hybrid approach** (matches how the platforms behave):
- **Mobile / touch** → keeps the native sheet (it *does* list installed social apps, and can file-share to Instagram).
- **Desktop** → an explicit menu of web *share-intent* links: **X/Twitter, Facebook, LinkedIn, WhatsApp, Reddit, Telegram** + **Copy link**.
- **Every device** → a **📸 Save image (Instagram)** action that composes a screenshot card (the live game frame + time/branding overlay): native file-share to Instagram/Stories on mobile, PNG download on desktop. (Instagram has no web share-intent URL, so an image is the only way in.)

## How it looks (local testing)

Desktop result screen with the share menu open:

![share menu](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/social-sharing-shots/share-menu.png)

The generated Instagram share card (real game frame + overlay):

<img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/social-sharing-shots/share-card.png" width="320">

## Changes
- `src/share.ts` — `buildShareLinks`, `prefersNativeShare`, `shareImageFile`, `copyShareMessage`, exported `formatRunSeconds`.
- `src/share-card.ts` *(new)* — `captureGameFrame` (re-render + readback; renderer now `preserveDrawingBuffer:true`) and `composeShareCard` (1080×1350 card), `buildShareCardBlob`, `downloadBlob`.
- `src/ui/share-menu.ts` *(new)* — the hybrid control; every button stops `touchstart` propagation so controls.ts can't kill the tap on mobile (cf. #173).
- `src/game/scene-setup.ts` / `src/course.ts` — pass renderer+camera into `CourseModule.init`; stable `#resultSplitTable` id.

## Tests
- `tests/share-tests.js` → **54** checks (links, native-share detection, image file-share, copy, formatting).
- `tests/verification/dom_smoke_test.js` updated for the menu UX (hidden → opens on click, six platforms, Copy link copies a stable public link).
- Green locally: `tsc` 0, `eslint` 0 errors, full Node suite, Vite build, **browser suite 89/89 (7/7 suites)**.

## Caveats
- Native file-share → Instagram isn't verified on a physical device (logic is unit-tested with stubs).
- `preserveDrawingBuffer:true` is a small always-on cost; the browser suite shows no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)