### PR TITLE
Show realistic units in Game Stats (speed, altitude, time)

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
     <div id="gameStatsContent">
       <div class="stat-item">
         <span class="stat-label">Current Time</span>
-        <span id="currentTime" class="stat-value">0.00s</span>
+        <span id="currentTime" class="stat-value">0.0s</span>
       </div>
       <div class="stat-item">
         <span class="stat-label">Best Time</span>
@@ -128,11 +128,11 @@
       </div>
       <div class="stat-item">
         <span class="stat-label">Speed</span>
-        <span id="speedValue" class="stat-value">0.0</span>
+        <span id="speedValue" class="stat-value">0 km/h (0 mph)</span>
       </div>
       <div class="stat-item">
-        <span class="stat-label">Position</span>
-        <span id="positionValue" class="stat-value">0,0</span>
+        <span class="stat-label">Altitude</span>
+        <span id="altitudeValue" class="stat-value">0 m (0 ft)</span>
       </div>
       <div class="stat-item">
         <span class="stat-label">Status</span>

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6,11 +6,31 @@
 import type { PlayerPos, UpdateResult } from '../snowman.js';
 import { setupCollapsiblePanel } from './collapsible-panel.js';
 
+// --- Real-world units for the Game Stats readout ---
+// The simulation runs in metric world units where 1 unit ≈ 1 metre (the same
+// scale the course HUD already uses for its "… m to finish" distance) and
+// velocities are in metres per second (gravity is modelled at 9.8 m/s²). We
+// surface both metric and imperial so the numbers read like real skiing stats.
+const MPS_TO_KMH = 3.6;          // metres/second → km/h
+const MPS_TO_MPH = 2.236936;     // metres/second → mph
+const M_TO_FT = 3.280839895;     // metres → feet
+// Display anchor so altitude reads like a real alpine elevation and never goes
+// negative on the lower half of the run (terrain drops below the y=0 plane far
+// downhill). Cosmetic only — it shifts the readout, not the physics.
+const BASE_ELEVATION_M = 1500;
+
+// Format a run time for the Game Stats panel. One decimal is plenty of
+// precision for the live readout, and keeps the values consistent wherever the
+// panel's time elements are written.
+export function formatStatTime(seconds: number): string {
+  return seconds !== Infinity ? `${seconds.toFixed(1)}s` : '--';
+}
+
 // Seed the best-time readout and wire up the Game Stats panel collapse/swipe.
 export function initializeGameStats(bestTime: number): void {
   const bestTimeElement = document.getElementById('bestTimeValue');
   if (bestTimeElement) {
-    bestTimeElement.textContent = bestTime !== Infinity ? `${bestTime.toFixed(2)}s` : '--';
+    bestTimeElement.textContent = formatStatTime(bestTime);
   }
 
   // Game stats panel collapse/swipe behavior (shared with the Controls panel).
@@ -36,11 +56,12 @@ export function initializeControlsToggle(): void {
   });
 }
 
-// Per-frame stats readout: color-coded speed, x/z position, and the ground /
+// Per-frame stats readout: color-coded speed, altitude, and the ground /
 // jump / ski-technique indicator.
 export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: boolean): void {
-  // Format speed with color based on value
-  const speed = result.currentSpeed.toFixed(1);
+  // Convert the metric world speed into real skiing units (km/h and mph).
+  const speedMps = result.currentSpeed;
+  const speedText = `${Math.round(speedMps * MPS_TO_KMH)} km/h (${Math.round(speedMps * MPS_TO_MPH)} mph)`;
   let speedColor = '#FFFFFF'; // Default white
 
   // Color code speed (green for slow, yellow for medium, red for fast)
@@ -55,13 +76,15 @@ export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: bo
   // Update individual stat elements
   const speedElement = document.getElementById('speedValue');
   if (speedElement) {
-    speedElement.textContent = speed;
+    speedElement.textContent = speedText;
     speedElement.style.color = speedColor;
   }
 
-  const positionElement = document.getElementById('positionValue');
-  if (positionElement) {
-    positionElement.textContent = `${pos.x.toFixed(0)},${pos.z.toFixed(0)}`;
+  // Altitude (height above the run's base elevation) in metres and feet.
+  const altitudeElement = document.getElementById('altitudeValue');
+  if (altitudeElement) {
+    const altitudeM = BASE_ELEVATION_M + pos.y;
+    altitudeElement.textContent = `${Math.round(altitudeM)} m (${Math.round(altitudeM * M_TO_FT)} ft)`;
   }
 
   const groundElement = document.getElementById('groundStatus');
@@ -95,13 +118,13 @@ export function updateTimerDisplay(gameActive: boolean, startTime: number, bestT
     // Update the current time element in game stats
     const currentTimeElement = document.getElementById('currentTime');
     if (currentTimeElement) {
-      currentTimeElement.textContent = `${currentTime.toFixed(2)}s`;
+      currentTimeElement.textContent = formatStatTime(currentTime);
     }
 
     // Keep best time updated
     const bestTimeElement = document.getElementById('bestTimeValue');
     if (bestTimeElement) {
-      bestTimeElement.textContent = bestTime !== Infinity ? `${bestTime.toFixed(2)}s` : '--';
+      bestTimeElement.textContent = formatStatTime(bestTime);
     }
   }
 }

--- a/src/ui/result-overlay.ts
+++ b/src/ui/result-overlay.ts
@@ -7,6 +7,7 @@
 import { AudioModule } from '../audio.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
+import { formatStatTime } from './hud.js';
 
 // Add timer and best time tracking (state.startTime / state.bestTime)
 const MIN_VALID_SCORE_TIME = 4;
@@ -164,7 +165,7 @@ export function createShowGameOver(deps: ResultOverlayDeps): (reason: string) =>
         // Update the best time in the game stats window too
         const bestTimeElement = document.getElementById('bestTimeValue');
         if (bestTimeElement) {
-          bestTimeElement.textContent = `${state.bestTime.toFixed(2)}s`;
+          bestTimeElement.textContent = formatStatTime(state.bestTime);
           bestTimeElement.style.color = '#ffff00'; // Highlight new record
         }
       } else {


### PR DESCRIPTION
## What & why

The **Game Stats** panel showed raw simulation numbers — speed as a unitless value and "Position" as raw `x,z` world coordinates — neither of which reads like real skiing telemetry. Time also used two decimals, more precision than the live readout needs.

This makes the panel read like real ski stats:

| Before | After |
| --- | --- |
| Speed `30.0` | Speed `30 km/h (18 mph)` |
| Position `0,-42` | Altitude `1524 m (4999 ft)` |
| Current Time `9.04s` | Current Time `9.0s` |

![Game Stats panel](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/stats-units-shots/stats-panel.png)

## Details

- **Speed** → convert the metric world velocity (m/s) to **km/h and mph** (`m/s × 3.6` / `× 2.237`), keeping the existing slow/medium/fast color coding.
- **Position → Altitude** → show the player's height in **m and ft** (element id `positionValue` → `altitudeValue`, label `Position` → `Altitude`). Anchored with a `BASE_ELEVATION_M = 1500` so the readout stays positive and reads like an alpine run — terrain drops below the `y=0` plane on the lower half of the course, which would otherwise show a negative altitude. **Cosmetic only; physics untouched.**
- **Scale** — `1 world unit ≈ 1 m`, matching the course HUD's existing `"… m to finish"` distance and the metric physics (`gravity = 9.8 m/s²`).
- **Time** → one decimal instead of two for the panel's **Current Time / Best Time**, via a shared `formatStatTime()` helper reused by the result overlay's panel update.

Both unit systems are shown (`km/h (mph)`, `m (ft)`) per request.

## Scope note

This changes the **Game Stats panel** only (as requested). The result screen's own time lines (`Your Time: …`, `New Best Time: …`) and the course split times still use two decimals — happy to align those too if wanted.

## Testing

- `npm run build` — clean (type-check passes)
- `npm run lint` — 0 errors (pre-existing `any` warnings only)
- `npm test` — 44/44
- `npm run test:verify` — 44/44 (physics-invariant baseline unchanged — HUD-only change)
- Verified in-browser via headless Chrome (screenshot above): `9.0s`, `30 km/h (18 mph)`, `1524 m (4999 ft)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
