### PR TITLE
Make carve vs. parallel turns distinct (physics + pose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ SnowGlider is a Three.js-based skiing game featuring a snowman gliding down a pr
 
 ### Ski Techniques
 Steering isn't just turning — how you work the edges changes your speed (see [`PHYSICS.md`](docs/PHYSICS.md) §3 for the model):
-- **Carve**: hold a steady turn (←/→ in one direction) to keep your speed through the arc.
-- **Parallel turn**: stay committed to the carve — the skis lock together and the turn becomes almost free (the mastery tier above a carve).
+- **Parallel turn (skidded)**: the default steered turn — quick or abrupt steering brushes the skis sideways, **scrubbing speed for a tighter turn**. Your speed-control tool.
+- **Carve**: hold a *smooth, committed* turn (←/→ steadily in one direction) and the skis roll onto their edges while the snowman leans hard into the arc — **holding your speed through a wide line**. The mastery turn above a parallel (it commits over ~0.4 s).
 - **Snowplow / "pizza"**: hold Brake (↓/S) to wedge the **ski tips together** (tails apart) and scrub speed or stop.
 - **Tuck**: hold Accelerate (↑/W) with no steering to straight-line for maximum speed.
 - **Hop turn**: Jump (Space) **while** steering (←/→) for a quick edge-set pivot on tight, steep terrain.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,32 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Carve vs. parallel turns — make the two distinct (follow-up to #185)
+- The carve/parallel split shipped in #146/#185 was **almost indistinguishable and
+  not faithful to real skiing**: both were the same input (just hold a turn), they
+  differed only by a tiny turn-tax fading out, "carve" had *no* distinct pose at all,
+  and the hierarchy was backwards (it treated parallel as the mastery tier *above*
+  carve — in reality a carve is the advanced form of a parallel turn).
+- Reworked into **two clearly distinct steered turns** (snowplow unchanged):
+  - **Parallel (skidded)** — the default/uncommitted turn: brushes the skis, **scrubs
+    speed**, and turns **tighter** (`turnForce → 19`); skis stay flatter, body upright.
+  - **Carve** — a committed, smoothly-held turn (`carveCharge > 0.6`): **holds speed**
+    (sheds ~92% of the edge wash-out) and draws a **wider** arc (`turnForce → 10`),
+    with the skis rolled onto edge + drawn together and a **deep body inclination**
+    into the turn (lean clamp raised to ~0.42 rad). The mastery turn above a parallel.
+  - Turn **radius** is now the inverse of commitment (a carve can't be whipped tight),
+    so the two *feel* different to drive, not just post different numbers.
+- Input is unchanged (no new keys): hold a smooth line → it locks into a carve; abrupt
+  or reversed steering stays a skidded parallel turn. HUD + the in-game/start-menu
+  technique guides + `PHYSICS.md` §3.3 updated to match.
+- **Test-safe.** Every change stays behind the steering gate, so the no-input coasting
+  path is **byte-identical to the frozen baseline** (no baseline regen needed); the
+  invariant harness still reports `max abs diff 0` and all technique gating checks pass
+  (the "parallel-reachable" check is now "carve-reachable"). A new side-by-side
+  technique-comparison harness (`npm run test:turn-styles`) drives a held carve vs. a
+  skidded parallel turn from the same start and asserts the carve holds more speed and
+  arcs wider, with the parallel scrubbing more and turning tighter.
+
 ### Fix: start-screen leaderboard rows clipped at full height
 - The **Global Top Times** preview (`#startLeaderboard`) on the start screen was
   truncated — only the header and the first few of the top-5 rows showed, with the

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -116,65 +116,66 @@ Layered on top of the arcade handling. **When the player gives no steering and n
 brake input, `turnForce`/accel are unchanged and `skidScrub == 0`, so coasting is
 identical to the pre-technique physics** — see §6.
 
+There are **two** steered turns — a skidded parallel turn and a carve — plus the
+snowplow wedge. They are the two ends of one axis (`carveCharge`, below): how
+committed the edge is sets the turn's radius, its speed scrub, *and* its pose, so
+they read clearly differently to drive and to watch.
+
 | Technique | Trigger | Effect |
 |-----------|---------|--------|
-| **Skid**  | Left/Right, freshly set or *reversed* (panic-steer) | Edge washes out and scrubs speed (`skidScrub` near full) |
-| **Carve** | Left/Right, *committed* (held in one direction) | Holds speed: a locked edge sheds most of the wash-out (`turnForce = 16`) |
-| **Parallel** | Left/Right, fully committed (`carveCharge > 0.85`) | The mastery tier of the carve: the always-on turn tax fades out (nearly free turn); skis draw together and roll onto edge |
+| **Parallel (skidded)** | Left/Right, uncommitted (fresh, *reversed*, or abrupt) | Skis brush sideways and **scrub speed** (`skidScrub` near full); **tighter** turn (`turnForce → 19`); skis stay flatter, body upright |
+| **Carve** | Left/Right, *committed* (held smoothly, `carveCharge > 0.6`) | **Holds speed** — the locked edge sheds ~92% of the wash-out; **wider** arc (`turnForce → 10`); skis roll onto edge + draw together with a deep body lean. The mastery turn above a parallel |
 | **Snowplow** | Down | Sheds real speed, but sharper, planted turns (`turnForce = 24`, grip = 1.0); skis form a wedge |
 | **Tuck**  | Up, no steer | Least friction, most speed, least control (`accel = 10` on `-z`) |
 | **Hop turn** | Jump **+** Left/Right (grounded) | A quick edge-set pivot: snaps heading ~0.4 rad toward the steer, scrubs ~18% speed, small pop; lands on a fresh edge (see §4) |
 
-**Edge engagement — the carve/skid trade-off (issues #48 / #54).** A turn is only a
+**Edge engagement — carve vs. skidded parallel (issues #48 / #54).** A turn is only a
 skill if a clean, committed turn costs less speed than a panicked one. `carveCharge`
 ∈ [0,1] tracks how locked-in the current edge is: it builds while the player holds
 *one* steering direction and collapses to 0 the instant they reverse it or first set
-an edge out of a straight line. A locked carve sheds most of the edge wash-out; a
-fresh or reversed edge keeps it. So anticipating and holding a smooth line keeps
-speed, while flip-flopping the skis bleeds it. The state lives on `snowman.userData`
-(like the pose state), persists across frames, and is cleared by `resetSnowman`.
+an edge out of a straight line. Past `CARVE_LOCK = 0.6` the turn is a **carve** (wide
+arc, holds speed); below it the turn is a **skidded parallel** turn (tighter, scrubs
+speed). So anticipating and holding a smooth line carves and keeps speed, while
+abrupt or flip-flopping steering skids and bleeds it. The state lives on
+`snowman.userData` (like the pose state), persists across frames, and is cleared by
+`resetSnowman`.
 
 Key terms:
 
 ```
 terrainGrip = 0.6 + min(0.4, steepness * 0.5)        // more bite on pitches
 
-turnForce   = 16.0
-            = 24.0  if snowplow                       // planted wedge steers harder
-            = 14.0  if currentSpeed > 18 (no snowplow)// hard to wrench skis at speed
-left/right:  velocity.x ∓= turnForce * delta
-
 // Edge engagement (per-frame, on snowman.userData):
 if steering != 0:
     carveCharge = (steering == lastSteerDir)          // same way as last frame?
-                ? min(1, carveCharge + delta * 1.5)   // ~0.66 s of a held turn locks it in
+                ? min(1, carveCharge + delta * 1.5)   // ~0.4 s of a held turn locks the carve in
                 : 0                                    // reversal / fresh edge breaks it
 else:
     carveCharge = max(0, carveCharge - delta * 3.0)   // releases ~2x faster than it engages
 
+// Turn RADIUS is the inverse of commitment (a carve can't be whipped tight):
+turnForce   = 24.0                                    if snowplow   // tightest, planted wedge
+            = 19.0 + (10.0 - 19.0) * carveCharge      otherwise     // 19 skid (tight) -> 10 carve (wide)
+            *= 0.85                                    if currentSpeed > 18 (no snowplow)
+left/right:  velocity.x ∓= turnForce * delta
+
 skidScrub = 0  unless (steering && currentSpeed > 4):
     speedFactor2 = min(1, currentSpeed / 22)
     grip = snowplow ? 1.0 : terrainGrip
-    edgeScrub = 0.06 * speedFactor2 * (1 - grip*0.85) * (1 - 0.8 * carveCharge)
-    // Parallel-turn tax relief: the turn tax fades out across the parallel lock
-    // (carveCharge 0.85 -> 1), so a mastered parallel turn is nearly free. Below
-    // 0.85 parallelLock == 0, so carve/skid is byte-identical to before.
-    parallelLock = clamp01((carveCharge - 0.85) / (1 - 0.85))
-    skidScrub = edgeScrub + 0.01 * speedFactor2 * (1 - parallelLock)
+    edgeScrub = 0.10 * speedFactor2 * (1 - grip*0.85) * (1 - 0.92 * carveCharge)  // carve sheds ~92%
+    skidScrub = edgeScrub + 0.008 * speedFactor2 * (1 - carveCharge)              // turn tax, faded by a carve
 ```
 
 `technique` is classified each frame and returned for the HUD and ski pose: a steered
-turn reads as `skid` until the edge locks in, `carve` once `carveCharge > 0.55`, and
-finally **`parallel`** once `carveCharge > 0.85` (the `PARALLEL_LOCK` threshold) — the
-mastery tier above the beginner snowplow wedge. The snowplow forms a ski wedge
-(`wedge = 0.35 rad`) with the **tips converging and the tails splayed out** (a real
-"pizza"); a parallel turn instead draws the skis together and rolls them
-onto their edges into the turn (angulation). The pose is purely cosmetic — it never
-touches the physics. The always-on turn tax keeps a turn from ever being entirely
-free at speed (until the parallel tier relieves it), so straight-lining stays the
-fastest line and turning is a genuine speed-management choice — while a clean carve
-still finishes far
-faster than chatter-skidding (≈40% in the verification harness, §6).
+turn reads as **`parallel`** (skidded) until the edge locks in, then **`carve`** once
+`carveCharge > CARVE_LOCK` (0.6). The snowplow forms a ski wedge (`wedge = 0.35 rad`)
+with the **tips converging and the tails splayed out** (a real "pizza"); a **carve**
+rolls the skis hard onto their edges, draws them together, and inclines the whole body
+into the turn (lean clamp raised to ~0.42 rad); a **skidded parallel** turn keeps the
+skis flatter and the body upright. The pose is purely cosmetic — it never touches the
+physics. The always-on turn tax (faded out by a carve) keeps turning from ever being
+entirely free, so straight-lining stays the fastest line and a clean carve still
+finishes far faster than chatter-skidding (≈30%+ in the verification harness, §6).
 
 ### 3.4 Snowplow brake (and why it is clamped)
 
@@ -469,12 +470,14 @@ then reverted so the camera manager's smoothing never re-ingests its own shake.
 | Ground gravity (slope pull) | 9.8 | `snowman.js` |
 | Air gravity | 16 | `snowman.js` |
 | Base / max coast friction | 0.012 / 0.032 | `snowman.js` |
-| Turn force (normal/snowplow/fast) | 16 / 24 / 14 | `snowman.js` |
+| Turn force (parallel/snowplow/carve) | 19 / 24 / 10 (×0.85 over 18 u/s) | `snowman.js` |
 | Accel (tuck) | 10 | `snowman.js` |
 | Brake decel | 14 | `snowman.js` |
-| Max skid scrub | 0.06 | `snowman.js` |
+| Max skid scrub (uncommitted) | 0.10 + 0.008 tax | `snowman.js` |
+| Carve scrub relief | 0.92 | `snowman.js` |
 | Carve build / release rate | 1.5 / 3.0 per s | `snowman.js` |
-| Parallel-turn lock threshold | `carveCharge > 0.85` | `snowman.js` |
+| Carve lock threshold | `carveCharge > 0.6` | `snowman.js` |
+| Carve body-lean clamp | 0.42 rad (~24°) | `snowman.js` |
 | Hop turn pivot / speed-keep / pop / cooldown | 0.4 rad / 0.82 / 5.0 / 0.45 s | `snowman.js` |
 | Manual / auto jump impulse | `10 + v*0.5` / `6 + v*0.3` | `snowman.js` |
 | Max tilt | 0.25 rad (~14°) | `snowman.js` |

--- a/index.html
+++ b/index.html
@@ -91,11 +91,11 @@
       <h4 class="control-subhead">⛷️ Ski Techniques</h4>
       <div class="control-row">
         <span><span class="key">←</span><span class="key">→</span></span>
-        <span>Carve — hold a steady turn to keep your speed</span>
+        <span>Parallel turn — steer to brush the skis &amp; scrub speed for a tighter turn</span>
       </div>
       <div class="control-row">
         <span><span class="key">←</span><span class="key">→</span> hold</span>
-        <span>Parallel — commit to the carve; skis lock together, almost no speed lost</span>
+        <span>Carve — hold a smooth turn: skis edge in, lean hard, hold speed (wide arc)</span>
       </div>
       <div class="control-row">
         <span><span class="key">↓</span><span class="key">S</span></span>
@@ -200,11 +200,11 @@
         <h4 class="control-subhead">⛷️ Ski Techniques</h4>
         <div class="control-item">
           <span class="key-badge">←/→</span>
-          <span>Carve — hold a turn to keep speed</span>
+          <span>Parallel — brush the skis, scrub speed, turn tighter</span>
         </div>
         <div class="control-item">
           <span class="key-badge">←/→ hold</span>
-          <span>Parallel — skis lock together, almost free</span>
+          <span>Carve — hold a smooth turn: edge in, lean, hold speed</span>
         </div>
         <div class="control-item">
           <span class="key-badge">↓/S</span>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -34,6 +34,7 @@
     "test:sky": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sky-cycle-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
+    "test:turn-styles": "node tests/verification/turn_styles_compare.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test",

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -49,13 +49,16 @@ const MASTER_GAIN = 0.85;        // overall SFX headroom (leaves room for the mu
 const RAMP_TAU = 0.08;           // s; smoothing time-constant for continuous beds
 
 /** Per-technique base loudness of the ski-edge swish (before the speed taper).
- *  A skid scrapes hardest; a locked carve/parallel hisses; gliding straight is silent. */
+ *  A skidded parallel turn scrubs hardest; a committed carve hisses quieter; gliding
+ *  straight is silent. (#191: the low-charge skidded turn now reports 'parallel', and
+ *  the committed turn reports 'carve' — 'skid' is no longer emitted but kept as an
+ *  alias for the scrub so any caller passing it still sounds right.) */
 function techniqueEdge(technique: string): number {
   switch (technique) {
-    case 'skid': return 0.30;
+    case 'parallel': return 0.30; // skidded parallel scrubs hardest
+    case 'skid': return 0.30;     // legacy alias for the scrub (no longer emitted)
     case 'snowplow': return 0.26;
-    case 'carve': return 0.22;
-    case 'parallel': return 0.16;
+    case 'carve': return 0.18;    // a committed carve hisses, quieter than a scrub
     default: return 0; // glide / tuck / air / hop — no sustained edge noise
   }
 }

--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -173,7 +173,10 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
   // wedge / parallel edge + draw). Present-or-absent: no-ops on a snowman without arms.
   if (parts.leftSkiTip || parts.rightSkiTip) {
     const snowplow = !air && m.technique === 'snowplow';
-    const carving = !air && (m.technique === 'carve' || m.technique === 'parallel' || m.technique === 'skid');
+    // Only a committed CARVE digs the shovel in (tip-pressure). A skidded parallel
+    // turn keeps the skis flatter — it must NOT get carve tip-pressure (#191: the
+    // low-charge skidded turn now reports 'parallel', not the old locked-edge tier).
+    const carving = !air && m.technique === 'carve';
 
     // Smooth the resting camber between techniques so changes don't snap.
     const camberTarget = air ? SKI_CAMBER_AIR : (snowplow ? SKI_CAMBER_PLOW : SKI_CAMBER_GLIDE);

--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -142,10 +142,12 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
     hg.position.set(hb.position.x, hb.position.y + clamp(bob, -0.3, 0.3), hb.position.z);
 
     const targetLag = -turn * LAG_TARGET;
-    // Lean into every turn (the most readable cue), just deeper when actively carving.
-    // The old hard gate left the lean at 0 for the default `glide`/`snowplow` techniques,
-    // i.e. most of normal play, so it was never seen.
-    const carving = !air && (m.technique === 'carve' || m.technique === 'parallel' || m.technique === 'skid');
+    // Lean into every turn (the most readable cue), but only a committed CARVE gets the
+    // full deep head-cluster lean; a skidded parallel turn (and glide/snowplow) keep the
+    // lighter glide lean so the "skis flatter, body upright" parallel pose actually reads
+    // (the body-lean split is driven harder in pose.ts). Both stay above the old hard gate
+    // that left non-carve turns at 0.
+    const carving = !air && m.technique === 'carve';
     const targetLean = air ? 0 : -turn * LEAN_TARGET * (carving ? 1 : LEAN_GLIDE);
     fs.lagY += (targetLag - fs.lagY) * clamp(dt * 6, 0, 1);
     fs.leanZ += (targetLean - fs.leanZ) * clamp(dt * 5, 0, 1);

--- a/src/snowman/physics.ts
+++ b/src/snowman/physics.ts
@@ -223,10 +223,49 @@ export function stepSnowmanPhysics(
     // Terrain-dependent grip: a touch more bite on moderate pitches, looser when flat.
     const terrainGrip = 0.6 + Math.min(0.4, steepness * 0.5);
 
-    // Steering authority: snowplow tightens the turn, speed loosens it slightly.
-    let turnForce = 16.0;
-    if (snowplow) turnForce = 24.0;            // planted wedge = sharper steering
-    else if (currentSpeed > 18) turnForce = 14.0; // hard to wrench the skis at speed
+    // --- Edge engagement: carve vs skidded parallel (issues #48 / #54) -------
+    // `carveCharge` (0..1) tracks how committed/locked-in the current edge is: it
+    // builds while the player holds ONE steering direction and collapses to 0 the
+    // instant they reverse or first set an edge from straight. It is the single
+    // axis that splits a turn into a tight, speed-scrubbing *skidded parallel* turn
+    // (low charge) versus a wide, speed-holding *carve* (high charge) — driving the
+    // turn radius, the speed scrub, and the pose together so the two read clearly
+    // differently. The state lives on snowman.userData so it persists across frames
+    // and resetSnowman clears it. It is read/written every frame but only *used*
+    // under steering input, so the no-input coasting path stays byte-identical to the
+    // frozen baseline.
+    const CARVE_BUILD_RATE = 1.5;    // ~0.4s of a held turn to lock a carve in (> CARVE_LOCK)
+    const CARVE_RELEASE_RATE = 3.0;  // edge releases ~2x faster than it engages
+    const CARVE_LOCK = 0.6;          // carveCharge past this reads + behaves as a carve
+
+    const ud = snowman.userData || (snowman.userData = {});
+    let carveCharge = ud.carveCharge || 0;
+    let lastSteerDir = ud.lastSteerDir || 0;
+    if (steering !== 0) {
+      // Same direction as last frame => the edge keeps engaging; a reversal or a
+      // fresh edge out of a straight line breaks it and restarts the carve.
+      carveCharge = steering === lastSteerDir
+        ? Math.min(1, carveCharge + delta * CARVE_BUILD_RATE)
+        : 0;
+      lastSteerDir = steering;
+    } else {
+      carveCharge = Math.max(0, carveCharge - delta * CARVE_RELEASE_RATE);
+      lastSteerDir = 0;
+    }
+    ud.carveCharge = carveCharge;
+    ud.lastSteerDir = lastSteerDir;
+
+    // Steering authority sets the turn RADIUS, and it is the inverse of commitment:
+    //   - a skidded PARALLEL turn pivots tight (high authority) but scrubs speed;
+    //   - a committed CARVE draws a wide, clean arc (low authority) but holds speed.
+    // Blending by carveCharge makes the two turns *feel* different to drive, not just
+    // post different numbers. Snowplow stays the tightest, most planted turn.
+    const PARALLEL_TURN_FORCE = 19.0;  // skidded parallel: tight, pivoty
+    const CARVE_TURN_FORCE = 10.0;     // carved: wide, drawn-out arc
+    let turnForce = snowplow
+      ? 24.0                           // planted wedge = sharpest steering
+      : PARALLEL_TURN_FORCE + (CARVE_TURN_FORCE - PARALLEL_TURN_FORCE) * carveCharge;
+    if (!snowplow && currentSpeed > 18) turnForce *= 0.85; // harder to wrench at speed
 
     if (controls.left) {
       velocity.x -= turnForce * delta;
@@ -259,74 +298,33 @@ export function stepSnowmanPhysics(
       }
     }
 
-    // --- Edge engagement: carve vs skid (issues #48 / #54) -------------------
-    // Turning is only a real *skill* if a clean, committed turn costs less speed
-    // than a panicked one. `carveCharge` (0..1) tracks how "locked in" the
-    // current edge is: it builds while the player commits to ONE steering
-    // direction and collapses to 0 the instant they reverse or first set an edge
-    // from straight. A locked carve sheds little speed; a fresh or reversed edge
-    // washes out sideways and scrubs hard. So anticipating and holding a smooth
-    // line keeps speed, while flip-flopping the skis bleeds it - the
-    // speed-management trade-off the roadmap calls for.
-    //
-    // The state lives on snowman.userData (like `technique` and the pose state)
-    // so it persists across frames without widening the updateSnowman contract,
-    // and resetSnowman clears it between runs. Crucially it is *read/written but
-    // never used to alter velocity when the player gives no steering input*, so
-    // the no-input coasting path stays byte-identical to the frozen baseline.
-    const CARVE_BUILD_RATE = 1.5;    // ~0.66s of a held turn to lock the carve in
-    const CARVE_RELEASE_RATE = 3.0;  // edge releases ~2x faster than it engages
-    const CARVE_SCRUB_RELIEF = 0.8;  // a locked carve sheds up to 80% of edge wash-out
-    const TURN_TAX = 0.01;           // small always-on turn cost so a turn is never free
-    const PARALLEL_LOCK = 0.85;      // carveCharge past this = a mastered parallel turn
-
-    const ud = snowman.userData || (snowman.userData = {});
-    let carveCharge = ud.carveCharge || 0;
-    let lastSteerDir = ud.lastSteerDir || 0;
-    if (steering !== 0) {
-      // Same direction as last frame => the edge keeps engaging; a reversal or a
-      // fresh edge out of a straight line breaks it and starts the carve over.
-      carveCharge = steering === lastSteerDir
-        ? Math.min(1, carveCharge + delta * CARVE_BUILD_RATE)
-        : 0;
-      lastSteerDir = steering;
-    } else {
-      carveCharge = Math.max(0, carveCharge - delta * CARVE_RELEASE_RATE);
-      lastSteerDir = 0;
-    }
-    ud.carveCharge = carveCharge;
-    ud.lastSteerDir = lastSteerDir;
-
-    // Edge skid / carve drag: only meaningful while steering. Snowplow adds grip,
-    // so braking through a turn stays controlled instead of washing out.
+    // Edge skid / carve drag: only meaningful while steering. A skidded parallel
+    // turn (low carveCharge) washes the edges out sideways and bleeds real speed; a
+    // committed carve (carveCharge -> 1) sheds almost all of it and holds speed - so
+    // holding a smooth, anticipatory line keeps speed while panicky/abrupt steering
+    // scrubs it (the speed-management trade-off, issues #48/#54). Snowplow adds grip
+    // so braking through a turn stays controlled. Gated on steering, so the no-input
+    // coasting path is untouched and stays byte-identical to the frozen baseline.
+    const CARVE_SCRUB_RELIEF = 0.92; // a locked carve sheds ~92% of the edge wash-out
+    const SKID_SCRUB = 0.10;         // base wash-out scrub for an uncommitted (skidded) turn
+    const TURN_TAX = 0.008;          // small always-on turn cost, faded out by a carve
     let skidScrub = 0;
     if (steering !== 0 && currentSpeed > 4) {
       const speedFactor2 = Math.min(1, currentSpeed / 22);
       const grip = snowplow ? 1.0 : terrainGrip;
-      // Edge wash-out: sharper turn relative to grip => more scrub (~0..0.06). A
-      // locked carve (carveCharge to 1) sheds most of it; a skid (carveCharge to 0)
-      // keeps all of it.
-      const edgeScrub = 0.06 * speedFactor2 * (1 - grip * 0.85) * (1 - CARVE_SCRUB_RELIEF * carveCharge);
-      // Plus an always-on turn tax (scaled by speed) so committing to a turn still
-      // costs a little versus straight-lining - turning is never free, but a clean
-      // carve is cheap. A fully-locked PARALLEL turn (carveCharge past the 0.85
-      // parallel threshold - skis together and rolled onto edge) is the most
-      // efficient turn there is, so the tax fades out across the parallel lock:
-      // mastering the carve into a parallel turn makes it nearly free. Below 0.85
-      // `parallelLock` is 0, so carve/skid feel and the gating carve-vs-skid check
-      // are byte-identical.
-      const parallelLock = Math.min(1, Math.max(0, (carveCharge - PARALLEL_LOCK) / (1 - PARALLEL_LOCK)));
-      skidScrub = edgeScrub + TURN_TAX * speedFactor2 * (1 - parallelLock);
+      const edgeScrub = SKID_SCRUB * speedFactor2 * (1 - grip * 0.85) * (1 - CARVE_SCRUB_RELIEF * carveCharge);
+      skidScrub = edgeScrub + TURN_TAX * speedFactor2 * (1 - carveCharge);
     }
 
-    // Expose technique for HUD + ski pose. A turn reads as a "skid" until the edge
-    // locks in (carveCharge), then a "carve", and finally a "parallel" turn once
-    // the edge is fully committed past PARALLEL_LOCK - the mastery tier above the
-    // beginner snowplow wedge.
+    // Expose technique for HUD + ski pose. There are exactly two steered turns now
+    // (plus the snowplow wedge): an uncommitted, speed-scrubbing skidded **parallel**
+    // turn, which locks into a speed-holding **carve** once the edge is committed past
+    // CARVE_LOCK. (Real-skiing order: a carve is the mastery form of a parallel turn,
+    // not a tier beyond it.)
     technique = 'glide';
     if (isInAir) technique = 'air';
     else if (snowplow) technique = 'snowplow';
-    else if (steering !== 0) technique = carveCharge > PARALLEL_LOCK ? 'parallel' : (carveCharge > 0.55 ? 'carve' : 'skid');
+    else if (steering !== 0) technique = carveCharge > CARVE_LOCK ? 'carve' : 'parallel';
     else if (controls.up) technique = 'tuck';
     
     // Only use automatic turning if no user input

--- a/src/snowman/pose.ts
+++ b/src/snowman/pose.ts
@@ -29,9 +29,10 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   } = state;
 
   // Show the current technique on the snowman: a snowplow forms a beginner ski
-  // wedge ("pizza" — tips together, tails apart), while a parallel turn draws the
-  // skis together and rolls them onto their edges into the turn (angulation) —
-  // visually distinct from the wedge. Purely cosmetic; none of this touches the physics.
+  // wedge ("pizza" — tips together, tails apart); a carve rolls the skis hard onto
+  // their edges and draws them together (paired with a deep body lean below); a
+  // skidded parallel turn keeps the skis flatter and brushing. Purely cosmetic; none
+  // of this touches the physics.
   if (!isInAir && snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
     const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
     const lerp = Math.min(1, delta * 10);
@@ -42,11 +43,16 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
     // snowplow). The opposite signs would splay the tips out (a reverse wedge).
     ls.rotation.y += ((wedge) - ls.rotation.y) * lerp;
     rs.rotation.y += ((-wedge) - rs.rotation.y) * lerp;
-    // Parallel angulation: both skis edge the same way (into the turn) and slide
-    // toward each other; everything relaxes back to neutral otherwise.
-    const isParallel = technique === 'parallel';
-    const edge = isParallel ? steering * 0.28 : 0.0;
-    const draw = isParallel ? 0.35 : 0.0;
+    // Make the two steered turns read clearly differently on the snowman:
+    //   - CARVE: skis rolled hard onto their edges into the turn and drawn tight
+    //     together (angulation) — paired below with a deep body inclination. The
+    //     signature "on a rail" carve look.
+    //   - PARALLEL (skidded): skis stay flatter and at roughly neutral width, brushing
+    //     across the snow rather than knifing in.
+    // Purely cosmetic; none of this touches the physics.
+    let edge = 0.0, draw = 0.0;
+    if (technique === 'carve') { edge = steering * 0.5; draw = 0.4; }
+    else if (technique === 'parallel') { edge = steering * 0.1; draw = 0.05; }
     const lbx = (snowman.userData.leftSkiBaseX ?? -1) + draw;
     const rbx = (snowman.userData.rightSkiBaseX ?? 1) - draw;
     ls.rotation.z += (edge - ls.rotation.z) * lerp;
@@ -117,10 +123,15 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   
   // Add more controlled turning tilt with speed-based scaling
   const turnTiltFactor = Math.min(0.3, currentSpeed / 25); // Less tilt at lower speeds
-  const turnTilt = velocity.x * turnTiltFactor;
-  
+  // A committed carve inclines the whole body hard into the turn (angulation/
+  // inclination) — the signature carve look, and the strongest cue separating it
+  // from a flatter, upright skidded parallel turn. Amplify the lean and raise the
+  // clamp during a carve; every other technique keeps the original gentle lean.
+  const isCarve = technique === 'carve';
+  const turnTilt = velocity.x * turnTiltFactor * (isCarve ? 2.0 : 1.0);
+
   // Limit maximum tilt angles to prevent unrealistic leaning
-  const maxTiltAngle = 0.25; // Reduced to about 14 degrees maximum tilt
+  const maxTiltAngle = isCarve ? 0.42 : 0.25; // ~24° into a carve, ~14° otherwise
   
   // Apply smoothing and clamping to rotation values
   const targetRotX = gradZ * 0.3 + jumpTilt; // Add jump tilt to X rotation

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -95,10 +95,10 @@ export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: bo
     } else {
       // Reflect the active ski technique so skill is legible in the HUD.
       const techMap: Record<string, { txt: string; color: string }> = {
-        parallel: { txt: '🎿 Parallel', color: '#00d2ff' },
-        carve:    { txt: '🎿 Carving',  color: '#55efc4' },
-        hop:      { txt: '🦘 Hop turn', color: '#fab1a0' },
-        skid:     { txt: '💨 Skidding', color: '#ffeaa7' },
+        parallel: { txt: '🎿 Parallel (skid)', color: '#ffeaa7' },
+        carve:    { txt: '🎿 Carving',        color: '#55efc4' },
+        hop:      { txt: '🦘 Hop turn',       color: '#fab1a0' },
+        skid:     { txt: '💨 Skidding',       color: '#ffeaa7' },
         snowplow: { txt: '🍕 Snowplow', color: '#74b9ff' },
         tuck:     { txt: '🏎️ Tuck',     color: '#ff7675' },
         glide:    { txt: '⛷️ Ground',   color: '#AAFFAA' }

--- a/tests/README.md
+++ b/tests/README.md
@@ -239,10 +239,20 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   mocked THREE: both modules build their DOM/gates, the per-frame loop runs, every
   checkpoint and the finish are reached, the ghost trajectory and best splits
   persist, and a faster second run is reported as a new record.
+- **`turn_styles_compare.js`** — drives the real `Snowman.updateSnowman` (physics
+  **and** `applySnowmanPose`) to compare the two steered turns — a committed
+  **carve** vs. a skidded **parallel** turn — side by side. It animates both as a
+  top-down ASCII map for human review and gates the distinctions the carve-vs-parallel
+  rework promises: the carve locks in (the parallel never does), the parallel pivots
+  harder (tighter) while the carve draws a wider arc, the carve leans the body deeper
+  and rolls/draws the skis together, and — via linked turns around the fall line —
+  the carve holds clearly more speed. Run via `npm run test:turn-styles` (also
+  included in `npm test`).
 - **`results.txt`** — the recorded output from the last full verification run.
 
 ```bash
-npm run test:verify   # physics_invariant_harness.js + dom_smoke_test.js
+npm run test:verify        # physics_invariant_harness.js + dom_smoke_test.js
+npm run test:turn-styles   # carve vs. parallel turn side-by-side comparison
 ```
 
 ## Playwright E2E (cross-browser + mobile)

--- a/tests/sfx-tests.js
+++ b/tests/sfx-tests.js
@@ -31,7 +31,7 @@ async function main() {
   // --- ski-edge swish gain -----------------------------------------------------
   check('carve: glide is silent', carveGainForTechnique('glide', 18) === 0);
   check('carve: air is silent', carveGainForTechnique('air', 18) === 0);
-  check('carve: a skid scrapes louder than a locked parallel', carveGainForTechnique('skid', 18) > carveGainForTechnique('parallel', 18));
+  check('carve: a skidded parallel scrapes louder than a committed carve', carveGainForTechnique('parallel', 18) > carveGainForTechnique('carve', 18));
   check('carve: tapers to silence when nearly stopped', carveGainForTechnique('skid', 0) === 0);
   check('carve: louder fast than slow (same technique)', carveGainForTechnique('carve', 12) > carveGainForTechnique('carve', 3));
   check('carve: speed taper saturates (clamped)', approx(carveGainForTechnique('skid', 50), carveGainForTechnique('skid', 12)));

--- a/tests/verification/physics_invariant_harness.js
+++ b/tests/verification/physics_invariant_harness.js
@@ -233,10 +233,10 @@ console.log('  baseline finalSpeed:', fo.toFixed(2), '| current finalSpeed:', fm
 console.log('  PASS:', scrubAtSpeed ? 'edge scrub active at speed ✅' : 'no scrub ❌');
 if (!scrubAtSpeed) hardFail = true;
 
-// 6) Parallel turn reachable: a sustained, committed carve (held Right) must lock
-// the edge in far enough to read as a "parallel" turn — the mastery tier above
-// carve (issue #48). carveCharge builds only while steering, so this is also gated
-// behind input and cannot affect coasting. [GATING]
+// 6) Carve reachable: a sustained, committed turn (held Right) must lock the edge
+// in far enough to read as a "carve" — the speed-holding mastery turn above the
+// uncommitted skidded "parallel" turn (issues #48/#54). carveCharge builds only
+// while steering, so this is also gated behind input and cannot affect coasting. [GATING]
 function simulateTech(updateFn, controls, seed, { steps = 120, dt = 1 / 60, z0 = -40, vz0 = -12 } = {}) {
   const rng = makeRng(seed); Math.random = rng;
   const snowman = fakeSnowman();
@@ -255,11 +255,11 @@ function simulateTech(updateFn, controls, seed, { steps = 120, dt = 1 / 60, z0 =
   return { seen };
 }
 const parRun = simulateTech(mod, RIGHT, 777);
-const reachesParallel = parRun.seen.has('parallel');
-console.log('\n--- Parallel turn: sustained committed carve reaches the parallel tier [GATING] ---');
+const reachesCarve = parRun.seen.has('carve');
+console.log('\n--- Carve: sustained committed turn reaches the carve tier [GATING] ---');
 console.log('  techniques seen on held-Right:', [...parRun.seen].join(', '));
-console.log('  PASS:', reachesParallel ? 'committed carve locks into a parallel turn ✅' : 'never reached parallel ❌');
-if (!reachesParallel) hardFail = true;
+console.log('  PASS:', reachesCarve ? 'committed turn locks into a carve ✅' : 'never reached carve ❌');
+if (!reachesCarve) hardFail = true;
 
 // 7) Hop turn (Jump + steer): a quick edge-set pivot that snaps the heading toward
 // the steer direction MUCH harder than a plain steering frame, and scrubs speed

--- a/tests/verification/turn_styles_compare.js
+++ b/tests/verification/turn_styles_compare.js
@@ -1,0 +1,265 @@
+// turn_styles_compare.js
+// Side-by-side comparison of the two steered ski turns introduced by the
+// carve-vs-parallel rework (follow-up to #185 / issues #48/#54): a committed
+// **carve** vs. a skidded **parallel** turn. It drives the REAL
+// Snowman.updateSnowman (physics + applySnowmanPose) and GATES the exit code on
+// the distinctions the rework promises:
+//
+//   - Carve  : holds speed, draws a WIDER arc, deep body lean, skis edged + drawn together.
+//   - Parallel (skidded): scrubs speed, turns TIGHTER, upright body, skis flatter + neutral width.
+//
+// Two scenarios, each isolating a property cleanly:
+//
+//   A) Single-arc side-by-side — one held-Right carve vs. one skidded parallel
+//      from an identical start. Animated as a top-down ASCII map for human
+//      review, and gated on turn RADIUS (speed-independent curvature) + POSE +
+//      the technique each turn locks into. (Final speed here is terrain-confounded
+//      — a single sustained turn wanders off across the radial hill — so it is a
+//      diagnostic only.)
+//   B) Linked turns around the fall line — committed carves vs. chatter-skidding,
+//      sharing the same terrain band, to gate SPEED-HOLDING fairly (the carve must
+//      finish clearly faster). Mirrors physics_invariant_harness check 3.
+//
+// This complements the physics_invariant_harness (which gates the no-input
+// coasting invariant). Run via:
+//   node tests/verification/turn_styles_compare.js
+//   npm run test:turn-styles
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+// --- Shared deterministic terrain (mirrors mountains.js downhill shape, no noise) ---
+// Identical to physics_invariant_harness.js so both harnesses agree on terrain.
+function getTerrainHeight(x, z) {
+  let y = 40 * Math.exp(-Math.sqrt(x * x + z * z) / 40);
+  if (z < -30) y += (z + 30) * 0.12;
+  return y;
+}
+function getTerrainGradient(x, z) {
+  const eps = 0.1, h = getTerrainHeight(x, z);
+  return { x: (getTerrainHeight(x + eps, z) - h) / eps, z: (getTerrainHeight(x, z + eps) - h) / eps };
+}
+function getDownhillDirection(x, z) {
+  const g = getTerrainGradient(x, z);
+  const d = { x: -g.x, z: -g.z };
+  const len = Math.sqrt(d.x * d.x + d.z * d.z);
+  return len ? { x: d.x / len, z: d.z / len } : { x: 0, z: 1 };
+}
+
+// Seeded PRNG so the auto-turn Math.random path (linked runs reverse, so it is
+// never hit there; single arcs hold a steer, also never hitting it) is deterministic.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+// Stub snowman with body + ski transforms so applySnowmanPose (run inside
+// updateSnowman) has somewhere to write the cosmetic pose we read back:
+//   snowman.rotation.z          -> body lean into the turn
+//   userData.leftSki/rightSki   -> ski edge (rotation.z) and width (position.x)
+function fakeSnowman() {
+  const ski = (baseX) => ({ position: { x: baseX }, rotation: { x: 0, y: 0, z: 0 } });
+  const ls = ski(-1), rs = ski(1);
+  return {
+    position: { set() {} },
+    rotation: { x: 0, y: Math.PI, z: 0 },
+    userData: { targetRotationY: Math.PI, currentRotX: 0, currentRotZ: 0,
+                leftSki: ls, rightSki: rs, leftSkiBaseX: -1, rightSkiBaseX: 1 }
+  };
+}
+
+const RIGHT = { left: false, right: true, up: false, down: false, jump: false };
+const LEFT = { left: true, right: false, up: false, down: false, jump: false };
+
+// Drive one descent. `ctrl(i)` supplies the controls each frame; `breakEdge`
+// simulates a continuously-skidded (uncommitted) turn by resetting the edge state
+// every frame so the carve never locks (a held turn otherwise commits into a
+// carve). Returns a per-frame record of position, speed, heading, technique, and
+// the cosmetic pose.
+function run(updateFn, ctrl, { steps = 130, dt = 1 / 60, z0 = -40, vz0 = -16, seed = 4242, breakEdge = false } = {}) {
+  const rng = makeRng(seed); Math.random = rng;
+  const snowman = fakeSnowman();
+  const pos = { x: 0, z: z0, y: getTerrainHeight(0, z0) };
+  const velocity = { x: 0, z: vz0 };
+  let st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, z0),
+             airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+  const frames = [];
+  for (let i = 0; i < steps; i++) {
+    if (breakEdge) { snowman.userData.carveCharge = 0; snowman.userData.lastSteerDir = 0; }
+    st = updateFn(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity, st.lastTerrainHeight,
+      st.airTime, st.jumpCooldown, ctrl(i), st.turnPhase, st.currentTurnDirection, st.turnChangeCooldown,
+      3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection, [], false, function () {});
+    frames.push({
+      i,
+      x: pos.x,
+      z: pos.z,
+      speed: Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z),
+      heading: Math.atan2(velocity.x, velocity.z),
+      technique: st.technique,
+      lean: snowman.rotation.z,                                              // body inclination
+      skiEdge: snowman.userData.leftSki.rotation.z,                          // ski roll onto edge
+      skiGap: snowman.userData.rightSki.position.x - snowman.userData.leftSki.position.x, // ski width
+      carveCharge: snowman.userData.carveCharge || 0
+    });
+    if (pos.z < -195) break;
+  }
+  return frames;
+}
+
+const last = (frames) => frames[frames.length - 1];
+const maxAbs = (frames, key) => frames.reduce((m, f) => Math.max(m, Math.abs(f[key])), 0);
+const techniques = (frames) => new Set(frames.map((f) => f.technique));
+
+// Mean turn radius over the arc — SPEED-INDEPENDENT (pathLength / total heading
+// change). Reported as a diagnostic; over a long arc gravity keeps redirecting the
+// velocity back toward the fall line, which muddies it, so the gated tightness
+// measure is the single-frame turn impulse below.
+function turnRadius(frames) {
+  let pathLen = 0, turned = 0;
+  for (let i = 1; i < frames.length; i++) {
+    pathLen += Math.hypot(frames[i].x - frames[i - 1].x, frames[i].z - frames[i - 1].z);
+    let d = frames[i].heading - frames[i - 1].heading;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    turned += d;
+  }
+  return Math.abs(turned) > 1e-6 ? pathLen / Math.abs(turned) : Infinity;
+}
+
+// Controlled single-frame turn impulse from an IDENTICAL state, differing only in
+// edge commitment: a carve (carveCharge locked) vs. a parallel (carveCharge 0).
+// The sideways velocity gained in one Right frame is the turn's tightness — the
+// parallel pivots harder (turnForce 19) than the carve (turnForce 10). Unconfounded
+// by terrain, speed, or path history, so it is the clean GATING tightness measure.
+function turnImpulse(updateFn, committed, { z0 = -40, vz0 = -16 } = {}) {
+  Math.random = makeRng(1);
+  const snowman = fakeSnowman();
+  snowman.userData.carveCharge = committed ? 1 : 0;
+  snowman.userData.lastSteerDir = committed ? 1 : 0;
+  const pos = { x: 0, z: z0, y: getTerrainHeight(0, z0) };
+  const velocity = { x: 0, z: vz0 };
+  const st = updateFn(snowman, 1 / 60, pos, velocity, false, 0, getTerrainHeight(0, z0), 0, 0, RIGHT,
+    0, 0, 3, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection, [], false, function () {});
+  return { dvx: Math.abs(velocity.x), technique: st.technique };
+}
+
+// --- Top-down ASCII map of both single arcs (downhill = downward) ------------
+function renderMaps(carve, parallel) {
+  const W = 27, H = 16;
+  const all = carve.concat(parallel);
+  let minX = Math.min(...all.map((f) => f.x)), maxX = Math.max(...all.map((f) => f.x));
+  const minZ = Math.min(...all.map((f) => f.z)), maxZ = Math.max(...all.map((f) => f.z));
+  const padX = Math.max(0.5, (maxX - minX) * 0.08); minX -= padX; maxX += padX;
+  const col = (x) => Math.max(0, Math.min(W - 1, Math.round((x - minX) / (maxX - minX || 1) * (W - 1))));
+  const row = (z) => Math.max(0, Math.min(H - 1, Math.round((maxZ - z) / (maxZ - minZ || 1) * (H - 1))));
+  const blank = () => Array.from({ length: H }, () => Array(W).fill(' '));
+  function plot(grid, frames, ch) {
+    for (const f of frames) grid[row(f.z)][col(f.x)] = ch;
+    grid[row(frames[0].z)][col(frames[0].x)] = 'S';
+    grid[row(last(frames).z)][col(last(frames).x)] = 'E';
+    return grid;
+  }
+  const cGrid = plot(blank(), carve, '·');
+  const pGrid = plot(blank(), parallel, '·');
+  const oGrid = blank();          // overlay: C = carve, P = parallel, X = both
+  for (const f of carve) oGrid[row(f.z)][col(f.x)] = 'C';
+  for (const f of parallel) {
+    const r = row(f.z), c = col(f.x);
+    oGrid[r][c] = oGrid[r][c] === 'C' ? 'X' : 'P';
+  }
+  const center = col(0);
+  const lines = [];
+  const cap = (s) => s + ' '.repeat(Math.max(0, W - s.length));
+  lines.push('   ' + cap('CARVE (held edge)') + '   ' + cap('PARALLEL (skidded)') + '   ' + cap('OVERLAY  C/P/X=both'));
+  for (let r = 0; r < H; r++) {
+    const draw = (grid) => grid[r].map((ch, c) => (ch === ' ' && c === center) ? ':' : ch).join('');
+    lines.push('   |' + draw(cGrid) + '|   |' + draw(pGrid) + '|   |' + draw(oGrid) + '|');
+  }
+  lines.push('   (S=start, E=end, ":"=fall line x=0; rows go downhill; same x/z scale across panels)');
+  return lines.join('\n');
+}
+
+(async () => {
+  // src/snowman is an ES module behind a `.js`-specifier import graph, so register
+  // the `.js` -> `.ts` resolver before importing the public facade (same pattern as
+  // physics_invariant_harness.js, so this runs with a plain `node ...`).
+  await import(pathToFileURL(path.join(__dirname, '..', 'loaders', 'register-ts-resolve.mjs')).href);
+  const { Snowman } = await import('../../src/snowman.ts');
+  const update = Snowman.updateSnowman;
+  // updateSnowman reads window.location.search / window.treeCollisionRadius on its
+  // debug + test-hook paths; provide the same minimal stub the harness expects.
+  global.window = global.window || { location: { search: '' } };
+
+  let hardFail = false;
+  const gate = (name, cond, detail) => {
+    console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}${detail ? ' — ' + detail : ''}`);
+    if (!cond) hardFail = true;
+  };
+
+  // === Scenario A: single-arc side-by-side (radius + pose + technique) ========
+  const Z0 = -40;
+  const carve = run(update, () => RIGHT, { z0: Z0, breakEdge: false });
+  const parallel = run(update, () => RIGHT, { z0: Z0, breakEdge: true });
+  const carveR = turnRadius(carve), parR = turnRadius(parallel);
+  // Clean tightness probe: one Right frame from an identical state, carve vs parallel.
+  const carveImp = turnImpulse(update, true), parImp = turnImpulse(update, false);
+
+  console.log('=== A) Carve vs. parallel — single turn, side-by-side ===');
+  console.log('(identical start: z=-40, entry 16 u/s, held Right; only edge commitment differs)\n');
+  console.log(renderMaps(carve, parallel));
+
+  console.log('\n--- Frame-by-frame (every 20 frames) ---');
+  console.log('  frame |        CARVE  speed  x      lean  tech     |     PARALLEL  speed  x      lean  tech');
+  for (let i = 0; i < Math.max(carve.length, parallel.length); i += 20) {
+    const c = carve[Math.min(i, carve.length - 1)];
+    const p = parallel[Math.min(i, parallel.length - 1)];
+    const fmt = (f) => `${f.speed.toFixed(2).padStart(6)} ${f.x.toFixed(1).padStart(6)} ${f.lean.toFixed(3).padStart(7)}  ${f.technique}`;
+    console.log(`  ${String(i).padStart(5)} |        ${fmt(c).padEnd(34)} |     ${fmt(p)}`);
+  }
+
+  console.log('\n--- Scenario A metrics ---');
+  console.log(`  turn impulse (1 frame) carve ${carveImp.dvx.toFixed(3)}  vs  parallel ${parImp.dvx.toFixed(3)}  (parallel pivots harder = tighter, +${((parImp.dvx / carveImp.dvx - 1) * 100).toFixed(0)}%)`);
+  console.log(`  mean turn radius (diag) carve ${carveR.toFixed(2)}  vs  parallel ${parR.toFixed(2)}  (carve = wider arc)`);
+  console.log(`  max body lean      carve ${maxAbs(carve, 'lean').toFixed(3)}  vs  parallel ${maxAbs(parallel, 'lean').toFixed(3)} rad`);
+  console.log(`  max ski edge       carve ${maxAbs(carve, 'skiEdge').toFixed(3)}  vs  parallel ${maxAbs(parallel, 'skiEdge').toFixed(3)} rad`);
+  console.log(`  min ski gap        carve ${Math.min(...carve.map((f) => f.skiGap)).toFixed(2)}  vs  parallel ${Math.min(...parallel.map((f) => f.skiGap)).toFixed(2)} (carve draws skis together)`);
+  console.log(`  techniques seen    carve {${[...techniques(carve)].join(', ')}}  parallel {${[...techniques(parallel)].join(', ')}}`);
+  console.log(`  final speed (diag) carve ${last(carve).speed.toFixed(2)}  vs  parallel ${last(parallel).speed.toFixed(2)}  (not gated: single sustained turn wanders to steeper terrain — see B for speed)`);
+
+  console.log('\n--- Scenario A gates (tightness + pose + technique) ---');
+  gate('committed turn locks into a carve', techniques(carve).has('carve'),
+    `carve techniques {${[...techniques(carve)].join(', ')}}`);
+  gate('skidded turn reads as parallel and never carves',
+    techniques(parallel).has('parallel') && !techniques(parallel).has('carve'),
+    `parallel techniques {${[...techniques(parallel)].join(', ')}}`);
+  gate('parallel pivots harder than the carve (tighter turn)', parImp.dvx > carveImp.dvx * 1.2,
+    `impulse ${parImp.dvx.toFixed(3)} > ${carveImp.dvx.toFixed(3)} (carve=${carveImp.technique}, parallel=${parImp.technique})`);
+  gate('carve leans the body deeper into the turn', maxAbs(carve, 'lean') > maxAbs(parallel, 'lean'),
+    `${maxAbs(carve, 'lean').toFixed(3)} > ${maxAbs(parallel, 'lean').toFixed(3)} rad`);
+  gate('carve rolls the skis harder onto edge', maxAbs(carve, 'skiEdge') > maxAbs(parallel, 'skiEdge'),
+    `${maxAbs(carve, 'skiEdge').toFixed(3)} > ${maxAbs(parallel, 'skiEdge').toFixed(3)} rad`);
+  gate('carve draws the skis closer together than the parallel turn',
+    Math.min(...carve.map((f) => f.skiGap)) < Math.min(...parallel.map((f) => f.skiGap)),
+    `gap ${Math.min(...carve.map((f) => f.skiGap)).toFixed(2)} < ${Math.min(...parallel.map((f) => f.skiGap)).toFixed(2)}`);
+
+  // === Scenario B: linked turns around the fall line (speed-holding) ==========
+  // Both link turns that oscillate around the fall line, so they end near the same
+  // x and share terrain; they differ only in reversal frequency:
+  //   - carve   : 30-frame committed edges -> carveCharge locks into a carve.
+  //   - chatter : reverse the edge every frame -> carveCharge never engages (skid).
+  // The skid must finish clearly slower. (Measured spread is large; gate at a
+  // conservative 8% so it stays robust, not flaky.)
+  const PERIOD = 30;
+  const carveLinked = run(update, (i) => (Math.floor(i / PERIOD) % 2 === 0 ? RIGHT : LEFT), { vz0: -20, steps: 120 });
+  const skidLinked = run(update, (i) => (i % 2 === 0 ? RIGHT : LEFT), { vz0: -20, steps: 120 });
+  const spread = last(carveLinked).speed / last(skidLinked).speed - 1;
+
+  console.log('\n=== B) Linked turns around the fall line — speed-holding ===');
+  console.log(`  carve   (committed ${PERIOD}-frame edges) finalSpeed ${last(carveLinked).speed.toFixed(2)} @x ${last(carveLinked).x.toFixed(1)}  techniques {${[...techniques(carveLinked)].join(', ')}}`);
+  console.log(`  skid    (chatter every frame)        finalSpeed ${last(skidLinked).speed.toFixed(2)} @x ${last(skidLinked).x.toFixed(1)}  techniques {${[...techniques(skidLinked)].join(', ')}}`);
+  console.log('\n--- Scenario B gate (speed-holding) ---');
+  gate('committed carves hold more speed than chatter-skidding', spread > 0.08,
+    `carve +${(spread * 100).toFixed(0)}% vs skid`);
+
+  console.log(`\nTURN-STYLES COMPARE: ${hardFail ? 'FAIL ❌ (a distinctness gate failed)' : 'OK ✅ (carve and parallel turns are distinct in radius, speed, and pose)'}`);
+  process.exit(hardFail ? 1 : 0);
+})().catch((err) => { console.error('turn-styles compare harness crashed:', err); process.exit(1); });


### PR DESCRIPTION
## What & why

Follow-up to #185 / #146. As reported: **carve vs. parallel was almost
indistinguishable and confusing — not what happens in real skiing or physics.**

Root cause (in the merged code):
- Carve and parallel were the **same input** (just hold a turn); the *only* physical
  difference was a tiny turn-tax fading out at `carveCharge > 0.85` — imperceptible.
- **`carve` had no distinct pose at all** (skis sat neutral, identical to gliding);
  only `parallel` had a subtle pose that snapped in suddenly.
- The hierarchy was **backwards**: it treated parallel as the mastery tier *above*
  carve. In reality a carve is the advanced form of a parallel turn.

## What changed

Two clearly distinct steered turns (snowplow unchanged), split along one axis —
how committed the edge is (`carveCharge`):

| | Parallel (skidded) | Carve |
|---|---|---|
| **Trigger** | default / uncommitted (abrupt or reversed steering) | hold a smooth turn (`carveCharge > 0.6`) |
| **Speed** | **scrubs** speed | **holds** speed (sheds ~92% wash-out) |
| **Radius** | **tighter** (`turnForce → 19`) | **wider** arc (`turnForce → 10`) |
| **Pose** | skis flatter, body upright | skis edged + drawn together, **deep body lean** |

Turn **radius is now the inverse of commitment** (a carve can't be whipped tight), so
the two *feel* different to drive, not just post different numbers.

**Input is unchanged** (no new keys, mobile-safe): hold a smooth line → it commits into
a carve; abrupt or reversed steering stays a skidded parallel turn.

## Screenshots — the poses are now unmistakable

| Carve (commit: edge + deep lean, holds speed) | Parallel / skidded (upright, flatter skis, scrubs) |
|---|---|
| <img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/carve-parallel-shots/carve.png" width="320"> | <img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/carve-parallel-shots/parallel.png" width="320"> |

Snowplow (pizza), unchanged, for reference:

<img src="https://raw.githubusercontent.com/den-run-ai/snowglider/assets/carve-parallel-shots/snowplow.png" width="300">

## Testing

- `npm run test:verify` ✅ — **no-input coasting is byte-identical to the frozen
  baseline (`max abs diff 0`)**, so no baseline regen was needed (every change stays
  behind the steering gate). All technique gates pass; the old "parallel-reachable"
  gate is now "carve-reachable" (held-Right shows `parallel → carve`).
- `npm test` (Node, 44/44 smoke) ✅, `npm run lint` ✅, `npm run build` ✅.
- HUD + in-game/start-menu technique guides + `PHYSICS.md` §3.3 + constants updated;
  screenshots captured by driving the real `createSnowman` + `applySnowmanPose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
