### PR TITLE
Expose ski techniques, fix snowplow wedge direction, and speed up skiing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ SnowGlider is a Three.js-based skiing game featuring a snowman gliding down a pr
 - **V**: Toggle camera view
 - **Reset Button**: Start a new run
 
+### Ski Techniques
+Steering isn't just turning — how you work the edges changes your speed (see [`PHYSICS.md`](docs/PHYSICS.md) §3 for the model):
+- **Carve**: hold a steady turn (←/→ in one direction) to keep your speed through the arc.
+- **Parallel turn**: stay committed to the carve — the skis lock together and the turn becomes almost free (the mastery tier above a carve).
+- **Snowplow / "pizza"**: hold Brake (↓/S) to wedge the **ski tips together** (tails apart) and scrub speed or stop.
+- **Tuck**: hold Accelerate (↑/W) with no steering to straight-line for maximum speed.
+- **Hop turn**: Jump (Space) **while** steering (←/→) for a quick edge-set pivot on tight, steep terrain.
+
 ### Touch Controls (Mobile)
 - **Left Side of Screen**: Turn left
 - **Right Side of Screen**: Turn right

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,27 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   Node (12), browser-avalanche (19) and full browser (89) suites stay green. See
   [`PHYSICS.md`](PHYSICS.md) §7.5.
 
+### Ski techniques in the UI + snowplow wedge fix + slightly faster skiing
+- **Techniques exposed.** The skill layer (carve, parallel turn, snowplow/pizza,
+  tuck, hop turn) existed in the physics but was never explained to the player. A
+  new **"Ski Techniques"** subsection now lists each one — with the input that
+  triggers it — in both the start-menu controls guide and the in-game **Game
+  Controls** collapsible widget. The widget content now scrolls (`overflow-y:
+  auto`, taller `max-height`) so every technique row stays reachable.
+- **Snowplow wedge direction fixed.** The cosmetic snowplow pose had the ski
+  **tips splayed apart and tails together** — a reverse wedge, the opposite of a
+  real "pizza". `src/snowman/pose.ts` swung each ski the wrong way (the comment
+  said "tips inward" but the math pushed them out). Swapping the two `rotation.y`
+  signs makes the **tips converge and the tails splay out**, a proper snowplow.
+  Purely visual — no physics change.
+- **Slightly faster skiing.** Lowered coast friction (`baseFriction 0.015 → 0.012`,
+  high-speed term `0.025 → 0.020`, so the range is `0.012 .. 0.032`) for glidier
+  sustained skiing and a higher top speed. This changes the no-input coasting path,
+  so the frozen verification baseline (`tests/verification/snowman_baseline.js`)
+  was regenerated in lockstep — the invariant harness still reports the current
+  coasting trajectory as byte-identical to the baseline, and every technique gating
+  check holds. Constants updated in [`PHYSICS.md`](PHYSICS.md).
+
 ### Rename `src/physics.ts` → `src/player-state.ts` (#178)
 - The repo had two files named `physics.ts` at different levels: the top-level
   one (the typed per-frame `PlayerState` container + step/reset wiring) and the

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -105,8 +105,8 @@ Dynamic friction that is gentle at low speed (smooth starts) and firmer at speed
 
 ```
 speedFactor = min(1, currentSpeed / 8)
-baseFriction = 0.015
-friction = baseFriction + 0.025 * speedFactor        // 0.015 .. 0.040
+baseFriction = 0.012
+friction = baseFriction + 0.020 * speedFactor        // 0.012 .. 0.032
 velocity *= (1 - (friction + skidScrub))             // skidScrub == 0 when coasting
 ```
 
@@ -167,7 +167,8 @@ skidScrub = 0  unless (steering && currentSpeed > 4):
 turn reads as `skid` until the edge locks in, `carve` once `carveCharge > 0.55`, and
 finally **`parallel`** once `carveCharge > 0.85` (the `PARALLEL_LOCK` threshold) — the
 mastery tier above the beginner snowplow wedge. The snowplow forms a ski wedge
-(`wedge = 0.35 rad`); a parallel turn instead draws the skis together and rolls them
+(`wedge = 0.35 rad`) with the **tips converging and the tails splayed out** (a real
+"pizza"); a parallel turn instead draws the skis together and rolls them
 onto their edges into the turn (angulation). The pose is purely cosmetic — it never
 touches the physics. The always-on turn tax keeps a turn from ever being entirely
 free at speed (until the parallel tier relieves it), so straight-lining stays the
@@ -467,7 +468,7 @@ then reverted so the camera manager's smoothing never re-ingests its own shake.
 | Start position / velocity | `z=-15`, `vz=-3.0` | `snowman.js` |
 | Ground gravity (slope pull) | 9.8 | `snowman.js` |
 | Air gravity | 16 | `snowman.js` |
-| Base / max coast friction | 0.015 / 0.040 | `snowman.js` |
+| Base / max coast friction | 0.012 / 0.032 | `snowman.js` |
 | Turn force (normal/snowplow/fast) | 16 / 24 / 14 | `snowman.js` |
 | Accel (tuck) | 10 | `snowman.js` |
 | Brake decel | 14 | `snowman.js` |

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
           <span class="key-badge">Space</span>
           <span>Jump</span>
         </div>
-        <div class="control-item">
+        <div class="control-item" id="cameraViewControl">
           <span class="key-badge">V</span>
           <span>Toggle Camera View</span>
         </div>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,27 @@
         <span><span class="key">V</span></span>
         <span>Toggle Chase View</span>
       </div>
+      <h4 class="control-subhead">⛷️ Ski Techniques</h4>
+      <div class="control-row">
+        <span><span class="key">←</span><span class="key">→</span></span>
+        <span>Carve — hold a steady turn to keep your speed</span>
+      </div>
+      <div class="control-row">
+        <span><span class="key">←</span><span class="key">→</span> hold</span>
+        <span>Parallel — commit to the carve; skis lock together, almost no speed lost</span>
+      </div>
+      <div class="control-row">
+        <span><span class="key">↓</span><span class="key">S</span></span>
+        <span>Snowplow / pizza — wedge the ski tips together to scrub speed &amp; stop</span>
+      </div>
+      <div class="control-row">
+        <span><span class="key">↑</span><span class="key">W</span></span>
+        <span>Tuck — straight-line (no steering) for maximum speed</span>
+      </div>
+      <div class="control-row">
+        <span><span class="key">Space</span>+<span class="key">←</span><span class="key">→</span></span>
+        <span>Hop turn — quick pivot for tight, steep terrain</span>
+      </div>
     </div>
     <p class="touch-note">📱 On touch devices: tap the left/right of the screen to steer, top/bottom for speed, and the center to jump.</p>
     
@@ -152,10 +173,31 @@
           <span class="key-badge">V</span>
           <span>Toggle Camera View</span>
         </div>
+        <h4 class="control-subhead">⛷️ Ski Techniques</h4>
+        <div class="control-item">
+          <span class="key-badge">←/→</span>
+          <span>Carve — hold a turn to keep speed</span>
+        </div>
+        <div class="control-item">
+          <span class="key-badge">←/→ hold</span>
+          <span>Parallel — skis lock together, almost free</span>
+        </div>
+        <div class="control-item">
+          <span class="key-badge">↓/S</span>
+          <span>Snowplow / pizza — tips together to brake &amp; stop</span>
+        </div>
+        <div class="control-item">
+          <span class="key-badge">↑/W</span>
+          <span>Tuck — straight-line for max speed</span>
+        </div>
+        <div class="control-item">
+          <span class="key-badge">Space+←/→</span>
+          <span>Hop turn — quick pivot on steeps</span>
+        </div>
       </div>
     </div>
   </div>
-  
+
   <button id="resetBtn">Reset</button>
   
   <!-- Auth Container -->

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -17,6 +17,7 @@
     "test:start-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/start-menu-tests.js",
     "test:collapsible": "node --import ./tests/loaders/register-ts-resolve.mjs tests/collapsible-panel-tests.js",
     "test:result-overlay": "node --import ./tests/loaders/register-ts-resolve.mjs tests/result-overlay-tests.js",
+    "test:lifecycle": "node --import ./tests/loaders/register-ts-resolve.mjs tests/lifecycle-tests.js",
     "test:test-hooks": "node --import ./tests/loaders/register-ts-resolve.mjs tests/test-hooks-tests.js",
     "test:firebase": "npx -y firebase-tools@15.20.0 emulators:exec --project snowglider-rules-test --only firestore \"node tests/firestore-rules-tests.js\"",
     "test:controls": "node --import ./tests/loaders/register-ts-resolve.mjs tests/controls-node-tests.js",

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -218,13 +218,26 @@ function setupTouchControls() {
   // Update regions when window is resized
   window.addEventListener('resize', updateTouchRegions);
   
+  // Touches that begin inside a scrollable UI panel (the Controls / Ski Techniques
+  // guides) must be handed to the browser so the panel can scroll natively. The
+  // document-level handlers below otherwise call preventDefault() on every move —
+  // killing the scroll — and would also mis-read the drag as ski steering. A
+  // TouchEvent's target stays the element the gesture started on, so excluding these
+  // targets lets the overflow areas scroll without leaking into gameplay input.
+  const isScrollableUiTouch = (event: TouchEvent): boolean => {
+    const target = event.target as Element | null;
+    return !!(target && typeof target.closest === 'function' &&
+      target.closest('#controlsGuide, #controlsContent'));
+  };
+
   // Handle touch start
   const handleTouchStart = (event: TouchEvent) => {
+    if (isScrollableUiTouch(event)) return; // let the controls guide scroll natively
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();
     }
-    
+
     // Process each touch point
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
@@ -235,14 +248,15 @@ function setupTouchControls() {
       };
     }
   };
-  
+
   // Handle touch move
   const handleTouchMove = (event: TouchEvent) => {
+    if (isScrollableUiTouch(event)) return; // let the controls guide scroll natively
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();
     }
-    
+
     // Process each touch point
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];
@@ -253,14 +267,15 @@ function setupTouchControls() {
       };
     }
   };
-  
+
   // Handle touch end
   const handleTouchEnd = (event: TouchEvent) => {
+    if (isScrollableUiTouch(event)) return; // matches the start/move early-out above
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();
     }
-    
+
     // Process each touch point being removed
     for (let i = 0; i < event.changedTouches.length; i++) {
       const touch = event.changedTouches[i];

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -119,8 +119,10 @@ export function createLifecycle(deps: LifecycleDeps) {
     // Reset camera initialization with current snowman position and rotation
     cameraManager.initialize(snowman.position, snowman.rotation);
 
-    // Update the camera mode text in the controls info
-    const viewControlItem = document.querySelector('#controlsContent .control-item:last-child');
+    // Update the camera mode text in the controls info. Target the camera row by a
+    // stable id (not :last-child) so appending more control items after it — e.g. the
+    // Ski Techniques rows — can't make the toggle rewrite the wrong row.
+    const viewControlItem = document.querySelector('#cameraViewControl');
     if (viewControlItem) {
       const keyBadge = viewControlItem.querySelector('.key-badge');
       const textSpan = viewControlItem.querySelector('span:last-child');

--- a/src/snowman/physics.ts
+++ b/src/snowman/physics.ts
@@ -198,8 +198,8 @@ export function stepSnowmanPhysics(
     // Dynamic friction based on speed - less friction at lower speeds for smoother acceleration
     // This prevents the jittery start by reducing initial resistance
     const speedFactor = Math.min(1, currentSpeed / 8);
-    const baseFriction = 0.015; // Lower base friction for smoother starts
-    const friction = baseFriction + (0.025 * speedFactor); // Maximum 0.04 at high speeds
+    const baseFriction = 0.012; // Lower base friction for smoother, glidier starts
+    const friction = baseFriction + (0.020 * speedFactor); // Maximum 0.032 at high speeds (faster cruising)
     
     // Apply forces to velocity (gravity pulls along slope direction) with smoother acceleration
     velocity.x += dir.x * steepness * gravity * delta;

--- a/src/snowman/pose.ts
+++ b/src/snowman/pose.ts
@@ -29,15 +29,19 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   } = state;
 
   // Show the current technique on the snowman: a snowplow forms a beginner ski
-  // wedge (tips inward), while a parallel turn draws the skis together and rolls
-  // them onto their edges into the turn (angulation) — visually distinct from the
-  // wedge. Purely cosmetic; none of this touches the physics.
+  // wedge ("pizza" — tips together, tails apart), while a parallel turn draws the
+  // skis together and rolls them onto their edges into the turn (angulation) —
+  // visually distinct from the wedge. Purely cosmetic; none of this touches the physics.
   if (!isInAir && snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
     const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
     const lerp = Math.min(1, delta * 10);
-    const wedge = technique === 'snowplow' ? 0.35 : 0.0; // radians; tips angled inward
-    ls.rotation.y += ((-wedge) - ls.rotation.y) * lerp;
-    rs.rotation.y += ((wedge) - rs.rotation.y) * lerp;
+    const wedge = technique === 'snowplow' ? 0.35 : 0.0; // radians; converge the tips ("pizza")
+    // Each ski's tip is at local +z and the skis sit at x = ∓1, so a POSITIVE
+    // rotation.y swings the left ski's tip toward center and a NEGATIVE one swings
+    // the right ski's tip toward center — tips meet, tails splay out (a real
+    // snowplow). The opposite signs would splay the tips out (a reverse wedge).
+    ls.rotation.y += ((wedge) - ls.rotation.y) * lerp;
+    rs.rotation.y += ((-wedge) - rs.rotation.y) * lerp;
     // Parallel angulation: both skis edge the same way (into the turn) and slide
     // toward each other; everything relaxes back to neutral otherwise.
     const isParallel = technique === 'parallel';

--- a/styles/main.css
+++ b/styles/main.css
@@ -51,10 +51,10 @@ canvas { display: block; }
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 300px; /* Height when expanded */
-  overflow-y: auto; /* Allow scrolling */
+  max-height: 70vh; /* Height when expanded; tall enough for the Ski Techniques rows */
   transition: all 0.3s ease;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto; /* Scroll if the techniques don't fit, so every row stays reachable */
 }
 
 #controlsInfo.collapsed {
@@ -138,6 +138,17 @@ canvas { display: block; }
   font-size: 13px;
   min-width: 45px;
   text-align: center;
+}
+
+/* Section divider used in both the start-menu guide and the in-game controls
+   widget to set the emergent "Ski Techniques" apart from the raw key bindings. */
+.control-subhead {
+  margin: 10px 0 4px;
+  font-size: 13px;
+  font-weight: bold;
+  opacity: 0.85;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  padding-top: 8px;
 }
 
 #toggleControls {
@@ -695,7 +706,7 @@ canvas { display: block; }
   margin-bottom: 15px; /* Reduced from 30px */
   max-width: 500px;
   text-align: left;
-  max-height: 180px; /* Add max height */
+  max-height: 240px; /* Add max height (room for the Ski Techniques rows) */
   overflow-y: auto; /* Make scrollable if needed */
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -55,6 +55,8 @@ canvas { display: block; }
   transition: all 0.3s ease;
   overflow-x: hidden;
   overflow-y: auto; /* Scroll if the techniques don't fit, so every row stays reachable */
+  touch-action: pan-y; /* allow native vertical scroll on touch (controls.ts skips these touches) */
+  -webkit-overflow-scrolling: touch;
 }
 
 #controlsInfo.collapsed {
@@ -708,6 +710,8 @@ canvas { display: block; }
   text-align: left;
   max-height: 240px; /* Add max height (room for the Ski Techniques rows) */
   overflow-y: auto; /* Make scrollable if needed */
+  touch-action: pan-y; /* allow native vertical scroll on touch (controls.ts skips these touches) */
+  -webkit-overflow-scrolling: touch;
 }
 
 #controlsGuide h3 {

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -113,6 +113,37 @@ async function main() {
   check('touch in the centre region sets jump', controls.jump === true);
   dispatchTouch('touchend', document, [{ identifier: 2, clientX: W / 2, clientY: H / 2 }]);
 
+  console.log('\n--- scrollable controls guide: touch passthrough (mobile) ---');
+  // A touch that begins inside #controlsContent (the Ski Techniques scroller) must be
+  // left to the browser: NOT preventDefaulted (so the panel scrolls natively) and NOT
+  // read as ski steering — even when its coordinates fall in a control region.
+  const guide = document.createElement('div');
+  guide.id = 'controlsContent';
+  const guideRow = document.createElement('div');
+  guideRow.className = 'control-item';
+  guide.appendChild(guideRow);
+  document.body.appendChild(guide);
+  controls.left = false;
+  // Sanity: a normal document touch in the left region IS preventDefaulted.
+  const gameEvt = new window.Event('touchstart', { bubbles: true, cancelable: true });
+  gameEvt.changedTouches = [{ identifier: 7, clientX: W / 6, clientY: H / 2 }];
+  document.dispatchEvent(gameEvt);
+  check('a normal game touch is preventDefaulted', gameEvt.defaultPrevented === true);
+  dispatchTouch('touchend', document, [{ identifier: 7, clientX: W / 6, clientY: H / 2 }]);
+
+  controls.left = false;
+  // Same left-region coordinates, but the gesture starts on the scroller row.
+  const point = [{ identifier: 8, clientX: W / 6, clientY: H / 2 }];
+  for (const type of ['touchstart', 'touchmove', 'touchend']) {
+    const evt = new window.Event(type, { bubbles: true, cancelable: true });
+    evt.changedTouches = point;
+    guideRow.dispatchEvent(evt);
+    check(`${type} inside #controlsContent is NOT preventDefaulted (native scroll)`,
+      evt.defaultPrevented === false);
+  }
+  check('a drag inside #controlsContent is never read as ski steering', controls.left === false);
+  document.body.removeChild(guide);
+
   console.log('\n--- visual touch controls (mobile) ---');
   check('mobile setup creates the 5 visual touch-control overlays',
     document.querySelectorAll('.touch-control').length === 5);

--- a/tests/lifecycle-tests.js
+++ b/tests/lifecycle-tests.js
@@ -1,0 +1,114 @@
+// Headless, c8-instrumented coverage for src/game/lifecycle.ts `toggleCameraView`.
+//
+// Regression guard for the camera-row update bug: the in-game camera label used to
+// be found via `#controlsContent .control-item:last-child`. Once the Ski Techniques
+// rows were appended after the camera (V) row, the last child became the Hop turn
+// row, so toggling the camera rewrote the WRONG row. The fix targets the camera row
+// by a stable id (`#cameraViewControl`). This test drives the real toggleCameraView
+// and asserts it updates the V row (both ternary branches) and never the Hop row.
+//
+// Run via the register-ts-resolve loader so lifecycle.ts's `./*.js` sibling imports
+// resolve to their `.ts` sources.
+const { JSDOM } = require('jsdom');
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  condition ? pass++ : fail++;
+}
+
+const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://snowglider.ai/' });
+global.window = dom.window;
+global.document = dom.window.document;
+const { document } = dom.window;
+
+// Mirror the in-game Game Controls widget: the camera (V) row is NOT the last child —
+// the Ski Techniques rows (ending in Hop turn) follow it, exactly like index.html.
+function buildControlsDom() {
+  document.body.innerHTML = `
+    <div id="controlsContent">
+      <div class="control-item" id="cameraViewControl">
+        <span class="key-badge">V</span>
+        <span>Toggle Camera View</span>
+      </div>
+      <div class="control-item">
+        <span class="key-badge">↓/S</span>
+        <span>Snowplow / pizza — tips together to brake &amp; stop</span>
+      </div>
+      <div class="control-item">
+        <span class="key-badge">Space+←/→</span>
+        <span>Hop turn — quick pivot on steeps</span>
+      </div>
+    </div>
+    <button id="cameraToggleBtn">Toggle Chase View</button>`;
+}
+
+function makeDeps(toggleModes) {
+  let i = 0;
+  return {
+    state: {},
+    cameraManager: {
+      toggleCameraMode: () => toggleModes[i++ % toggleModes.length],
+      initialize: () => {}
+    },
+    snowman: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0 } },
+    gameOverOverlay: document.createElement('div'),
+    restartButton: document.createElement('button'),
+    player: { pos: { x: 0, y: 0, z: 0 } },
+    startLoop: () => {}
+  };
+}
+
+function rowText(id) {
+  return document.querySelector(id)?.textContent.replace(/\s+/g, ' ').trim();
+}
+function lastRowText() {
+  return document.querySelector('#controlsContent .control-item:last-child')
+    ?.textContent.replace(/\s+/g, ' ').trim();
+}
+
+async function main() {
+  console.log('--- lifecycle.ts toggleCameraView ---');
+  const { createLifecycle } = await import('../src/game/lifecycle.ts');
+
+  buildControlsDom();
+  const hopBefore = lastRowText();
+  // First toggle => first-person ('thirdPerson' is the OTHER mode), so label = "Chase".
+  const { toggleCameraView } = createLifecycle(makeDeps(['firstPerson', 'thirdPerson']));
+
+  const mode1 = toggleCameraView();
+  check('toggle returns the new camera mode', mode1 === 'firstPerson');
+  check('camera (V) row badge stays "V"',
+    document.querySelector('#cameraViewControl .key-badge').textContent === 'V');
+  check('camera row label updates (firstPerson => "Toggle Chase View")',
+    rowText('#cameraViewControl') === 'V Toggle Chase View');
+  check('camera-toggle button text updates too',
+    document.getElementById('cameraToggleBtn').textContent === 'Toggle Chase View');
+  check('Hop turn (last) row is NOT rewritten by the camera toggle',
+    lastRowText() === hopBefore &&
+    lastRowText() === 'Space+←/→ Hop turn — quick pivot on steeps');
+
+  // Second toggle => thirdPerson, exercising the other ternary branch ("Normal").
+  const mode2 = toggleCameraView();
+  check('second toggle flips the mode', mode2 === 'thirdPerson');
+  check('camera row label updates (thirdPerson => "Toggle Normal View")',
+    rowText('#cameraViewControl') === 'V Toggle Normal View');
+  check('Hop turn row still untouched after the second toggle',
+    lastRowText() === 'Space+←/→ Hop turn — quick pivot on steeps');
+
+  // Missing-DOM branch: toggleCameraView must not throw when the rows/button are gone.
+  document.body.innerHTML = '';
+  let threw = false;
+  try { createLifecycle(makeDeps(['firstPerson'])).toggleCameraView(); }
+  catch { threw = true; }
+  check('toggleCameraView is a no-op (no throw) when the controls DOM is absent', !threw);
+
+  console.log(`\nLIFECYCLE TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('lifecycle test crashed:', err);
+  process.exit(1);
+});

--- a/tests/verification/snowman_baseline.js
+++ b/tests/verification/snowman_baseline.js
@@ -310,8 +310,8 @@ function updateSnowman(snowman, delta, pos, velocity, isInAir, verticalVelocity,
     // Dynamic friction based on speed - less friction at lower speeds for smoother acceleration
     // This prevents the jittery start by reducing initial resistance
     const speedFactor = Math.min(1, currentSpeed / 8);
-    const baseFriction = 0.015; // Lower base friction for smoother starts
-    const friction = baseFriction + (0.025 * speedFactor); // Maximum 0.04 at high speeds
+    const baseFriction = 0.012; // Lower base friction for smoother, glidier starts
+    const friction = baseFriction + (0.020 * speedFactor); // Maximum 0.032 at high speeds (faster cruising)
     
     // Apply forces to velocity (gravity pulls along slope direction) with smoother acceleration
     velocity.x += dir.x * steepness * gravity * delta;


### PR DESCRIPTION
## What & why

Three fixes to the snowman skiing controls, all raised in review of the
gameplay feel:

1. **Ski techniques weren't exposed.** The skill layer (carve, parallel turn,
   snowplow/pizza, tuck, hop turn) already exists in the physics but was never
   explained anywhere in the UI — only the raw key bindings were listed. Added a
   new **"Ski Techniques"** section to *both* the start-menu controls guide and
   the in-game **Game Controls** collapsible widget, each row showing the input
   that triggers it. The widget content now scrolls (`overflow-y: auto`, taller
   `max-height`) so the extra rows stay reachable instead of being clipped.

2. **Snowplow / "pizza" wedge pointed the wrong way.** The cosmetic snowplow pose
   splayed the ski **tips apart** (tails together) — a reverse wedge, the opposite
   of a real pizza. In `src/snowman/pose.ts` each ski was rotated the wrong way
   (the comment even said "tips inward" while the math pushed them out). Swapped
   the two `rotation.y` signs so the **tips converge and the tails splay out**.
   Purely visual — no physics impact.

3. **Skiing felt a little slow.** Lowered coast friction
   (`baseFriction 0.015 → 0.012`, high-speed term `0.025 → 0.020`; range
   `0.012 .. 0.032`) for glidier sustained skiing and a higher top speed. This is
   a deliberate change to the no-input coasting path, so the frozen verification
   baseline (`tests/verification/snowman_baseline.js`) was regenerated in lockstep.

## Screenshots

**Snowplow wedge — before vs after** (top-down; downhill is toward the top, so the
ski *tips* are at the top). Before, the tips splay apart (reverse wedge); after,
they converge into a proper pizza.

| Before (tips apart ✗) | After (tips together ✓ "pizza") |
|---|---|
| <img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/skiing-controls-shots/snowplow-before.png" width="340"> | <img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/skiing-controls-shots/snowplow-after.png" width="340"> |

**Ski Techniques exposed in the in-game Game Controls widget:**

<img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/skiing-controls-shots/ingame-widget.png" width="320">

**…and in the start-menu controls guide:**

<img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/skiing-controls-shots/start-guide.png" width="560">

## Testing

- `npm test` — full Node suite ✅
- `npm run test:verify` — invariant harness ✅: coasting trajectory is **byte-identical**
  to the regenerated baseline (`max abs diff 0`), and all technique gating checks
  (snowplow brake, carve-vs-skid +32%, scrub ≥ baseline, high-speed edge scrub,
  parallel-reachable, hop turn) pass.
- `npm run lint` ✅ (0 errors), `npm run build` ✅
- Screenshots captured by driving the real app (Vite + headless system Chrome).

## Notes

- Speed magnitude (~moderate, friction-only) was chosen deliberately; gravity is
  unchanged. Constants are updated in `docs/PHYSICS.md` and the change is logged in
  `docs/CHANGELOG.md`.
- Did **not** touch `docs/ROADMAP.md` to avoid conflicting with #183, which is
  updating it concurrently — but this PR is the concrete "techniques are now
  surfaced to the player" follow-through on Finding 2 / P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
