### PR TITLE
Add avalanche powder cloud (issue #49)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,26 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Avalanche powder cloud (issue #49)
+- An approaching avalanche now kicks up a **billowing cloud of snow powder** as it
+  tumbles down the slope, so it reads as a rolling wall of snow instead of a bare
+  cluster of boulder spheres. This is the "in-scene cloud" remaining item under
+  ROADMAP Finding 3 (avalanche telegraphing) / issue #49 — complementing the
+  warning banner, danger meter, vignette and proximity shake shipped in #56.
+- Self-contained in `src/avalanche.ts`: a pool of `260` alpha-blended powder
+  sprites (`depthWrite: false`) — the same sprite approach as the ski snow-splash
+  in `snow.ts` — emitted from the tumbling boulders each frame from inside
+  `update()`, so no game-loop wiring changed. Each puff lofts, billows (drag +
+  light gravity), expands and fades over ~1–2.5 s.
+- **Purely cosmetic and test-safe.** The powder never touches `pos`/`velocity` or
+  the boulder physics, so the physics-invariant harness stays byte-identical and
+  the burial / `getClosestDistance` / `hasPassed` contracts are unchanged. The
+  pool builds only when a `document` is present, so the headless Node avalanche
+  tests are unaffected (powder is a no-op there). New DOM-smoke coverage exercises
+  the pool's build / activate / reset / dispose lifecycle under jsdom; existing
+  Node (12), browser-avalanche (19) and full browser (89) suites stay green. See
+  [`PHYSICS.md`](PHYSICS.md) §7.5.
+
 ### Rename `src/physics.ts` → `src/player-state.ts` (#178)
 - The repo had two files named `physics.ts` at different levels: the top-level
   one (the typed per-frame `PlayerState` container + step/reset wiring) and the

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -396,6 +396,33 @@ if (pos.y < floorY + radius):                  // ground contact
 | `getClosestDistance(playerPos)` | drives the warning UI | **2D** (x,z) nearest boulder |
 | `hasPassed(playerPos)` | "you survived" → reset | ≥ 80% of boulders at `z < playerZ - 10` |
 
+### 7.5 Powder cloud (purely cosmetic — issue #49)
+
+So an approaching slide reads as a rolling cloud of snow and not just a cluster of
+spheres, the tumbling boulders trail a **billowing powder plume**. It is a pool of
+`POWDER_COUNT = 260` additive-free (alpha-blended, `depthWrite: false`) sprites —
+the same sprite approach as the ski snow-splash in `snow.ts`, not the boulders'
+`InstancedMesh`, because each puff fades, expands and rotates independently.
+
+- **Lifecycle.** Built once in the constructor (`_initPowder`), but **only when a
+  `document` exists** — the headless Node avalanche tests construct the system with
+  no DOM, so the pool stays empty and every powder call is a no-op there. Driven
+  from inside `update(dt)` (so it only runs while the slide is `active`), cleared by
+  `reset()` (`_hidePowder`), and freed by `dispose()`.
+- **Emission.** Each frame `_updatePowder` spawns ~3–7 puffs at random boulders,
+  near each boulder's base, inheriting a fraction of its velocity plus an upward
+  loft and lateral spread. Round-robin over the pool; emission stops early once all
+  puffs are in use, so the cloud reaches a steady density rather than growing
+  unbounded.
+- **Per-puff motion.** Light gravity (`4.5`) and strong air drag (`1.4/s`) so it
+  lofts then billows and settles; the sprite **expands** (up to ~3×) and fades over
+  a `1.1–2.5 s` life (quick fade-in, then fade-out below 55% life remaining).
+- **Determinism.** The powder is entirely cosmetic — it never reads or writes the
+  snowman's `pos`/`velocity` or the boulder physics, so the physics-invariant
+  harness and the burial/`getClosestDistance`/`hasPassed` contracts are unchanged.
+  It honors the snow-effects convention (like falling snow / ski splash) of running
+  regardless of `prefers-reduced-motion`, which gates only camera motion (§9).
+
 ---
 
 ## 8. Course timing & ghost

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -408,7 +408,9 @@ the same sprite approach as the ski snow-splash in `snow.ts`, not the boulders'
   `document` exists** — the headless Node avalanche tests construct the system with
   no DOM, so the pool stays empty and every powder call is a no-op there. Driven
   from inside `update(dt)` (so it only runs while the slide is `active`), cleared by
-  `reset()` (`_hidePowder`), and freed by `dispose()`.
+  `reset()` (`_hidePowder`), and freed by `dispose()`. Inactive puffs are kept
+  `visible = false` so three skips them in the render traversal / transparent sort on
+  the idle menu/gameplay path; emission flips a puff visible only while it is live.
 - **Emission.** Each frame `_updatePowder` spawns ~3–7 puffs at random boulders,
   near each boulder's base, inheriting a fraction of its velocity plus an upward
   loft and lateral spread. Round-robin over the pool; emission stops early once all

--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -145,7 +145,8 @@ export class AvalancheSystem {
 
     for (let i = 0; i < POWDER_COUNT; i++) {
       const sprite = new THREE.Sprite(base.clone());
-      sprite.scale.set(0, 0, 0); // start invisible
+      sprite.scale.set(0, 0, 0);
+      sprite.visible = false; // skip render traversal/sort until emitted
       sprite.userData = {
         active: false,
         life: 0,
@@ -281,6 +282,7 @@ export class AvalancheSystem {
       ud.life -= dt;
       if (ud.life <= 0) {
         ud.active = false;
+        sprite.visible = false; // drop it from the render traversal again
         sprite.scale.set(0, 0, 0);
         sprite.material.opacity = 0;
         continue;
@@ -339,6 +341,7 @@ export class AvalancheSystem {
       ud.maxLife = 1.1 + Math.random() * 1.4;
       ud.life = ud.maxLife;
       ud.active = true;
+      sprite.visible = true; // back into the render traversal while it's live
       sprite.scale.set(ud.size, ud.size, ud.size);
       sprite.material.opacity = 0; // ramps in on the next update
     }
@@ -403,6 +406,7 @@ export class AvalancheSystem {
   _hidePowder(): void {
     for (const sprite of this.powder) {
       sprite.userData.active = false;
+      sprite.visible = false; // keep inactive puffs out of the render traversal
       sprite.scale.set(0, 0, 0);
       sprite.material.opacity = 0;
     }

--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -13,6 +13,10 @@
 // native type-stripping both run it exactly as before.
 import * as THREE from 'three';
 
+// Number of billowing powder-cloud sprites kicked up by the slide (see the
+// `powder` field below). Sized like the ski snow-splash pool in snow.ts.
+const POWDER_COUNT = 260;
+
 /**
  * Minimal positional shape the avalanche reads. Accepts both a real
  * `THREE.Vector3` (the live game passes `snowman.position`) and the plain
@@ -41,6 +45,18 @@ export class AvalancheSystem {
   // Parameterised so `mesh.material` is the single MeshStandardMaterial we build
   // (not the default `Material | Material[]`), keeping `dispose()` type-safe.
   mesh: THREE.InstancedMesh<THREE.IcosahedronGeometry, THREE.MeshStandardMaterial>;
+
+  // --- Powder cloud (issue #49 / ROADMAP Finding 3) -------------------------
+  // A diffuse plume of billowing snow sprites kicked up by the tumbling boulders,
+  // so an approaching slide reads as a rolling cloud of powder and not just a
+  // cluster of spheres. Sprite-based (like the ski snow-splash in snow.ts) rather
+  // than instanced because each puff fades, expands and rotates independently.
+  // Built only when a DOM is present — the headless Node avalanche tests construct
+  // the system without a `document`, so the pool stays empty and the powder
+  // emit/update calls below are no-ops there.
+  powder: THREE.Sprite[];
+  powderNext: number;            // round-robin cursor into the powder pool
+  powderTexture: THREE.Texture | null;  // shared puff texture (disposed once)
 
   constructor(scene: THREE.Scene, count: number = 120) {
     this.scene = scene;
@@ -78,8 +94,72 @@ export class AvalancheSystem {
     this.mesh.frustumCulled = false;
     this.scene.add(this.mesh);
 
+    // Powder cloud pool (empty/no-op when there is no DOM, e.g. Node tests).
+    this.powder = [];
+    this.powderNext = 0;
+    this.powderTexture = null;
+    this._initPowder();
+
     // Hide initially
     this._hideAll();
+  }
+
+  // Build the billowing-powder sprite pool. Guarded on `document` so the headless
+  // Node avalanche tests (which `new AvalancheSystem(...)` without a DOM) skip it
+  // and the powder methods below safely operate on an empty pool.
+  _initPowder(): void {
+    if (typeof document === 'undefined') return;
+
+    // Soft, faintly cool-white radial puff that fades to transparent at the rim.
+    // Paint it only when a real 2D context is available; a headless DOM (jsdom in
+    // the smoke test) may expose only a partial stub, so guard the drawing and
+    // still build the pool below — degrading to a blank texture rather than
+    // silently disabling the effect.
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d');
+    if (ctx && typeof ctx.createRadialGradient === 'function') {
+      const g = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+      g.addColorStop(0, 'rgba(255,255,255,0.9)');
+      g.addColorStop(0.4, 'rgba(238,244,255,0.55)');
+      g.addColorStop(0.75, 'rgba(220,232,255,0.2)');
+      g.addColorStop(1, 'rgba(220,232,255,0)');
+      ctx.fillStyle = g;
+      ctx.fillRect(0, 0, 64, 64);
+    }
+
+    const texture = new THREE.CanvasTexture(canvas);
+    this.powderTexture = texture;
+
+    // Template material. Cloned per particle so each puff fades/rotates on its own.
+    // Alpha (not additive) blending with depthWrite off so the cloud reads as a
+    // translucent billow against the bright snow rather than washing out to white.
+    const base = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.NormalBlending,
+      opacity: 0
+    });
+
+    for (let i = 0; i < POWDER_COUNT; i++) {
+      const sprite = new THREE.Sprite(base.clone());
+      sprite.scale.set(0, 0, 0); // start invisible
+      sprite.userData = {
+        active: false,
+        life: 0,
+        maxLife: 0,
+        vx: 0, vy: 0, vz: 0,
+        size: 0,
+        opacity0: 0,
+        rotSpeed: (Math.random() - 0.5) * 1.2
+      };
+      this.scene.add(sprite);
+      this.powder.push(sprite);
+    }
+
+    base.dispose(); // only the per-particle clones are kept
   }
 
   // Connect to terrain system
@@ -181,6 +261,87 @@ export class AvalancheSystem {
     }
 
     this.mesh.instanceMatrix.needsUpdate = true;
+
+    // Billowing powder kicked up by the tumbling boulders.
+    this._updatePowder(dt);
+  }
+
+  // Advance the existing powder puffs and spawn a few new ones from random
+  // boulders each frame, so a live slide trails a rolling cloud of snow. No-op
+  // when the pool is empty (headless Node). Driven only while `active`, since
+  // update() early-returns otherwise.
+  _updatePowder(dt: number): void {
+    if (this.powder.length === 0) return;
+
+    // 1) Integrate active puffs: drift, light gravity, air drag, expand + fade.
+    for (const sprite of this.powder) {
+      const ud = sprite.userData;
+      if (!ud.active) continue;
+
+      ud.life -= dt;
+      if (ud.life <= 0) {
+        ud.active = false;
+        sprite.scale.set(0, 0, 0);
+        sprite.material.opacity = 0;
+        continue;
+      }
+
+      sprite.position.x += ud.vx * dt;
+      sprite.position.y += ud.vy * dt;
+      sprite.position.z += ud.vz * dt;
+
+      ud.vy -= 4.5 * dt;               // light gravity: lofts, then settles
+      ud.vx *= (1 - 1.4 * dt);         // air drag billows and slows the spread
+      ud.vz *= (1 - 1.4 * dt);
+      ud.vy *= (1 - 0.6 * dt);
+
+      const ratio = ud.life / ud.maxLife;       // 1 at birth -> 0 at death
+      const grow = ud.size * (1 + (1 - ratio) * 2.0); // clouds expand as they age
+      sprite.scale.set(grow, grow, grow);
+
+      // Quick fade-in over the first ~12% of life, hold, then fade out below 55%.
+      const fade = Math.max(0, Math.min(1, Math.min((1 - ratio) / 0.12, ratio / 0.55)));
+      sprite.material.opacity = ud.opacity0 * fade;
+      sprite.material.rotation += ud.rotSpeed * dt;
+    }
+
+    // 2) Emit a handful of new puffs from random boulders (the cloud refills as
+    //    puffs expire; emission stops early once the pool is saturated).
+    const emit = 3 + Math.floor(Math.random() * 5); // ~3..7 per frame
+    for (let k = 0; k < emit; k++) {
+      // Find the next inactive puff (round-robin); bail this frame if all in use.
+      let n = this.powderNext;
+      let tries = 0;
+      while (this.powder[n].userData.active && tries < this.powder.length) {
+        n = (n + 1) % this.powder.length;
+        tries++;
+      }
+      this.powderNext = (n + 1) % this.powder.length;
+      if (tries >= this.powder.length) break;
+
+      const bi = Math.floor(Math.random() * this.count);
+      const bidx = bi * 3;
+      const r = this.sizes[bi];
+
+      const sprite = this.powder[n];
+      sprite.position.set(
+        this.positions[bidx]     + (Math.random() - 0.5) * (1.5 + r),
+        this.positions[bidx + 1] + 0.3 + Math.random() * r,
+        this.positions[bidx + 2] + (Math.random() - 0.5) * (1.5 + r)
+      );
+
+      const ud = sprite.userData;
+      ud.vx = this.velocities[bidx] * 0.25 + (Math.random() - 0.5) * 4;
+      ud.vy = 2 + Math.random() * 4;                           // loft upward
+      ud.vz = this.velocities[bidx + 2] * 0.35 - Math.random() * 1.5; // carried downhill
+      ud.size = 3 + Math.random() * 3.5 + r;
+      ud.opacity0 = 0.4 + Math.random() * 0.35;
+      ud.maxLife = 1.1 + Math.random() * 1.4;
+      ud.life = ud.maxLife;
+      ud.active = true;
+      sprite.scale.set(ud.size, ud.size, ud.size);
+      sprite.material.opacity = 0; // ramps in on the next update
+    }
   }
 
   // Check if player is buried by avalanche (collision = burial)
@@ -236,6 +397,16 @@ export class AvalancheSystem {
   reset(): void {
     this.active = false;
     this._hideAll();
+    this._hidePowder();
+  }
+
+  _hidePowder(): void {
+    for (const sprite of this.powder) {
+      sprite.userData.active = false;
+      sprite.scale.set(0, 0, 0);
+      sprite.material.opacity = 0;
+    }
+    this.powderNext = 0;
   }
 
   _hideAll(): void {
@@ -252,6 +423,16 @@ export class AvalancheSystem {
     this.scene.remove(this.mesh);
     this.mesh.geometry.dispose();
     this.mesh.material.dispose();
+
+    for (const sprite of this.powder) {
+      this.scene.remove(sprite);
+      sprite.material.dispose();
+    }
+    this.powder.length = 0;
+    if (this.powderTexture) {
+      this.powderTexture.dispose();
+      this.powderTexture = null;
+    }
   }
 }
 

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -226,6 +226,24 @@ async function main() {
     Math.abs(ud.parts.headGroup.position.y - ud.partBaseTransforms.headGroup.position.y) < 1e-9 &&
     Math.abs(ud.parts.head.scale.y - 1) < 1e-9);
 
+  // ---- AvalancheSystem powder cloud (issue #49 / ROADMAP Finding 3) ----
+  // The billowing powder is sprite-based and only built when a DOM is present, so
+  // exercise it under jsdom: the pool must build, activate while the slide is live,
+  // clear on reset, and empty on dispose. (Pure JS three sprites need no WebGL.)
+  console.log('\n--- AvalancheSystem powder cloud ---');
+  const { AvalancheSystem } = await import('../../src/avalanche.ts');
+  const av = new AvalancheSystem(new RealTHREE.Scene(), 30);
+  av.setTerrainFunction(() => 0);
+  check('powder sprite pool built under a DOM', Array.isArray(av.powder) && av.powder.length > 0);
+  check('powder starts fully inactive', av.powder.every(p => p.userData.active === false));
+  av.trigger({ x: 0, y: 12, z: -50 });
+  for (let i = 0; i < 10; i++) av.update(0.05);
+  check('powder activates while the slide is live', av.powder.some(p => p.userData.active === true));
+  av.reset();
+  check('reset() clears every powder puff', av.powder.every(p => p.userData.active === false));
+  av.dispose();
+  check('dispose() empties the powder pool', av.powder.length === 0);
+
   console.log(`\nSMOKE TEST TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 }

--- a/tests/verification/dom_smoke_test.js
+++ b/tests/verification/dom_smoke_test.js
@@ -236,11 +236,19 @@ async function main() {
   av.setTerrainFunction(() => 0);
   check('powder sprite pool built under a DOM', Array.isArray(av.powder) && av.powder.length > 0);
   check('powder starts fully inactive', av.powder.every(p => p.userData.active === false));
+  // Inactive puffs must be visible=false so three skips them in the render
+  // traversal/transparent sort on the idle menu/gameplay path (perf, esp. mobile).
+  check('inactive powder is hidden from the renderer', av.powder.every(p => p.visible === false));
   av.trigger({ x: 0, y: 12, z: -50 });
   for (let i = 0; i < 10; i++) av.update(0.05);
-  check('powder activates while the slide is live', av.powder.some(p => p.userData.active === true));
+  const live = av.powder.filter(p => p.userData.active === true);
+  check('powder activates while the slide is live', live.length > 0);
+  check('live puffs are flipped visible, idle puffs stay hidden',
+    live.every(p => p.visible === true) &&
+    av.powder.every(p => p.visible === p.userData.active));
   av.reset();
   check('reset() clears every powder puff', av.powder.every(p => p.userData.active === false));
+  check('reset() re-hides every puff from the renderer', av.powder.every(p => p.visible === false));
   av.dispose();
   check('dispose() empties the powder pool', av.powder.length === 0);
 


### PR DESCRIPTION
## Avalanche powder cloud (issue #49)

An approaching avalanche now kicks up a **billowing cloud of snow powder** as the boulders tumble down the slope, so the slide reads as a rolling wall of snow instead of a bare cluster of spheres. This delivers the remaining **"in-scene cloud"** item under ROADMAP **Finding 3** (avalanche telegraphing) / **issue #49** — complementing the warning banner, danger meter, vignette and proximity shake shipped in #56.

### Before / After

| Before (bare boulders) | After (powder cloud) |
|---|---|
| ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/avalanche-powder-shots/before.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/avalanche-powder-shots/after.png) |

*Both frames are the live game at ~the same "AVALANCHE RIGHT BEHIND YOU!" moment (closest boulder ~10 m behind).*

### Implementation
- **Self-contained in `src/avalanche.ts`.** A pool of `260` alpha-blended powder sprites (`depthWrite: false`) — the same sprite approach as the ski snow-splash in `snow.ts`, **not** the boulders' `InstancedMesh`, because each puff fades / expands / rotates independently.
- Emitted from the tumbling boulders each frame **from inside `update()`**, so **no game-loop wiring changed** — it works automatically wherever the avalanche runs.
- Each puff lofts upward, billows (air drag + light gravity), expands (~3×) and fades over ~1–2.5 s. Built once in the constructor, cleared by `reset()`, freed by `dispose()`.

### Why it's safe
- **Purely cosmetic.** The powder never reads or writes the snowman's `pos`/`velocity` or the boulder physics, so the **physics-invariant harness stays byte-identical** (max abs diff `0.000e+0`) and the `checkBurial` / `getClosestDistance` / `hasPassed` contracts are unchanged.
- The pool builds **only when a `document` is present**, so the headless Node avalanche tests are unaffected (powder is a no-op there).
- Follows the in-scene snow-effects convention (like falling snow / ski splash) of running regardless of `prefers-reduced-motion`, which gates only camera motion.

### Tests
- `tsc --noEmit` + `eslint` clean
- Node avalanche **12/12**, contract-surface **44/44**
- Physics-invariant harness **byte-identical**; all technique-gating checks hold
- DOM-smoke **41/41** — **5 new** powder checks (build / activate / reset / dispose lifecycle under jsdom)
- Full browser suite **89/89** (avalanche **19/19**)

### Docs
- `docs/PHYSICS.md` §7.5 (new) describes the powder model
- `docs/CHANGELOG.md` Unreleased entry
- ROADMAP Finding 3 / issue #49 status intentionally **left to PR #183** (the concurrent roadmap-refresh PR) to avoid a conflict — this PR delivers that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
