### PR TITLE
Fix build-version footer hidden at 100% zoom on the start screen

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -665,15 +665,25 @@ canvas { display: block; }
   left: 0;
   width: 100%;
   height: 100%;
+  /* Keep padding inside the 100% box so the overlay is exactly the viewport
+     size (otherwise height:100% + padding spills past the bottom edge). */
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  /* `safe` keeps the content reachable when it is taller than the viewport
+     (e.g. at 100% zoom on a short window): plain `center` would push the
+     overflow off both edges with no way to scroll up to it. `safe` falls back
+     to start-alignment in that case so the whole panel stays scrollable. */
+  justify-content: safe center;
   align-items: center;
   background-color: rgba(0, 0, 0, 0.8);
   z-index: 2000;
   color: white;
   font-family: 'Arial', sans-serif;
   padding: 10px; /* Add padding to ensure content doesn't touch the edge */
+  /* Reserve room for the fixed #buildBadge footer so scrolled content never
+     hides behind it. */
+  padding-bottom: 30px;
   overflow-y: auto; /* Allow scrolling if needed */
 }
 
@@ -880,13 +890,21 @@ canvas { display: block; }
   opacity: 0.85;
 }
 
-/* Unobtrusive build-version footer (replaces the old pill on the CTA) */
+/* Unobtrusive build-version footer (replaces the old pill on the CTA).
+   Pinned to the bottom of the viewport so it stays visible even when the start
+   panel content is taller than the screen (it used to be the last flow item and
+   got clipped off the bottom at 100% zoom). It lives inside #startGameContainer,
+   so it is still hidden along with the overlay once the game starts. */
 #buildBadge {
-  margin-top: 10px;
+  position: fixed;
+  bottom: 8px;
+  left: 0;
+  right: 0;
   font: 500 11px system-ui, sans-serif;
   letter-spacing: 0.3px;
   color: rgba(255, 255, 255, 0.45);
   text-align: center;
+  pointer-events: none; /* purely informational — never intercept clicks */
 }
 
 /* While the start overlay is up, lift the account/sign-in control above it so


### PR DESCRIPTION
## Problem
On the start screen, the `build <timestamp> UTC` footer (`#buildBadge`) was only visible when zooming the browser out to ~75%. At 100% zoom on a laptop it disappeared below the bottom edge.

**Root cause:** `#buildBadge` was the last in-flow child of `#startGameContainer` — a full-viewport `display:flex; flex-direction:column; justify-content:center; overflow-y:auto` overlay. Once the panel content (controls, ski techniques, leaderboard, hints) grew taller than the window, `justify-content:center` centered the overflow and pushed the footer off the bottom edge (the classic flex-centering scroll trap — the top is unreachable too). Zooming out shrank the content enough to fit, so the footer reappeared.

## Fix (`styles/main.css`, CSS-only)
- **Pin `#buildBadge` as a fixed bottom footer** (`position: fixed; bottom: 8px`) so it's always visible regardless of content height/zoom. It still lives inside `#startGameContainer`, so it's hidden along with the overlay once the game starts.
- **`justify-content: safe center`** so overflowing panel content stays reachable (plain `center` clips the top with no way to scroll up).
- **`box-sizing: border-box` + a `padding-bottom` reserve** so the overlay is exactly viewport-height and scrolled content never hides under the footer.

## Before / After
Same viewport (760×600), with the Global Top Times leaderboard shown to mirror the reported layout.

| Before (footer clipped off-screen) | After (footer pinned & visible) |
|---|---|
| ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/build-badge-shots/before.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/build-badge-shots/after.png) |

## Verification
- Headless Chrome at multiple viewport heights (560 / 600 / 700 / 720 / 760 / 1080), including the user's leaderboard layout: badge visible at the bottom and title reachable in every case. At 760×600 the badge bottom moved from **610px (clipped, `visible:false`)** to **592px (`visible:true`)**.
- `npm run lint` — clean (0 errors).
- `npm run test:start-menu` — 37/0 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)