### PR TITLE
test(share): cover share-card + share-menu to restore >90% coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/physics-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -25,6 +25,8 @@
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
+    "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",
+    "test:share-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-menu-tests.js",
     "test:audio-asset": "node tests/audio-asset-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",

--- a/tests/share-card-tests.js
+++ b/tests/share-card-tests.js
@@ -1,0 +1,149 @@
+// share-card-tests.js
+// Headless, c8-instrumented coverage for src/share-card.ts — frame capture +
+// Instagram share-card compositing + download.
+//
+// The browser suites render the game but never click "Save image", so the capture /
+// Canvas2D / download paths sit uncovered on Codecov. jsdom has no 2D canvas context
+// (the native `canvas` pkg isn't installed), so we install small global stubs for
+// document / Image / URL and a fake CanvasRenderingContext2D, then drive every branch
+// and assert the control flow + the canvas calls it makes. Run via the
+// register-ts-resolve loader so the module's `./share.js` import resolves to `.ts`.
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS ✅' : 'FAIL ❌'}: ${name}`);
+  condition ? pass++ : fail++;
+}
+function setGlobal(name, value) {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+function clearGlobal(name) {
+  if (Object.prototype.hasOwnProperty.call(globalThis, name)) delete globalThis[name];
+}
+
+// A fake 2D context that records what the card drew.
+function makeCtx2d(calls) {
+  return {
+    set fillStyle(_) {}, set font(_) {}, set textAlign(_) {}, set textBaseline(_) {},
+    createLinearGradient() { calls.gradients++; return { addColorStop() {} }; },
+    fillRect() { calls.fillRect++; },
+    fillText(t) { calls.texts.push(t); },
+    drawImage() { calls.drawImage++; },
+  };
+}
+
+// Install document/Image/URL stubs. opts toggles the failure branches.
+function installDom(opts = {}) {
+  const calls = { gradients: 0, fillRect: 0, drawImage: 0, texts: [], clicked: 0, revoked: 0, removed: 0 };
+  const anchor = { click() { calls.clicked++; } };
+  const canvas = {
+    width: 0, height: 0,
+    getContext: () => (opts.noCtx ? null : makeCtx2d(calls)),
+    toBlob: (cb) => {
+      if (opts.toBlobThrows) throw new Error('toBlob boom');
+      cb(opts.nullBlob ? null : { type: 'image/png', size: 1 });
+    },
+  };
+  setGlobal('document', {
+    createElement: (tag) => (tag === 'canvas' ? canvas : tag === 'a' ? anchor : {}),
+    body: { appendChild() {}, removeChild() { calls.removed++; } },
+  });
+  // Image: onload fires asynchronously with a non-zero size (or onerror).
+  setGlobal('Image', class {
+    set src(_v) {
+      setTimeout(() => {
+        if (opts.imgError) { if (this.onerror) this.onerror(); }
+        else { this.width = opts.imgW ?? 1200; this.height = opts.imgH ?? 800; if (this.onload) this.onload(); }
+      }, 0);
+    }
+  });
+  setGlobal('URL', opts.noObjectUrl ? {} : {
+    createObjectURL: () => 'blob:fake', revokeObjectURL: () => { calls.revoked++; },
+  });
+  return { calls, anchor, canvas };
+}
+
+async function main() {
+  const {
+    captureGameFrame, composeShareCard, buildShareCardBlob, downloadBlob
+  } = await import('../src/share-card.ts');
+
+  // ---- captureGameFrame ----
+  console.log('--- captureGameFrame ---');
+  check('null ctx -> null', captureGameFrame(null) === null);
+  check('missing renderer fields -> null', captureGameFrame({ renderer: {}, scene: {}, camera: {} }) === null);
+  let rendered = 0;
+  const okCtx = {
+    renderer: { render() { rendered++; }, domElement: { toDataURL: () => 'data:image/png;base64,AAAA' } },
+    scene: {}, camera: {},
+  };
+  check('happy path renders a fresh frame + returns the PNG data URL',
+    captureGameFrame(okCtx) === 'data:image/png;base64,AAAA' && rendered === 1);
+  const throwCtx = {
+    renderer: { render() {}, domElement: { toDataURL: () => { throw new Error('context lost'); } } },
+    scene: {}, camera: {},
+  };
+  check('toDataURL throwing -> null (never throws)', captureGameFrame(throwCtx) === null);
+
+  // ---- composeShareCard ----
+  console.log('\n--- composeShareCard ---');
+  clearGlobal('document');
+  check('no document -> null', (await composeShareCard({ frameDataUrl: null, time: 1, isBest: false, url: 'https://x/' })) === null);
+
+  installDom({ noCtx: true });
+  check('no 2d context -> null', (await composeShareCard({ frameDataUrl: null, time: 1, isBest: false, url: 'https://x/' })) === null);
+
+  let dom = installDom();
+  const best = await composeShareCard({ frameDataUrl: null, time: 42.13, isBest: true, url: 'https://snowglider.ai/' });
+  check('no-frame (gradient) card -> blob', !!best);
+  check('gradient fallback is drawn (no captured image)', dom.calls.drawImage === 0 && dom.calls.gradients >= 1);
+  check('best card shows the NEW PERSONAL BEST headline', dom.calls.texts.some((t) => /NEW PERSONAL BEST/.test(t)));
+  check('card shows the formatted time + brand + host',
+    dom.calls.texts.includes('42.13s') &&
+    dom.calls.texts.some((t) => /SnowGlider/.test(t)) &&
+    dom.calls.texts.includes('snowglider.ai'));
+
+  dom = installDom();
+  const fromFrame = await composeShareCard({ frameDataUrl: 'data:image/png;base64,AAAA', time: 10, isBest: false, url: 'https://snowglider.ai/' });
+  check('captured-frame card -> blob', !!fromFrame);
+  check('captured frame is drawn as the cover background', dom.calls.drawImage === 1);
+  check('non-best card shows the RUN COMPLETE headline', dom.calls.texts.some((t) => /RUN COMPLETE/.test(t)));
+  check('time guard renders 10.00s', dom.calls.texts.includes('10.00s'));
+
+  // A frame that fails to load falls back to the gradient.
+  dom = installDom({ imgError: true });
+  const frameFailed = await composeShareCard({ frameDataUrl: 'data:bad', time: 5, isBest: false, url: 'https://snowglider.ai/' });
+  check('un-loadable frame falls back to gradient -> still a blob', !!frameFailed && dom.calls.drawImage === 0);
+
+  installDom({ nullBlob: true });
+  check('toBlob yielding null -> null', (await composeShareCard({ frameDataUrl: null, time: 1, isBest: false, url: 'https://x/' })) === null);
+
+  installDom({ toBlobThrows: true });
+  check('toBlob throwing -> null (never throws)', (await composeShareCard({ frameDataUrl: null, time: 1, isBest: false, url: 'https://x/' })) === null);
+
+  // ---- buildShareCardBlob ----
+  console.log('\n--- buildShareCardBlob ---');
+  installDom();
+  check('null ctx -> composes a gradient card blob', !!(await buildShareCardBlob(null, 5, false, 'https://snowglider.ai/')));
+  check('live ctx -> captures the frame then composes', !!(await buildShareCardBlob(okCtx, 5, true, 'https://snowglider.ai/')));
+
+  // ---- downloadBlob ----
+  console.log('\n--- downloadBlob ---');
+  dom = installDom();
+  check('downloadBlob -> true and clicks an anchor', downloadBlob({ type: 'image/png' }, 'run.png') === true && dom.calls.clicked === 1);
+  check('downloadBlob removes the temp anchor', dom.calls.removed === 1);
+  installDom({ noObjectUrl: true });
+  check('no URL.createObjectURL -> false', downloadBlob({ type: 'image/png' }) === false);
+  clearGlobal('document');
+  check('no document -> false', downloadBlob({ type: 'image/png' }) === false);
+
+  clearGlobal('document'); clearGlobal('Image'); clearGlobal('URL');
+  console.log(`\nSHARE-CARD TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Share-card test harness crashed:', err);
+  process.exit(1);
+});

--- a/tests/share-menu-tests.js
+++ b/tests/share-menu-tests.js
@@ -1,0 +1,147 @@
+// share-menu-tests.js
+// Headless, c8-instrumented coverage for src/ui/share-menu.ts — the finish-screen
+// share control. dom_smoke builds the menu and clicks the desktop primary + copy, but
+// never clicks the per-platform links, the "Save image" button, or the mobile
+// native-share path, so those handlers sit uncovered on Codecov. We build the control
+// under jsdom and click every action, stubbing the share/clipboard/canvas/URL seams.
+// Run via the register-ts-resolve loader so `../share.js`/`../share-card.js` resolve.
+
+'use strict';
+
+const { JSDOM } = require('jsdom');
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  condition ? pass++ : fail++;
+}
+const tick = () => new Promise((r) => setTimeout(r, 10));
+
+const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://snowglider.ai/' });
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+global.File = window.File || global.File;
+
+// Give jsdom canvases a working (fake) 2D context + toBlob so composeShareCard
+// returns a blob (jsdom has no real canvas backend).
+window.HTMLCanvasElement.prototype.getContext = function () {
+  return {
+    set fillStyle(_) {}, set font(_) {}, set textAlign(_) {}, set textBaseline(_) {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillRect() {}, fillText() {}, drawImage() {},
+  };
+};
+window.HTMLCanvasElement.prototype.toBlob = function (cb) { cb({ type: 'image/png', size: 1 }); };
+
+// Replace navigator for a scenario. prefersNativeShare()/shareResult()/shareImageFile()
+// read the global navigator; jsdom's is read-only, so swap the whole global.
+function setNavigator(nav) {
+  Object.defineProperty(global, 'navigator', { value: nav, configurable: true, writable: true });
+}
+// Window.open + URL.createObjectURL stubs (downloadBlob + openIntent).
+const opened = [];
+window.open = (url) => { opened.push(url); return null; };
+global.URL.createObjectURL = () => 'blob:fake';
+global.URL.revokeObjectURL = () => {};
+
+async function main() {
+  const { buildShareControls } = await import('../src/ui/share-menu.ts');
+
+  function mount(opts) {
+    document.body.innerHTML = '';
+    const el = buildShareControls(opts);
+    document.body.appendChild(el);
+    return el;
+  }
+
+  // ---- Desktop: primary toggles the menu (no native share available). ----
+  console.log('--- desktop menu toggle ---');
+  setNavigator({});
+  let root = mount({ time: 42.13, isBest: true });
+  const primary = root.querySelector('#shareResultBtn');
+  const menu = root.querySelector('#shareMenu');
+  check('menu starts hidden', menu.style.display === 'none');
+  primary.click();
+  check('primary opens the menu on desktop', menu.style.display === 'block');
+  check('primary marks itself expanded', primary.getAttribute('aria-expanded') === 'true');
+  primary.click();
+  check('primary closes the menu again', menu.style.display === 'none');
+
+  // ---- Per-platform links open the right share-intent URL. ----
+  console.log('\n--- per-platform links ---');
+  opened.length = 0;
+  root.querySelector('#share-x-btn').click();
+  root.querySelector('#share-facebook-btn').click();
+  root.querySelector('#share-telegram-btn').click();
+  check('X link opens a twitter intent', opened.some((u) => /twitter\.com\/intent\/tweet/.test(u)));
+  check('Facebook link opens the sharer', opened.some((u) => /facebook\.com\/sharer/.test(u)));
+  check('Telegram link opens t.me/share', opened.some((u) => /t\.me\/share\/url/.test(u)));
+  check('every opened link is the public snowglider url', opened.every((u) => /snowglider\.ai/.test(decodeURIComponent(u))));
+
+  // ---- Copy link ----
+  console.log('\n--- copy link ---');
+  let copied = null;
+  setNavigator({ clipboard: { writeText: async (t) => { copied = t; } } });
+  const copyBtn = root.querySelector('#shareCopyBtn');
+  copyBtn.click();
+  await tick();
+  check('copy writes the message to the clipboard', typeof copied === 'string' && /snowglider\.ai/.test(copied));
+  check('copy button reflects the copied state', /copied/i.test(copyBtn.textContent));
+
+  // ---- Save image, desktop: composes a card then downloads it. ----
+  console.log('\n--- save image (desktop download) ---');
+  setNavigator({}); // no navigator.share -> prefersNativeShare() false -> download
+  root = mount({ time: 30, isBest: false, getCapture: () => null });
+  const imageBtn = root.querySelector('#shareImageBtn');
+  imageBtn.click();
+  await tick();
+  check('desktop save-image downloads the card', /image saved/i.test(imageBtn.textContent));
+
+  // ---- Save image, mobile: file-shares the card to the native sheet. ----
+  console.log('\n--- save image (mobile file share) ---');
+  let sharedFiles = null;
+  setNavigator({
+    share: async (d) => { sharedFiles = d.files; },
+    canShare: () => true,
+    maxTouchPoints: 5,
+    userAgent: 'iPhone',
+  });
+  root = mount({ time: 30, isBest: false, getCapture: () => null });
+  const imageBtn2 = root.querySelector('#shareImageBtn');
+  imageBtn2.click();
+  await tick();
+  check('mobile save-image file-shares the PNG', Array.isArray(sharedFiles) && sharedFiles.length === 1);
+  check('mobile save-image reflects the shared state', /shared/i.test(imageBtn2.textContent));
+
+  // ---- Save image, no canvas context -> "unavailable". ----
+  console.log('\n--- save image (no card) ---');
+  const realGetContext = window.HTMLCanvasElement.prototype.getContext;
+  window.HTMLCanvasElement.prototype.getContext = function () { return null; };
+  setNavigator({});
+  root = mount({ time: 30, isBest: false, getCapture: () => null });
+  const imageBtn3 = root.querySelector('#shareImageBtn');
+  imageBtn3.click();
+  await tick();
+  check('save-image with no card -> unavailable', /unavailable/i.test(imageBtn3.textContent));
+  window.HTMLCanvasElement.prototype.getContext = realGetContext;
+
+  // ---- Mobile primary: native share sheet. ----
+  console.log('\n--- mobile primary native share ---');
+  let nativeShared = null;
+  setNavigator({ share: async (d) => { nativeShared = d; }, maxTouchPoints: 5, userAgent: 'iPhone' });
+  root = mount({ time: 42.13, isBest: true });
+  root.querySelector('#shareResultBtn').click();
+  await tick();
+  check('mobile primary calls the native share sheet', !!nativeShared && /snowglider\.ai/.test(nativeShared.url));
+  check('mobile primary reflects the shared state', /shared/i.test(root.querySelector('#shareResultBtn').textContent));
+
+  console.log(`\nSHARE-MENU TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Share-menu test harness crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

#177 shipped `src/share-card.ts` (Canvas2D + WebGL frame capture) and the interactive handlers in `src/ui/share-menu.ts`, but nothing called them: the Node suite never exercised them and the browser suite never clicks **Save image** / the per-platform links. So `share-card.ts` landed at **~35%** on Codecov and dragged the project to *barely* above the 90% gate set by #176.

## What

Two focused, c8-instrumented Node tests (stub the canvas / `Image` / `URL` / share seams — no native `canvas` backend needed):

- **`tests/share-card-tests.js`** (23 checks) — `captureGameFrame` guards + happy path, `composeShareCard` gradient/frame/null-blob/throw branches, `drawCover`, `buildShareCardBlob`, `downloadBlob`.
- **`tests/share-menu-tests.js`** (16 checks, jsdom) — menu toggle, per-platform intent links, copy, Save-image download (desktop) / file-share (mobile) / unavailable, and the mobile native-share primary.

Wired into `npm test` (`test:share-card`, `test:share-menu`).

## Coverage (Node flag)

| file | before | after |
|---|---|---|
| `src/share-card.ts` | 34.78% | **97.1%** |
| `src/ui/share-menu.ts` | 83.41% | **98.99%** |
| `src/share.ts` | — | 98.47% |

Tests-only + `package.json`, so the `patch` diff carries no coverable `src/` lines and the project floor goes back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
