### PR TITLE
feat(snowman): make the flex layer actually visible (issue #53)

### DIFF
--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -34,19 +34,22 @@ interface FlexState { t: number; settle: number; settleVel: number; leanZ: numbe
 const finite = (n: number): number => (Number.isFinite(n) ? n : 0);
 const clamp = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, n));
 
-// --- tuning (all small + clamped, so the snowman reads as alive but never breaks) ---
+// --- tuning (clamped, so the snowman reads as clearly alive but never breaks) ---
+// Amplitudes are sized to be visible at the follow-cam distance: the earlier values
+// (~1.5% squash / 0.05u bob) rounded to nothing on screen (issue #53 follow-up).
 const BREATHE_FREQ = 6.0;       // rad/s of the squash-stretch wobble
-const BREATHE_BASE = 0.015;     // idle squash amplitude (1.5%)
-const BREATHE_SPEED = 0.020;    // extra amplitude at full speed
-const BREATHE_AIR = 0.008;      // quieter breathing while airborne
+const BREATHE_BASE = 0.04;      // idle squash amplitude (4%)
+const BREATHE_SPEED = 0.06;     // extra amplitude at full speed (=> ~10% squashing fast)
+const BREATHE_AIR = 0.02;       // quieter breathing while airborne
 const SPEED_REF = 18;           // speed at which the "fast" terms saturate
 const SETTLE_K = 50;            // landing-spring stiffness
 const SETTLE_C = 12;            // landing-spring damping
-const SETTLE_CLAMP = 0.25;      // max squash from a landing
+const SETTLE_CLAMP = 0.30;      // max squash from a landing
 const BOB_FREQ = 5.0;           // head bob rad/s
-const BOB_AMP = 0.05;           // head bob world units
-const LAG_TARGET = 0.12;        // how far the head trails into a turn (rad)
-const LEAN_TARGET = 0.16;       // carve lean of the head cluster (rad)
+const BOB_AMP = 0.16;           // head bob world units
+const LAG_TARGET = 0.20;        // how far the head trails into a turn (rad)
+const LEAN_TARGET = 0.28;       // carve lean of the head cluster (rad)
+const LEAN_GLIDE = 0.5;         // fraction of the lean kept when not actively carving
 
 const BALLS: ReadonlyArray<string> = ['bottom', 'middle', 'head'];
 const BALL_PHASE: ReadonlyArray<number> = [0, 1.1, 2.2]; // stagger so the stack ripples
@@ -85,7 +88,7 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
 
   // Landing settle: a downward squash impulse that springs back to neutral.
   if (m.justLanded && finite(m.landingForce) > 0.25) {
-    fs.settleVel -= clamp(finite(m.landingForce) * 0.9, 0, 1.2);
+    fs.settleVel -= clamp(finite(m.landingForce) * 1.4, 0, 1.8);
   }
   fs.settleVel += (-SETTLE_K * fs.settle - SETTLE_C * fs.settleVel) * dt;
   fs.settle += fs.settleVel * dt;
@@ -110,16 +113,19 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
     hg.position.set(hb.position.x, hb.position.y + clamp(bob, -0.3, 0.3), hb.position.z);
 
     const targetLag = -turn * LAG_TARGET;
+    // Lean into every turn (the most readable cue), just deeper when actively carving.
+    // The old hard gate left the lean at 0 for the default `glide`/`snowplow` techniques,
+    // i.e. most of normal play, so it was never seen.
     const carving = !air && (m.technique === 'carve' || m.technique === 'parallel' || m.technique === 'skid');
-    const targetLean = carving ? -turn * LEAN_TARGET : 0;
+    const targetLean = air ? 0 : -turn * LEAN_TARGET * (carving ? 1 : LEAN_GLIDE);
     fs.lagY += (targetLag - fs.lagY) * clamp(dt * 6, 0, 1);
     fs.leanZ += (targetLean - fs.leanZ) * clamp(dt * 5, 0, 1);
     fs.lagY = finite(fs.lagY); fs.leanZ = finite(fs.leanZ);
 
     hg.rotation.set(
       hb.rotation.x + clamp(fs.settle * 0.25, -0.1, 0.1),
-      hb.rotation.y + clamp(fs.lagY, -0.2, 0.2),
-      hb.rotation.z + clamp(fs.leanZ, -0.22, 0.22)
+      hb.rotation.y + clamp(fs.lagY, -0.28, 0.28),
+      hb.rotation.z + clamp(fs.leanZ, -0.34, 0.34)
     );
   }
 


### PR DESCRIPTION
## What & why

PR #170 added the cosmetic "flexible / wiggly snowman" layer (issue #53), but **the effect was never observable in-game**. I traced it end-to-end and ran it live in a headless browser: the layer *is* wired correctly and runs every frame on the real snowman — its amplitudes were simply tuned far below the visible threshold at the follow-cam distance.

Measured live (active skiing + hard turning) **before** this PR:

| Effect | Live peak | Visible? |
|---|---|---|
| Ball squash / breathing | ~1.6% | no |
| Head bob | ±0.027 units | no |
| Head **carve-lean** | **0.00°** (never fired) | no |
| Head turn-lag | ±6.2° | barely |

Two root causes: (1) the breathe/bob/lean constants were ~3–4× too small, and (2) the carve-lean was **hard-gated** behind `technique ∈ {carve, parallel, skid}`, so during the default `glide`/`snowplow` of normal play it stayed at exactly 0°.

> Note for users: the layer also fully disables under OS **Reduce Motion** (by design) — worth knowing if it still looks rigid for someone.

## Changes (`src/snowman-flex.ts` only)

- breathe `1.5%/2%` → `4%/6%` (≈10% squash at speed); air `0.8%` → `2%`
- head bob `0.05` → `0.16`u; turn-lag `0.12` → `0.20` rad; carve-lean `0.16` → `0.28` rad
- **lean into every turn** (0.5× when not actively carving) instead of 0 outside the carve set
- landing impulse `×0.9` → `×1.4`, settle clamp `0.25` → `0.30` for a real impact dip
- widen the head-rotation safety clamps to match the larger targets

All amplitudes stay clamped + volume-conserving. **The physics kernel (`updateSnowman`) is untouched**, so the frozen snowman baseline stays byte-identical (no baseline regen).

## Verification

- `tests/snowman-flex-tests.js` — **7/7** (bounded/finite/NaN-safe/reset/reduced-motion all still hold)
- `npm run test:verify` — **36/36** (physics-invariant + DOM smoke, incl. the flex-registry smoke checks)
- `npm run lint` — 0 errors
- Live headless probe re-confirmed the new in-game deltas.

## Confirming screenshots

Real model + real `Flex` math, close camera, driven to each extreme. Carve-lean now reaches **±16°**, breathing **110%↔90%**, landing **91%** — vs. the rigid neutral reference:

![snowman flex comparison](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/snowman-flex-shots/snowman-flex-comparison.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)