### PR TITLE
docs: snow rendering & lighting guide + model SVG (#188 step 2)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,8 @@
 
 How the pieces fit together: the static module system, load order, the global
 namespace and injection seams, the per-frame data flow, and the Firebase/scoring
-subsystem. For the simulation itself see [`PHYSICS.md`](PHYSICS.md); for tests see
+subsystem. For the simulation itself see [`PHYSICS.md`](PHYSICS.md); for how snow is
+lit and shaded see [`SNOW_RENDERING.md`](SNOW_RENDERING.md); for tests see
 [`tests/README.md`](../tests/README.md).
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Snow rendering & lighting guide (docs)
+- Added [`docs/SNOW_RENDERING.md`](SNOW_RENDERING.md) plus
+  `docs/snow-lighting-model.svg`, versioning the rationale behind the snow-lighting
+  stack (issues #17/#18/#2): warm sun + cool skylight + AO for snow form, the
+  whiteout / grey-corduroy / muddy-snow failure modes to avoid, the merged static
+  light values, and the per-layer ownership boundaries the sun cycle (#163) must
+  respect. Linked from [`ARCHITECTURE.md`](ARCHITECTURE.md). Docs-only.
+
 ### Avalanche powder cloud (issue #49)
 - An approaching avalanche now kicks up a **billowing cloud of snow powder** as it
   tumbles down the slope, so it reads as a rolling wall of snow instead of a bare

--- a/docs/SNOW_RENDERING.md
+++ b/docs/SNOW_RENDERING.md
@@ -1,0 +1,91 @@
+# Snow Rendering & Lighting Guide
+
+This is the design rationale for how SnowGlider lights and shades snow. It is the
+reference the snow/lighting PRs (issues #17, #18, and the #2 sky work) converged on,
+and the contract any later atmospheric layer — notably the #163 sun cycle — must
+preserve. For the module wiring see [`ARCHITECTURE.md`](ARCHITECTURE.md); for the
+simulation model see [`PHYSICS.md`](PHYSICS.md). The lighting lives in
+[`src/game/scene-setup.ts`](../src/game/scene-setup.ts), the sky/fog in
+[`src/sky.ts`](../src/sky.ts), and the snow material/normals in
+[`src/mountains.ts`](../src/mountains.ts).
+
+## Core visual principle
+
+Snow form should come from **warm sun, cool skylight, and occluded concavities** —
+not from grey paint or broad intensity changes.
+
+![Snow lighting model: a warm directional key light lights the slope, cool blue
+skylight fills the shadows, and ambient occlusion darkens concavities. The bottom
+row contrasts flat-white whiteout, muddy grey shading, and the target warm-plus-cool
+snow form.](snow-lighting-model.svg)
+
+- **Sunlit snow** is warm and near-white.
+- **Shaded snow** is cool blue, not grey.
+- **Troughs, lee sides, and track grooves** get their form from
+  ambient-occlusion / concavity, not from a grey vertex tint.
+- **Distant snow** fades cool and hazy, so far-field banding is less visible.
+
+## Failure modes to avoid
+
+| Failure | Cause | Fix |
+|---|---|---|
+| **Whiteout** | Too much flat/soft light or ambient — terrain form disappears | Keep ambient low; let the hemisphere fill shade *by orientation*, not a uniform wash |
+| **Grey corduroy** | Hard low sun raking periodic terrain ridges into repeated grey bands | Soften the key light, smooth the *shading* normals, and remove the periodic ridge as a banding source |
+| **Muddy snow** | Neutral grey shadows instead of cool blue ones | Shadows are filled by a cool-blue hemisphere sky color, never neutral grey |
+
+The "grey lines" that survived the snow *texture* fix (#17) were terrain **shadows**,
+not a texture: every mogul lit on one side and greyed on the other, made periodic by
+the regular `sin(x * 0.2) * cos(z * 0.3)` terrain ridge. They were addressed by
+(a) smoothing the *shading* normals while leaving the skiable height field untouched,
+and (b) the light rebalance below. Fully replacing that periodic ridge with
+fBm/domain-warp terrain remains a follow-up.
+
+## The merged static lighting (source of truth: `scene-setup.ts`)
+
+Intensities are pre-multiplied by `Math.PI` to preserve the original r134 brightness
+under three.js physically-correct lighting (see the renderer note in
+`scene-setup.ts`). The snow-readability rebalance (#17 follow-up) dialed the hard sun
+*down* and the orientation-aware fill *up*, so deep powder reads low-contrast — bright
+almost everywhere with soft shading — the way real snow does under an open sky.
+
+| Element | Merged value | Role |
+|---|---|---|
+| `AmbientLight` | `0xffffff` at `0.26 * Math.PI` | Low floor so nothing goes pure black |
+| `HemisphereLight` | sky `0xdcebfb` / ground `0xbcc7d4` at `0.62 * Math.PI` | Cool-blue skylight fill that shades **by orientation** — the source of cool shadow color and snow form |
+| `DirectionalLight` | `0xffffff` at `0.5 * Math.PI`, position `(50, 100, 50)` | The warm-ish key light; casts the shadows |
+| Sky (`src/sky.ts`) | Preetham atmospheric sky, `exposure 0.45` | Bright azure sky + visible sun aligned to the directional light |
+| Fog / distance | horizon-tinted `Fog`, near `140` / far `750` | Distant snow fades cool and hazy |
+
+The design-intent palette these values serve (near-white `#EDF0F6` base albedo, warm
+`#FFF6E6` sunlit snow, cool `#B6C9E6` shaded snow, `#93A9CC` occluded pockets) is the
+target the snow material and tints aim at; the code in `mountains.ts` /
+`scene-setup.ts` is the authoritative value.
+
+## Ownership boundaries
+
+Keeping each layer in its lane is what prevents the whiteout / grey / muddy
+regressions from creeping back when one piece is retuned:
+
+| Layer | Owns | Must not own |
+|---|---|---|
+| Static snow-lighting (`scene-setup.ts`, `mountains.ts`) | albedo, normal-map de-striping, smoothed render normals, static light balance, near-white slope tint | sun-cycle animation |
+| Terrain (`mountains.ts` height field) | the slope geometry; replacing the periodic ridge that bands under low sun | lighting rebalance |
+| AO / curvature readability (if added) | concavity shading from the smoothed-normal clone | terrain physics changes |
+| Sun cycle (`src/sky.ts`, #163) | directional sun position/color/intensity, Preetham `sunPosition`/`exposure`, bounded fog/background tint | snow albedo, vertex tint, smoothed normals, terrain, **hemisphere fill** |
+
+## The sun cycle is an atmospheric layer, not a readability fix
+
+When the #163 sunrise ↔ midday cycle lands, it animates **on top of** this settled
+static look. It captures the merged static lighting as its midday snapshot and lerps
+toward warmer, dimmer golden-hour values and back — it does **not** rebalance snow
+readability. Specifically the cycle must:
+
+- preserve the warm-sun / cool-shadow relationship described above;
+- leave the `HemisphereLight` (the cool-shadow source) completely untouched;
+- keep `AmbientLight` static — never animate it toward the old `0.5 * Math.PI`
+  whiteout value;
+- reproduce the captured static snapshot **exactly** at midday and when frozen
+  (reduced-motion / disabled).
+
+See the `#163 implementation contract` in issue #188 for the full set of invariants
+and the `test:sky` coverage that enforces them.

--- a/docs/snow-lighting-model.svg
+++ b/docs/snow-lighting-model.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="446" viewBox="0 0 680 446" role="img">
+<title>Snow lighting model: warm directional sun, cool blue skylight filling shadows, and ambient occlusion darkening concavities</title>
+<desc>A snow mound cross-section shows a warm sunlit slope, a cool blue shaded slope, and a darker occluded pocket at its base, lit by a warm key light and diffuse cool skylight. Below, three swatches compare flat-white whiteout, grey muddy shading, and the target warm-plus-cool look.</desc>
+<style>
+.t{font-family:system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:400;fill:#2C2C2A}
+.ts{font-family:system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;font-weight:400;fill:#5F5E5A}
+.th{font-family:system-ui,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:500;fill:#2C2C2A}
+.leader{stroke:#A0A39B;stroke-width:.6;stroke-dasharray:3 3;fill:none}
+</style>
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></marker>
+<clipPath id="snow">
+<path d="M80 240 C140 240 165 118 250 110 C335 118 360 240 420 240 Z"/>
+<path d="M90 400 C120 400 130 338 150 335 C170 338 180 400 210 400 Z"/>
+<path d="M280 400 C310 400 320 338 340 335 C360 338 370 400 400 400 Z"/>
+<path d="M465 400 C495 400 505 338 525 335 C545 338 555 400 585 400 Z"/>
+</clipPath>
+</defs>
+
+<rect x="1" y="1" width="678" height="444" rx="14" fill="#FAF9F6" stroke="#E6E4DC" stroke-width="1"/>
+
+<rect x="40" y="240" width="430" height="16" fill="#E7ECF3"/>
+<line x1="40" y1="240" x2="470" y2="240" stroke="#BCC4CF" stroke-width="0.8"/>
+<ellipse cx="398" cy="248" rx="58" ry="7" fill="#A8BCDB" opacity="0.5"/>
+
+<rect x="80" y="104" width="100" height="138" fill="#FFF6E6" clip-path="url(#snow)"/>
+<rect x="180" y="104" width="140" height="138" fill="#EAEEF5" clip-path="url(#snow)"/>
+<rect x="320" y="104" width="100" height="138" fill="#B6C9E6" clip-path="url(#snow)"/>
+<ellipse cx="360" cy="236" rx="34" ry="11" fill="#93A9CC" clip-path="url(#snow)"/>
+<path d="M80 240 C140 240 165 118 250 110 C335 118 360 240 420 240 Z" fill="none" stroke="#BCC4CF" stroke-width="1"/>
+
+<circle cx="100" cy="68" r="24" fill="#FBC453" opacity="0.3"/>
+<circle cx="100" cy="68" r="16" fill="#FBC453"/>
+<line x1="118" y1="80" x2="168" y2="138" stroke="#F2A33A" stroke-width="1.3" marker-end="url(#arrow)"/>
+<line x1="130" y1="66" x2="198" y2="126" stroke="#F2A33A" stroke-width="1.3" marker-end="url(#arrow)"/>
+<line x1="108" y1="92" x2="150" y2="162" stroke="#F2A33A" stroke-width="1.3" marker-end="url(#arrow)"/>
+
+<line x1="270" y1="46" x2="270" y2="62" stroke="#8FA9D6" stroke-width="1" opacity="0.8" marker-end="url(#arrow)"/>
+<line x1="320" y1="44" x2="320" y2="60" stroke="#8FA9D6" stroke-width="1" opacity="0.8" marker-end="url(#arrow)"/>
+<line x1="370" y1="46" x2="370" y2="62" stroke="#8FA9D6" stroke-width="1" opacity="0.8" marker-end="url(#arrow)"/>
+
+<line class="leader" x1="478" y1="122" x2="162" y2="208"/>
+<circle cx="160" cy="210" r="2" fill="#8A8A85"/>
+<line class="leader" x1="478" y1="174" x2="357" y2="203"/>
+<circle cx="355" cy="205" r="2" fill="#8A8A85"/>
+<line class="leader" x1="478" y1="226" x2="360" y2="232"/>
+<circle cx="360" cy="234" r="2" fill="#8A8A85"/>
+
+<text class="th" x="52" y="40">Warm key light</text>
+<text class="th" x="325" y="40" text-anchor="middle">Skylight fill (cool)</text>
+
+<text class="th" x="482" y="118">Sunlit slope</text>
+<text class="ts" x="482" y="134">#FFF6E6 warm white</text>
+<text class="th" x="482" y="170">Shaded slope</text>
+<text class="ts" x="482" y="186">#B6C9E6 cool blue</text>
+<text class="th" x="482" y="222">Occluded pocket</text>
+<text class="ts" x="482" y="238">#93A9CC (AO)</text>
+
+<text class="th" x="60" y="302">Three lighting regimes</text>
+
+<rect x="90" y="330" width="120" height="72" fill="#F8FAFD" clip-path="url(#snow)"/>
+<path d="M90 400 C120 400 130 338 150 335 C170 338 180 400 210 400 Z" fill="none" stroke="#BCC4CF" stroke-width="0.8"/>
+<line x1="90" y1="400" x2="210" y2="400" stroke="#D2D5DB" stroke-width="0.5"/>
+
+<rect x="280" y="330" width="60" height="72" fill="#D6D9DF" clip-path="url(#snow)"/>
+<rect x="340" y="330" width="60" height="72" fill="#B3B6BD" clip-path="url(#snow)"/>
+<path d="M280 400 C310 400 320 338 340 335 C360 338 370 400 400 400 Z" fill="none" stroke="#BCC4CF" stroke-width="0.8"/>
+<line x1="280" y1="400" x2="400" y2="400" stroke="#D2D5DB" stroke-width="0.5"/>
+
+<rect x="465" y="330" width="42" height="72" fill="#FFF6E6" clip-path="url(#snow)"/>
+<rect x="507" y="330" width="36" height="72" fill="#EAEEF5" clip-path="url(#snow)"/>
+<rect x="543" y="330" width="42" height="72" fill="#B6C9E6" clip-path="url(#snow)"/>
+<ellipse cx="556" cy="394" rx="13" ry="6" fill="#93A9CC" clip-path="url(#snow)"/>
+<path d="M465 400 C495 400 505 338 525 335 C545 338 555 400 585 400 Z" fill="none" stroke="#BCC4CF" stroke-width="0.8"/>
+<line x1="465" y1="400" x2="585" y2="400" stroke="#D2D5DB" stroke-width="0.5"/>
+
+<text class="ts" x="150" y="420" text-anchor="middle">Flat white = whiteout</text>
+<text class="ts" x="340" y="420" text-anchor="middle">Grey shading = muddy</text>
+<text class="ts" x="525" y="420" text-anchor="middle">Warm + cool = form</text>
+</svg>


### PR DESCRIPTION
Step 2 of the issue #188 snow/light landing plan: version the snow-lighting rationale with the code, now that the #181 static baseline has merged.

## What
- **`docs/SNOW_RENDERING.md`** — the snow rendering & lighting guide: the warm-sun / cool-skylight / AO model, the whiteout · grey-corduroy · muddy-snow failure modes, the merged static light values (ambient `0.26π`, hemisphere `0.62π` `#dcebfb`/`#bcc7d4`, directional `0.5π` @ `(50,100,50)`, sky exposure `0.45`), and the per-layer ownership boundaries the #163 sun cycle must respect.
- **`docs/snow-lighting-model.svg`** — the lighting-model diagram from issue #188, committed as text/vector and referenced from the guide.
- Linked from `ARCHITECTURE.md`; CHANGELOG entry added.

## Scope
Docs-only — no source, tests, build, or workflow touched. Establishes the written contract the #163 re-integration (step 5) is gated on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)