### PR TITLE
fix: address codex P2 review findings on the snow/light stack (#163, #181)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,22 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Codex review follow-ups on the snow/light stack (#163, #181)
+- **Golden hour no longer renders muddy (sky.ts, #163).** The cycle's golden-hour
+  `THREE.Color` endpoints were built at module load — *before* `scene-setup` opts out
+  of three's colour management (`ColorManagement.enabled = false`) — so they were
+  sRGB→linear converted while the captured midday colours (built after the opt-out)
+  stayed raw. `lerpColors` then mixed two colour spaces and darkened/muddied golden
+  hour. The endpoints are now constructed inside `applyAtmosphericSky` under the same
+  opted-out regime, so the authored hues survive. Guarded by a new `test:sky` check.
+- **Ski trails no longer clump on fast/hitchy frames (snowtracks.ts, #181).** The
+  stamping loop emitted every missed `STAMP_SPACING` dab at the *current* position, so
+  a fast glide, a frame hitch, or the capped `0.1 s` delta stacked a clump of dabs
+  under the snowman and left the crossed segment untracked. Missed stamps are now
+  interpolated along the segment travelled that frame, with the residual carried
+  across frames so spacing stays even. New `test:snowtrails` regression check. Both
+  fixes are render-only — the physics-invariant harness stays byte-identical.
+
 ### Golden-hour ↔ midday sun cycle (#163)
 - The atmospheric sky (#2) now **gently breathes between the static midday and a
   low, warm golden hour and back** on a 90 s loop, so the light feels alive without

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -316,10 +316,19 @@ const SUN_ELEV_MIN_DEG = 14;
 // Golden-hour endpoints (the midday endpoints are captured at setup). All stay
 // bounded under the static guide so golden hour is warmer/dimmer than midday and
 // never brightens past it.
-const GOLDEN_DIR_COLOR = new THREE.Color(0xffc89e);     // warm low sun
+//
+// The colour endpoints are kept as hex and turned into THREE.Color objects inside
+// applyAtmosphericSky — NOT at module load. scene-setup opts out of three's colour
+// management (`ColorManagement.enabled = false`) only when setupScene() runs, which
+// is *after* this module is imported. Building Color endpoints up here would convert
+// the sRGB hex into linear working space, while the captured midday colours are built
+// after the opt-out and stay raw; lerpColors would then mix two colour spaces and
+// render golden hour muddy/dark. Constructing both under the same opted-out regime
+// keeps the authored hues. (codex review, #163.)
+const GOLDEN_DIR_COLOR_HEX = 0xffc89e;                  // warm low sun
 const GOLDEN_DIR_INTENSITY_FACTOR = 0.8;                // × captured midday intensity (dimmer)
 const GOLDEN_EXPOSURE = 0.38;                           // < captured midday exposure
-const GOLDEN_FOG_COLOR = new THREE.Color(0xe6dcc8);     // warm pale haze, still soft
+const GOLDEN_FOG_COLOR_HEX = 0xe6dcc8;                  // warm pale haze, still soft
 
 interface SunCycle {
   material: THREE.ShaderMaterial;
@@ -329,6 +338,10 @@ interface SunCycle {
   enabled: boolean;
   reducedMotion: boolean;
   elapsed: number;
+  // Golden-hour colour endpoints, built under the same colour-management regime as
+  // the captured midday colours below so lerpColors stays in one colour space.
+  goldenDirColor: THREE.Color;
+  goldenFogColor: THREE.Color;
   // Captured static-midday snapshot (the cycle's bright endpoint).
   midday: {
     sunDir: THREE.Vector3;   // unit
@@ -396,10 +409,10 @@ function applyProgress(c: SunCycle, p: number): void {
     m.dirIntensity,
     p
   );
-  c.directionalLight.color.lerpColors(GOLDEN_DIR_COLOR, m.dirColor, p);
-  c.fog.color.lerpColors(GOLDEN_FOG_COLOR, m.fogColor, p);
+  c.directionalLight.color.lerpColors(c.goldenDirColor, m.dirColor, p);
+  c.fog.color.lerpColors(c.goldenFogColor, m.fogColor, p);
   if (c.scene.background instanceof THREE.Color) {
-    c.scene.background.lerpColors(GOLDEN_FOG_COLOR, m.bgColor, p);
+    c.scene.background.lerpColors(c.goldenFogColor, m.bgColor, p);
   }
 }
 
@@ -449,6 +462,10 @@ function applyAtmosphericSky(
     enabled: options.enabled ?? SUN_CYCLE_ENABLED,
     reducedMotion: options.reducedMotion ?? detectReducedMotion(),
     elapsed: 0,
+    // Built here (after scene-setup's ColorManagement opt-out) so they share the
+    // captured midday colours' regime — see GOLDEN_*_HEX.
+    goldenDirColor: new THREE.Color(GOLDEN_DIR_COLOR_HEX),
+    goldenFogColor: new THREE.Color(GOLDEN_FOG_COLOR_HEX),
     midday: {
       sunDir: pos.clone().normalize(),
       distance: pos.length(),

--- a/src/snowtracks.ts
+++ b/src/snowtracks.ts
@@ -211,21 +211,46 @@ export class SnowTrails {
         const dx = px - this.lastX;
         const dz = pz - this.lastZ;
         const moved = Math.sqrt(dx * dx + dz * dz);
-        this.sinceStamp += moved;
+        const prevX = this.lastX;
+        const prevZ = this.lastZ;
         this.lastX = px;
         this.lastZ = pz;
-        if (moved / Math.max(delta, 1e-3) > MIN_SPEED) {
-          while (this.sinceStamp >= STAMP_SPACING) {
-            this.sinceStamp -= STAMP_SPACING;
-            // Two grooves, offset left/right of travel by the ski gauge.
-            const sin = Math.sin(heading);
-            const cos = Math.cos(heading);
-            // Lateral (cross-track) offset = perpendicular to heading in XZ.
-            const offX = cos * SKI_HALF_GAUGE;
-            const offZ = -sin * SKI_HALF_GAUGE;
-            this.stampDab(px + offX, pz + offZ, heading);
-            this.stampDab(px - offX, pz - offZ, heading);
+        if (moved > 0 && moved / Math.max(delta, 1e-3) > MIN_SPEED) {
+          // Lay each missed stamp ALONG the segment travelled this frame, not all at
+          // the current position. A fast or hitchy frame (or the capped 0.1s delta)
+          // can cover several `STAMP_SPACING`s at once; stamping them all at `px/pz`
+          // stacked a clump of dabs under the snowman and left the crossed segment
+          // untracked (grooves became blobs + gaps). `sinceStamp` carries the residual
+          // distance across frames so spacing stays even. (codex review, #181.)
+          const inv = 1 / moved;
+          const ux = dx * inv;
+          const uz = dz * inv;
+          // Two grooves, offset left/right of travel by the ski gauge.
+          const sin = Math.sin(heading);
+          const cos = Math.cos(heading);
+          // Lateral (cross-track) offset = perpendicular to heading in XZ.
+          const offX = cos * SKI_HALF_GAUGE;
+          const offZ = -sin * SKI_HALF_GAUGE;
+          // First stamp completes the spacing left over from the previous frame.
+          let dist = STAMP_SPACING - this.sinceStamp;
+          if (dist > moved) {
+            this.sinceStamp += moved;
+          } else {
+            let lastDist = 0;
+            while (dist <= moved) {
+              const sx = prevX + ux * dist;
+              const sz = prevZ + uz * dist;
+              this.stampDab(sx + offX, sz + offZ, heading);
+              this.stampDab(sx - offX, sz - offZ, heading);
+              lastDist = dist;
+              dist += STAMP_SPACING;
+            }
+            this.sinceStamp = moved - lastDist;
           }
+        } else {
+          // Creeping/stopped: accumulate travel (capped) but don't lay grooves at a
+          // crawl, and don't let a backlog build up that would dump on the next glide.
+          this.sinceStamp = Math.min(this.sinceStamp + moved, STAMP_SPACING);
         }
       }
     } else {

--- a/tests/sky-cycle-tests.js
+++ b/tests/sky-cycle-tests.js
@@ -170,6 +170,30 @@ function test(name, fn) {
   });
 
   // -------------------------------------------------------------------------
+  test('golden colour endpoints honour the scene colour-management opt-out (codex #163)', () => {
+    // Production builds the scene with three colour management OFF (scene-setup opts
+    // out before lights/fog are created). sky.ts is imported earlier, while CM is
+    // still ON — so a module-scope golden Color endpoint would be linearised at
+    // import and, lerped against the raw captured midday colours, render golden hour
+    // muddy/dark. The endpoints must be built inside applyAtmosphericSky, under the
+    // same opted-out regime, so their raw RGB matches the authored hex.
+    const prevCM = THREE.ColorManagement.enabled;
+    try {
+      THREE.ColorManagement.enabled = false;
+      const { scene, directional } = makeScene();
+      Sky.applyAtmosphericSky(scene, directional);
+      Sky.update(Sky.CYCLE_DURATION_S / 2); // golden hour, p == 0 → endpoints exactly
+      const close = (a, b, label) =>
+        assert.ok(Math.abs(a.r - b.r) < 1e-6 && Math.abs(a.g - b.g) < 1e-6 && Math.abs(a.b - b.b) < 1e-6,
+          `${label}: got (${a.r},${a.g},${a.b}) vs raw (${b.r},${b.g},${b.b}) — colour spaces mixed`);
+      close(scene.fog.color, new THREE.Color(0xe6dcc8), 'golden fog raw-sRGB');
+      close(directional.color, new THREE.Color(0xffc89e), 'golden sun raw-sRGB');
+    } finally {
+      THREE.ColorManagement.enabled = prevCM;
+    }
+  });
+
+  // -------------------------------------------------------------------------
   test('golden hour does not wash the whole mountain warm (fill stays static & cool)', () => {
     const { scene, ambient, hemisphere, directional } = makeScene();
     Sky.applyAtmosphericSky(scene, directional);

--- a/tests/snowtrails-tests.js
+++ b/tests/snowtrails-tests.js
@@ -113,6 +113,27 @@ async function main() {
     assert(trails.activeCount() >= 2, 'moving on the ground should stamp dab pairs');
   });
 
+  runTest('A fast/hitchy frame spreads its dabs along the path, not stacked (#181)', () => {
+    const trails = makeTrails(220);
+    trails.update(0.1, snowmanAt(0, 0), false);    // anchor
+    // One frame covering ~10x STAMP_SPACING (a hitch / fast glide / capped delta).
+    trails.update(0.1, snowmanAt(0, -11), false);
+    assert(trails.activeCount() >= 10, `a fast frame should lay many dabs, got ${trails.activeCount()}`);
+    // Collect the z of every *active* dab (non-zero scale in its instance matrix).
+    const m = new THREE.Matrix4();
+    const zs = [];
+    for (let i = 0; i < trails.count; i++) {
+      trails.mesh.getMatrixAt(i, m);
+      const e = m.elements;
+      if (Math.hypot(e[0], e[1], e[2]) > 1e-4) zs.push(e[14]); // e[14] = z
+    }
+    const maxZ = Math.max(...zs); // nearest the segment start (~ -1.1)
+    const minZ = Math.min(...zs); // nearest the segment end   (~ -11)
+    // The pre-fix code stamped every miss at the endpoint, so the span was ~0.
+    assert(maxZ - minZ > 5, `dabs must spread along the 11-unit path; span was ${(maxZ - minZ).toFixed(2)}`);
+    assert(maxZ > -3, `a dab should land near the segment start; nearest was z=${maxZ.toFixed(2)}`);
+  });
+
   runTest('Dabs conform to the terrain slope (not left flat)', () => {
     // Terrain that drops along +z (height = -0.2*z) => surface normal tilts in z.
     const trails = new SnowTrails(new THREE.Scene(), 40);


### PR DESCRIPTION
Two codex review P2s were left unaddressed when the snow/light stack merged (I gated those merges on CI, not on the codex reviews). Both are cosmetic / render-only and now fixed with regression tests that fail on the pre-fix code. The physics-invariant harness stays byte-identical.

## 1. Golden hour rendered muddy — `src/sky.ts` (#163)
The sun cycle's golden-hour `THREE.Color` endpoints were constructed at **module load**, before `scene-setup` runs `THREE.ColorManagement.enabled = false`. So they were sRGB→linear converted, while the captured midday colours (built after the opt-out) stayed raw — `lerpColors` then blended two colour spaces and rendered golden hour darker/muddier than the authored hex (ironically the "muddy snow" failure mode the plan warns against).

**Fix:** build the golden endpoints inside `applyAtmosphericSky`, under the same opted-out regime as the captured midday colours. New `test:sky` check toggles `ColorManagement` and asserts the golden fog/sun match the raw authored hex — it fails on the pre-fix linearised values `(0.79, 0.72, 0.58)` vs raw `(0.90, 0.86, 0.78)`.

## 2. Ski trails clump on fast/hitchy frames — `src/snowtracks.ts` (#181)
The stamping loop emitted every missed `STAMP_SPACING` dab at the **current** `px/pz`, so a fast glide, a frame hitch, or the capped `0.1 s` delta stacked a clump of dabs under the snowman and left the crossed segment untracked (grooves became blobs + gaps).

**Fix:** interpolate missed stamps **along the segment** travelled that frame, carrying the residual distance across frames so spacing stays even. New `test:snowtrails` check asserts the dabs spread along an 11-unit path instead of stacking at the endpoint.

## Gates
`typecheck` ✓ · `lint` 0 errors ✓ · `test:sky` 11/11 ✓ · `test:snowtrails` 12/12 ✓ · physics-invariant harness byte-identical ✓. Each regression test was verified to fail on the old code and pass on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)