### PR TITLE
Reduce avalanche-proximity camera shake for better control

### DIFF
--- a/src/effects.ts
+++ b/src/effects.ts
@@ -160,8 +160,11 @@ export const EffectsModule = (function () {
     ui.meterLabelR.textContent = `${Math.max(0, distance).toFixed(0)} m behind`;
 
     // Vignette and shake scale with danger; only really bite when close.
+    // Keep the proximity shake subtle: enough to feel the threat from behind,
+    // but low enough that it doesn't fight the player's steering. The vignette
+    // and danger meter carry most of the telegraphing.
     ui.vignette.style.opacity = (danger * 0.9).toFixed(2);
-    proximityShake = reduceMotion ? 0 : danger * danger * 0.6;
+    proximityShake = reduceMotion ? 0 : danger * danger * 0.25;
 
     // Pulse the banner copy when it's almost on top of you.
     ui.banner.textContent = distance < WARN_NEAR + 6


### PR DESCRIPTION
## Problem

When an avalanche bears down from behind, the sustained per-frame camera shake in `effects.ts` ramps up with proximity. It was strong enough that it became **hard to control the skiing** — the shaking camera fought the player's steering right when precision matters most.

## Change

Cut the peak proximity-shake intensity in `src/effects.ts`:

```ts
proximityShake = reduceMotion ? 0 : danger * danger * 0.25;  // was 0.6
```

That's roughly a 60% reduction in the worst-case jitter (max camera offset drops from ~±0.3 to ~±0.125 in x/y).

## What's preserved

- The avalanche stays well telegraphed: the **red vignette**, the **⚠ AVALANCHE** banner, and the **"N m behind" danger meter** are all unchanged.
- The `danger²` curve still keeps shake near zero until the slide is right on top of you.
- The one-off landing-impulse shake (`addShake`) is untouched.
- `prefers-reduced-motion` users still get zero shake.

## Testing

- `npm run lint` — 0 errors (pre-existing `any` warnings only)
- `npm run test:verify` — 36/36 smoke tests pass (includes the `tickCamera` / `updateAvalanche` checks; no test pins the shake magnitude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)