### PR TITLE
feat(terrain): aperiodic domain-warped fBm ridge — kill grey banding source (#188 NS1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,26 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Aperiodic terrain ridge — kills the grey "corduroy" banding source (#188 step 3)
+- The terrain ridge in `mountains.ts` was the **periodic** `sin(x*0.2)*cos(z*0.3)`.
+  A low directional sun raked that regular plaid into repeated grey bands (the
+  `Grey corduroy` failure mode in [`SNOW_RENDERING.md`](SNOW_RENDERING.md)) and was the
+  reason the sun cycle's low-sun guard (`SUN_ELEV_MIN_DEG`, `src/sky.ts`) had to sit
+  at 14°.
+- Replaced it with a **deterministic, domain-warped fBm** (`terrainRidgeField`): the
+  ridges now meander instead of forming a lattice, so a raking light has no periodicity
+  left to band. The field uses a fixed-seed integer hash (not the `Math.random`-seeded
+  `SimplexNoise`), so the terrain is stable across page loads and the Node
+  terrain/regression tests pin its shape; it is damped toward the peak with the same
+  `(1 - exp(-distance/60))` falloff as the existing perlin layer, so the summit stays
+  smooth and relief grows down the slope.
+- Applied to **both** the physics sampler (`getTerrainHeight`, ×0.8) and the visual
+  mesh (`createTerrain`, ×1.5), keeping their existing amplitude relationship.
+- **Invariant preserved:** the no-input coasting kernel is untouched, so the physics
+  invariant harness stays byte-identical; full Node suite, production build, and the
+  browser suite (89/89) all pass. The companion change — dropping the low-sun guard
+  toward 8° and retuning golden hour — is the separate **NS2** follow-up.
+
 ### Social sharing — link previews + screenshot in the mobile share
 - Follow-up to "desktop platform menu + screenshot card" below. Three gaps made
   sharing feel broken: shared links had no preview at all, Facebook/LinkedIn

--- a/docs/SNOW_RENDERING.md
+++ b/docs/SNOW_RENDERING.md
@@ -30,15 +30,24 @@ snow form.](snow-lighting-model.svg)
 | Failure | Cause | Fix |
 |---|---|---|
 | **Whiteout** | Too much flat/soft light or ambient — terrain form disappears | Keep ambient low; let the hemisphere fill shade *by orientation*, not a uniform wash |
-| **Grey corduroy** | Hard low sun raking periodic terrain ridges into repeated grey bands | Soften the key light, smooth the *shading* normals, and remove the periodic ridge as a banding source |
+| **Grey corduroy** | Hard low sun raking periodic terrain ridges into repeated grey bands | Soften the key light, smooth the *shading* normals, and remove the periodic ridge as a banding source (the ridge is now aperiodic — see below) |
 | **Muddy snow** | Neutral grey shadows instead of cool blue ones | Shadows are filled by a cool-blue hemisphere sky color, never neutral grey |
 
 The "grey lines" that survived the snow *texture* fix (#17) were terrain **shadows**,
 not a texture: every mogul lit on one side and greyed on the other, made periodic by
-the regular `sin(x * 0.2) * cos(z * 0.3)` terrain ridge. They were addressed by
+the regular `sin(x * 0.2) * cos(z * 0.3)` terrain ridge. They were first addressed by
 (a) smoothing the *shading* normals while leaving the skiable height field untouched,
-and (b) the light rebalance below. Fully replacing that periodic ridge with
-fBm/domain-warp terrain remains a follow-up.
+and (b) the light rebalance below.
+
+The banding *source* itself — that periodic ridge — has now been removed (issue #188
+step 3): `mountains.ts` replaces `sin(x * 0.2) * cos(z * 0.3)` with a **deterministic
+domain-warped fBm** (`terrainRidgeField`), so the ridges meander instead of forming a
+regular lattice and a low sun has no periodicity left to rake into corduroy. The field
+is fixed-seed (an integer hash, not the `Math.random`-seeded SimplexNoise) so terrain
+is stable across loads and the Node terrain/regression tests pin its shape, and it is
+damped toward the peak like the existing perlin layer (smooth summit, relief growing
+down-slope). This is what lets the sun cycle's low-sun guard drop from 14° toward 8°
+(the guard change + golden-hour retune is the separate NS2 follow-up).
 
 ## The merged static lighting (source of truth: `scene-setup.ts`)
 

--- a/src/mountains.ts
+++ b/src/mountains.ts
@@ -179,6 +179,66 @@ class SimplexNoise {
   }
 }
 
+// --- Deterministic aperiodic ridge field (issue #188 step 3) ---
+//
+// The terrain ridge used to be the *periodic* `Math.sin(x * 0.2) * Math.cos(z * 0.3)`.
+// A low directional sun raked that regular plaid into repeated grey "corduroy" bands
+// (the `Grey corduroy` failure mode in docs/SNOW_RENDERING.md) and pinned the sun
+// cycle's low-sun guard at 14° (`SUN_ELEV_MIN_DEG`, src/sky.ts). This replaces it with
+// a *deterministic* domain-warped fBm so the ridges meander instead of forming a
+// regular lattice — no periodicity, so nothing for a raking light to band, and a more
+// natural backcountry surface. It is deliberately deterministic (a fixed-seed integer
+// hash, NOT the `Math.random`-seeded SimplexNoise above) so the terrain is stable
+// across page loads and the Node terrain/regression tests can pin its shape.
+
+// Integer-lattice hash -> [0, 1). All 32-bit (Math.imul) so it is bit-exact and
+// deterministic for the same (ix, iz), including negative coordinates.
+function hashLattice(ix: number, iz: number): number {
+  let h = Math.imul(ix | 0, 0x27d4eb2d) ^ Math.imul(iz | 0, 0x165667b1);
+  h = Math.imul(h ^ (h >>> 15), 0x85ebca6b);
+  h ^= h >>> 13;
+  h = Math.imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+  return (h >>> 0) / 4294967296;
+}
+
+// Smooth (smoothstep-interpolated) value noise in [-1, 1].
+function valueNoise(x: number, z: number): number {
+  const x0 = Math.floor(x), z0 = Math.floor(z);
+  const fx = x - x0, fz = z - z0;
+  const u = fx * fx * (3 - 2 * fx);
+  const w = fz * fz * (3 - 2 * fz);
+  const n00 = hashLattice(x0, z0), n10 = hashLattice(x0 + 1, z0);
+  const n01 = hashLattice(x0, z0 + 1), n11 = hashLattice(x0 + 1, z0 + 1);
+  const nx0 = n00 + (n10 - n00) * u;
+  const nx1 = n01 + (n11 - n01) * u;
+  return (nx0 + (nx1 - nx0) * w) * 2 - 1;
+}
+
+// Fractional Brownian motion: 3 octaves, lacunarity 2, gain 0.5, normalized to ~[-1, 1].
+function fbm(x: number, z: number): number {
+  let sum = 0, amp = 0.5, freq = 1, norm = 0;
+  for (let o = 0; o < 3; o++) {
+    sum += amp * valueNoise(x * freq, z * freq);
+    norm += amp;
+    freq *= 2;
+    amp *= 0.5;
+  }
+  return sum / norm;
+}
+
+// The aperiodic ridge field in ~[-1, 1] that replaces `sin(x*0.2)*cos(z*0.3)`.
+// A low-frequency fBm warps the domain so the ridges curve and meander (natural
+// backcountry), and the warped fBm supplies the medium/fine relief.
+const RIDGE_FREQ = 0.06;   // base ridge scale (octaves add detail down to ~4u)
+const RIDGE_WARP_FREQ = 0.03;
+const RIDGE_WARP_AMP = 8;
+export function terrainRidgeField(x: number, z: number): number {
+  const wx = fbm(x * RIDGE_WARP_FREQ, z * RIDGE_WARP_FREQ);
+  const wz = fbm(x * RIDGE_WARP_FREQ + 5.2, z * RIDGE_WARP_FREQ - 3.7);
+  return fbm((x + wx * RIDGE_WARP_AMP) * RIDGE_FREQ, (z + wz * RIDGE_WARP_AMP) * RIDGE_FREQ);
+}
+
 // --- Terrain utilities ---
 
 // Global height map for efficient lookup - will be populated when terrain is created
@@ -201,8 +261,10 @@ function getTerrainHeight(x: number, z: number): number {
   // Add noise for natural backcountry terrain
   y += 1.5 * Math.sin(x * 0.05) * Math.cos(z * 0.05) * (1 - Math.exp(-distance / 60));
   
-  // Add additional terrain features and ridges
-  y += Math.sin(x * 0.2) * Math.cos(z * 0.3) * 0.8;
+  // Add additional terrain features and ridges (aperiodic — see terrainRidgeField).
+  // Damped toward the peak (like the low-freq term + mesh perlin) so the summit stays
+  // smooth and the relief grows down the slope where it reads as backcountry terrain.
+  y += terrainRidgeField(x, z) * 0.8 * (1 - Math.exp(-distance / 60));
   
   // Ensure downhill gradient in extended sections - create a consistent downhill slope
   // This factor increases the further (more negative) z gets, creating a gradual slope
@@ -484,8 +546,9 @@ function createTerrain(scene: THREE.Scene) {
     const key = `${Math.round(x*10)},${Math.round(z*10)}`;
     heightMap[key] = y;
     
-    // Add natural terrain features and ridges
-    y += Math.sin(x * 0.2) * Math.cos(z * 0.3) * 1.5;
+    // Add natural terrain features and ridges (aperiodic — see terrainRidgeField).
+    // Damped toward the peak like the perlin roughness above (same distance falloff).
+    y += terrainRidgeField(x, z) * 1.5 * (1 - Math.exp(-distance / 60));
     
     // Ensure downhill gradient in extended sections - create a consistent downhill slope
     // Must match getTerrainHeight implementation exactly!

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -307,10 +307,13 @@ function createAtmosphericSky(sunDirection: THREE.Vector3): THREE.Mesh {
 const SUN_CYCLE_ENABLED = true;
 const CYCLE_DURATION_S = 90;          // one full midday → golden → midday loop
 
-// Low-sun guard. The terrain still has the periodic `sin(x*0.2)*cos(z*0.3)`
-// ridge that bands under a hard low sun, so the golden-hour sun is held at a
-// safe elevation (issue #188: 12–15° until fBm/domain-warp terrain lands; 8° is
-// only allowed once that ridge is gone or visually proven safe).
+// Low-sun guard. The periodic `sin(x*0.2)*cos(z*0.3)` terrain ridge that used to
+// band under a hard low sun has been replaced by an aperiodic domain-warped fBm
+// (issue #188 step 3 / mountains.ts `terrainRidgeField`), so the banding source is
+// gone. The guard is still held at 14° here on purpose: lowering it toward 8° and
+// retuning the golden-hour endpoints (with a fresh `test:sky` capture) is the
+// separate NS2 follow-up, kept out of the terrain-only change so the sun-cycle
+// tests stay untouched.
 const SUN_ELEV_MIN_DEG = 14;
 
 // Golden-hour endpoints (the midday endpoints are captured at setup). All stay

--- a/tests/terrain-tests.js
+++ b/tests/terrain-tests.js
@@ -29,6 +29,7 @@ async function loadUtils() {
 // so it shadows the read-only `Utils` global instead of reassigning it.
 (async () => {
 const Utils = await loadUtils();
+const { terrainRidgeField } = await import('../src/mountains.js');
 
 // Custom assert functions
 function assert(condition, message) {
@@ -307,6 +308,52 @@ runTest('Collidable rocks avoid the ski line and spawn pocket', () => {
   assert(!isHazard(5.1, -150, 3.0), 'a size-3 rock at x=5.1 reaches into the |x|<5 ski lane, so it is excluded');
   assert(!isHazard(12, -15, 3.0), 'a size-3 rock 12u from the start reaches into the spawn pocket, so it is excluded');
   assert(isHazard(8.5, -150, 3.0), 'a size-3 rock fully clear of the corridor + radius is still a hazard');
+});
+
+// Test 9: Aperiodic ridge field (issue #188 step 3)
+// The terrain ridge used to be the periodic sin(x*0.2)*cos(z*0.3); it is now a
+// deterministic domain-warped fBm. Lock in the three properties the banding fix
+// depends on: deterministic, bounded, and genuinely aperiodic.
+runTest('Aperiodic ridge field', () => {
+  assert(typeof terrainRidgeField === 'function', 'mountains exports terrainRidgeField');
+
+  // Deterministic: same input -> same output, across calls (so terrain is stable
+  // across page loads and tests can pin it).
+  assertEquals(terrainRidgeField(12.5, -73.25), terrainRidgeField(12.5, -73.25),
+    'ridge field is deterministic for the same input');
+  assertEquals(terrainRidgeField(-40, -150), terrainRidgeField(-40, -150),
+    'ridge field is deterministic at a second point');
+
+  // Bounded near [-1, 1] (it is an fBm normalized to that range) so it can keep the
+  // ±0.8 / ±1.5 amplitudes without blowing up terrain height.
+  let lo = Infinity, hi = -Infinity;
+  for (let x = -120; x <= 120; x += 7) {
+    for (let z = -200; z <= 0; z += 7) {
+      const v = terrainRidgeField(x, z);
+      assert(!isNaN(v), `ridge field is finite at (${x}, ${z})`);
+      lo = Math.min(lo, v); hi = Math.max(hi, v);
+    }
+  }
+  assert(lo >= -1.2 && hi <= 1.2, `ridge field stays bounded (got [${lo.toFixed(2)}, ${hi.toFixed(2)}])`);
+  assert(lo < -0.2 && hi > 0.2, 'ridge field actually varies (not flat)');
+
+  // Aperiodic: the OLD ridge repeated every 2π/0.2 ≈ 31.4u in x and 2π/0.3 ≈ 20.9u
+  // in z. A field with those periods would (nearly) repeat under those shifts; the
+  // domain-warped fBm must not, or a raking low sun would still band. Require a
+  // clearly non-trivial change across the would-be periods at several samples.
+  const PX = 2 * Math.PI / 0.2, PZ = 2 * Math.PI / 0.3;
+  let repeats = 0, samples = 0;
+  for (let x = -60; x <= 60; x += 11) {
+    for (let z = -180; z <= -20; z += 13) {
+      samples++;
+      const dX = Math.abs(terrainRidgeField(x, z) - terrainRidgeField(x + PX, z));
+      const dZ = Math.abs(terrainRidgeField(x, z) - terrainRidgeField(x, z + PZ));
+      if (dX < 0.02 && dZ < 0.02) repeats++;
+    }
+  }
+  // Almost no sample should look periodic at the old periods.
+  assert(repeats <= samples * 0.05,
+    `ridge field is aperiodic (${repeats}/${samples} samples looked periodic at the old ridge periods)`);
 });
 
 // Print test summary


### PR DESCRIPTION
## NS1 — Aperiodic terrain ridge (issue #188 step 3)

Implements **NS1** of the snow/light next-steps: replace the periodic terrain ridge that is the *source* of the grey "corduroy" banding under a low sun.

### Problem
The terrain ridge in `mountains.ts` was the **periodic** `Math.sin(x * 0.2) * Math.cos(z * 0.3)`. A low directional sun rakes that regular plaid into repeated grey bands — the `Grey corduroy` failure mode in [`docs/SNOW_RENDERING.md`](https://github.com/den-run-ai/snowglider/blob/main/docs/SNOW_RENDERING.md). It is also why the sun cycle's low-sun guard (`SUN_ELEV_MIN_DEG` in `src/sky.ts`) had to sit at 14°. PR #181 smoothed the *shading normals* and rebalanced the light, but left the periodic ridge itself as a follow-up.

### Change
Replace the periodic ridge with a **deterministic, domain-warped fBm** (`terrainRidgeField`):
- **Aperiodic:** a low-frequency fBm warps the domain so the ridges meander instead of forming a lattice — a raking light has no periodicity left to band.
- **Deterministic:** a fixed-seed integer hash (`Math.imul`-based), *not* the `Math.random`-seeded `SimplexNoise`, so terrain is stable across page loads and the Node terrain/regression tests pin its shape.
- **Peak-damped:** multiplied by the same `(1 - exp(-distance/60))` falloff as the existing perlin layer, so the summit stays smooth and relief grows down the slope (this also keeps the near-peak gradient small).
- Applied to **both** the physics sampler (`getTerrainHeight`, ×0.8) and the visual mesh (`createTerrain`, ×1.5), preserving their existing amplitude relationship.

### Scope / what this is NOT
This is the terrain-only change. **Dropping the low-sun guard from 14° → 8° and retuning golden hour (with a fresh `test:sky` capture) is the separate NS2 follow-up** — deliberately kept out so the sun-cycle tests stay untouched. The guard comment in `sky.ts` is updated to reflect that the banding source is now gone.

### Safety / invariants
- **No-input coasting kernel is untouched** → the physics invariant harness stays **byte-identical** (`Invariant: coasting … IDENTICAL ✅`). The snowman kernel and its frozen baseline are not involved.
- In-game terrain already varied per load (random perlin + bumps); this change keeps that and only swaps the ridge term.

### Tests
- `npm test` — full Node suite, **all suites 0 failed** (incl. terrain, regression, physics, `test:verify`).
- New **`Aperiodic ridge field`** contract test in `tests/terrain-tests.js`: deterministic, bounded `~[-1,1]`, and *aperiodic* (asserts the field does not repeat at the old `sin(x*0.2)*cos(z*0.3)` periods).
- `npm run build` — production build OK.
- `npm run test:browser` — **89 passed, 0 failed, 7/7 suites**.

Screenshots (before/after low-sun terrain) to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)