### PR TITLE
Shaped skis: sidecut/camber/shovel/tail + cosmetic flex (#189)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,28 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Shaped skis — sidecut / camber / shovel / tail + cosmetic flex (#189)
+- The snowman's skis were two flat red `BoxGeometry` slabs with an angled box glued
+  on the front. They are now real ski shapes built from a **custom lofted
+  `BufferGeometry`** (`src/snowman/model.ts`, `buildSkiArm`): a sidecut top view
+  (wide shovel → narrow waist → medium tail), a smooth shovel/tip rise, a small tail
+  kick, rounded end caps, and a visible binding (plate + boot). Three materials give
+  a red top-sheet, a dark sintered base, and a steel-edge line accent (geometry
+  material groups).
+- Each ski is a **pose-owned root group** holding two pivot arms (tip + tail) that
+  overlap at the waist and are hidden under the binding, so the surface reads as one
+  continuous ski with no visible seam. `pose.ts` still owns the root transform
+  (snowplow wedge / parallel edge + draw); the arms only bend.
+- The cosmetic flex layer (`src/snowman-flex.ts`) gains a **ski-flex pass** that writes
+  *only* the arms' `rotation.x`: a gentle camber arch while gliding (with speed-chatter),
+  a reverse-camber compression spring on landings, tip-pressure in carves (scaled by
+  turn rate), a flatter/planted snowplow, and a de-cambered airborne ski. It never
+  touches position/velocity, honors `prefers-reduced-motion`, and leaves the
+  physics-invariant harness byte-identical (no baseline regeneration).
+- Tests: `tests/snowman-flex-tests.js` adds ski arms to the stub and asserts the
+  flex writes rotation only (position/scale/yaw/roll stay at base), a glide arch
+  appears, a carve adds tip-pressure, and `reset()` restores the arms.
+
 ### Aperiodic terrain ridge — kills the grey "corduroy" banding source (#188 step 3)
 - The terrain ridge in `mountains.ts` was the **periodic** `sin(x*0.2)*cos(z*0.3)`.
   A low directional sun raked that regular plaid into repeated grey bands (the
@@ -32,7 +54,6 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   invariant harness stays byte-identical; full Node suite, production build, and the
   browser suite (89/89) all pass. The companion change — dropping the low-sun guard
   toward 8° and retuning golden hour — is the separate **NS2** follow-up.
-
 ### Social sharing — link previews + screenshot in the mobile share
 - Follow-up to "desktop platform menu + screenshot card" below. Three gaps made
   sharing feel broken: shared links had no preview at all, Facebook/LinkedIn

--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -29,7 +29,11 @@ export interface FlexMotion {
 
 interface XYZ { x: number; y: number; z: number; }
 interface BaseTransform { position: XYZ; scale: XYZ; rotation: XYZ; }
-interface FlexState { t: number; settle: number; settleVel: number; leanZ: number; lagY: number; }
+interface FlexState {
+  t: number; settle: number; settleVel: number; leanZ: number; lagY: number;
+  // Ski flex (issue #189): a smoothed base camber + a landing compression spring.
+  skiCamber: number; skiSettle: number; skiSettleVel: number;
+}
 
 const finite = (n: number): number => (Number.isFinite(n) ? n : 0);
 const clamp = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, n));
@@ -54,10 +58,35 @@ const LEAN_GLIDE = 0.5;         // fraction of the lean kept when not actively c
 const BALLS: ReadonlyArray<string> = ['bottom', 'middle', 'head'];
 const BALL_PHASE: ReadonlyArray<number> = [0, 1.1, 2.2]; // stagger so the stack ripples
 
+// --- ski flex tuning (issue #189) -------------------------------------------
+// The skis are split (in model.ts) into a tip arm (extends +z) and a tail arm (extends
+// -z) that pivot at the waist. Bending an arm's rotation.x raises/lowers that end:
+// for the +z tip a NEGATIVE angle lifts it, for the -z tail a POSITIVE angle lifts it,
+// so a positive "camber" lifts BOTH ends into an arch. Landing pushes camber negative
+// (reverse-camber compression); a carve adds tip-pressure (the shovel digs down).
+const SKI_CAMBER_GLIDE = 0.06;   // gentle unweighted arch while gliding
+const SKI_CAMBER_PLOW = 0.025;   // snowplow sits flatter / planted
+const SKI_CAMBER_AIR = 0.0;      // airborne ski de-cambers (relaxes flat)
+const SKI_TIP_GAIN = 1.0;        // tip-arm angle per unit camber
+const SKI_TAIL_GAIN = 0.8;       // tail kicks a little less than the shovel
+const SKI_CHATTER_FREQ = 34;     // rad/s of the speed-chatter vibration
+const SKI_CHATTER_AMP = 0.012;   // chatter amplitude at full speed
+const SKI_TIP_PRESS = 0.11;      // extra shovel bend in a full-rate carve
+const SKI_SETTLE_K = 60;         // landing-spring stiffness (skis)
+const SKI_SETTLE_C = 11;         // landing-spring damping (skis)
+const SKI_SETTLE_CLAMP = 0.18;   // max reverse-camber from a landing
+const SKI_ARM_CLAMP = 0.5;       // hard clamp on any ski-arm bend (rad)
+const SKI_TIP_PARTS: ReadonlyArray<string> = ['leftSkiTip', 'rightSkiTip'];
+const SKI_TAIL_PARTS: ReadonlyArray<string> = ['leftSkiTail', 'rightSkiTail'];
+
 function getState(ud: Record<string, unknown>): FlexState {
   let fs = ud.flex as FlexState | undefined;
-  if (!fs) { fs = { t: 0, settle: 0, settleVel: 0, leanZ: 0, lagY: 0 }; ud.flex = fs; }
+  if (!fs) { fs = freshState(); ud.flex = fs; }
   return fs;
+}
+
+function freshState(): FlexState {
+  return { t: 0, settle: 0, settleVel: 0, leanZ: 0, lagY: 0, skiCamber: SKI_CAMBER_GLIDE, skiSettle: 0, skiSettleVel: 0 };
 }
 
 function prefersReducedMotion(): boolean {
@@ -135,6 +164,43 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
     const swing = clamp(-turn * 0.4 + Math.sin(fs.t * 7.0) * 0.12 * (0.4 + speedN), -0.6, 0.6);
     tail.rotation.set(tb.rotation.x + (air ? -0.3 : 0.1), tb.rotation.y, tb.rotation.z + swing);
   }
+
+  // --- Ski flex (issue #189) -------------------------------------------------
+  // Bend the tip/tail arms (rotation.x ONLY) for camber, landing compression, and carve
+  // tip-pressure. The ski ROOT transform stays untouched (pose.ts owns the snowplow
+  // wedge / parallel edge + draw). Present-or-absent: no-ops on a snowman without arms.
+  if (parts.leftSkiTip || parts.rightSkiTip) {
+    const snowplow = !air && m.technique === 'snowplow';
+    const carving = !air && (m.technique === 'carve' || m.technique === 'parallel' || m.technique === 'skid');
+
+    // Smooth the resting camber between techniques so changes don't snap.
+    const camberTarget = air ? SKI_CAMBER_AIR : (snowplow ? SKI_CAMBER_PLOW : SKI_CAMBER_GLIDE);
+    fs.skiCamber += (camberTarget - fs.skiCamber) * clamp(dt * 6, 0, 1);
+    fs.skiCamber = finite(fs.skiCamber);
+
+    // Landing compression: a damped spring kicked toward reverse camber on touchdown.
+    if (m.justLanded && finite(m.landingForce) > 0.25) {
+      fs.skiSettleVel -= clamp(finite(m.landingForce) * 1.2, 0, 1.6);
+    }
+    fs.skiSettleVel += (-SKI_SETTLE_K * fs.skiSettle - SKI_SETTLE_C * fs.skiSettleVel) * dt;
+    fs.skiSettle += fs.skiSettleVel * dt;
+    fs.skiSettle = clamp(finite(fs.skiSettle), -SKI_SETTLE_CLAMP, SKI_SETTLE_CLAMP);
+    fs.skiSettleVel = finite(fs.skiSettleVel);
+
+    // Speed-chatter: a fast low-amplitude vibration of the whole arch while gliding.
+    const chatter = air ? 0 : Math.sin(fs.t * SKI_CHATTER_FREQ) * SKI_CHATTER_AMP * speedN;
+    const camber = fs.skiCamber + fs.skiSettle + chatter;       // signed arch (negative => reverse)
+    const tipPress = carving ? SKI_TIP_PRESS * Math.abs(turn) : 0; // shovel digs in mid-carve
+
+    for (const key of SKI_TIP_PARTS) {
+      const p = parts[key]; const b = base[key];
+      if (p && b) p.rotation.set(b.rotation.x + clamp(-camber * SKI_TIP_GAIN + tipPress, -SKI_ARM_CLAMP, SKI_ARM_CLAMP), b.rotation.y, b.rotation.z);
+    }
+    for (const key of SKI_TAIL_PARTS) {
+      const p = parts[key]; const b = base[key];
+      if (p && b) p.rotation.set(b.rotation.x + clamp(camber * SKI_TAIL_GAIN, -SKI_ARM_CLAMP, SKI_ARM_CLAMP), b.rotation.y, b.rotation.z);
+    }
+  }
 }
 
 /** Snap every flex-animated part back to its neutral transform and clear the flex
@@ -151,7 +217,7 @@ function reset(snowman: THREE.Object3D): void {
     p.scale.set(b.scale.x, b.scale.y, b.scale.z);
     p.rotation.set(b.rotation.x, b.rotation.y, b.rotation.z);
   }
-  ud.flex = { t: 0, settle: 0, settleVel: 0, leanZ: 0, lagY: 0 };
+  ud.flex = freshState();
 }
 
 export const Flex = { update, reset };

--- a/src/snowman/model.ts
+++ b/src/snowman/model.ts
@@ -144,43 +144,64 @@ export function createSnowman(scene: THREE.Scene): THREE.Group {
   hatTop.castShadow = true;
   group.add(hatTop);
   
-  // Add skis
-  const skiMaterial = new THREE.MeshStandardMaterial({ color: 0xFF0000 }); // Bright red
-  
-  // Left ski
-  const leftSki = new THREE.Mesh(
-    new THREE.BoxGeometry(0.8, 0.2, 6), 
-    skiMaterial
-  );
-  leftSki.position.set(-1, 0.1, 1);
-  leftSki.castShadow = true;
-  // Add ski tip (angled front)
-  const leftSkiTip = new THREE.Mesh(
-    new THREE.BoxGeometry(0.8, 0.4, 1),
-    skiMaterial
-  );
-  leftSkiTip.position.set(0, 0.2, 3);
-  leftSkiTip.rotation.x = Math.PI / 8; // Angle up slightly
-  leftSki.add(leftSkiTip);
-  group.add(leftSki);
-  
-  // Right ski
-  const rightSki = new THREE.Mesh(
-    new THREE.BoxGeometry(0.8, 0.2, 6),
-    skiMaterial
-  );
-  rightSki.position.set(1, 0.1, 1);
-  rightSki.castShadow = true;
-  // Add ski tip (angled front)
-  const rightSkiTip = new THREE.Mesh(
-    new THREE.BoxGeometry(0.8, 0.4, 1),
-    skiMaterial
-  );
-  rightSkiTip.position.set(0, 0.2, 3);
-  rightSkiTip.rotation.x = Math.PI / 8; // Angle up slightly
-  rightSki.add(rightSkiTip);
-  group.add(rightSki);
-  
+  // --- Shaped skis (issue #189) ---------------------------------------------
+  // Real ski geometry instead of two flat boxes: a custom lofted BufferGeometry
+  // with sidecut (wide shovel -> narrow waist -> medium tail), a smooth shovel/tip
+  // rise, a small tail kick, rounded end caps, a visible binding block, and three
+  // materials (red top-sheet, dark base, steel-edge accent). Each ski is a pose-owned
+  // root GROUP holding two pivot arms (tip + tail) that overlap at the waist so the
+  // surface reads as one continuous ski; the cosmetic flex layer (src/snowman-flex.ts)
+  // bends those arms (rotation.x only) for camber/landing/carve, while pose.ts still
+  // owns the root transform (snowplow wedge / parallel edge+draw). See buildSkiArm().
+  // DoubleSide keeps the hand-wound loft solid from every angle (no reliance on a
+  // single correct triangle winding across the lofted tube + caps).
+  const topSheetMat = new THREE.MeshStandardMaterial({ color: 0xD42B2B, roughness: 0.5, side: THREE.DoubleSide }); // red top-sheet
+  const baseMat = new THREE.MeshStandardMaterial({ color: 0x1A1A20, roughness: 0.7, side: THREE.DoubleSide });     // dark sintered base
+  const steelMat = new THREE.MeshStandardMaterial({ color: 0xB8BCC4, roughness: 0.35, metalness: 0.6, side: THREE.DoubleSide }); // steel edge
+  const bootMat = new THREE.MeshStandardMaterial({ color: 0x202024, roughness: 0.6 });     // binding boot
+  const plateMat = new THREE.MeshStandardMaterial({ color: 0x55585F, roughness: 0.4, metalness: 0.5 }); // binding plate
+  const skiMats = [topSheetMat, baseMat, steelMat];
+
+  // Build one ski (root group + tip/tail arms + binding). Mirrored by `side`.
+  function createShapedSki(side: number): { root: THREE.Group; tipArm: THREE.Mesh; tailArm: THREE.Mesh } {
+    const root = new THREE.Group();
+    root.position.set(side, 0.1, 1);
+
+    // Two arms share the SAME longitudinal profile sampled in absolute ski-z, so their
+    // cross-sections are identical at the waist seam; each is built in arm-local space
+    // (waist at z=0) and overlaps SKI_SEAM_OVERLAP past the waist so a flex bend never
+    // opens a visible gap. Pivot lives at the waist (root-local z = SKI_Z_WAIST).
+    const tipArm = new THREE.Mesh(buildSkiArm(SKI_Z_WAIST - SKI_SEAM_OVERLAP, SKI_Z_TIP), skiMats);
+    const tailArm = new THREE.Mesh(buildSkiArm(SKI_Z_TAIL, SKI_Z_WAIST + SKI_SEAM_OVERLAP), skiMats);
+    for (const arm of [tipArm, tailArm]) {
+      arm.position.z = SKI_Z_WAIST; // arm-local origin -> waist pivot
+      arm.castShadow = true;
+      root.add(arm);
+    }
+
+    // Binding: a metal plate + boot block, parented to the ROOT (not the arms) so it sits
+    // over the waist seam and hides the joint while the arms flex underneath it.
+    const binding = new THREE.Group();
+    const waistY = sampleProfile(SKI_Z_WAIST, SKI_CENTER_Y);
+    const plate = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.05, 0.9), plateMat);
+    plate.position.set(0, waistY + 0.075, 0);
+    plate.castShadow = true;
+    binding.add(plate);
+    const boot = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.2, 0.52), bootMat);
+    boot.position.set(0, waistY + 0.2, 0.02);
+    boot.castShadow = true;
+    binding.add(boot);
+    binding.position.z = SKI_Z_WAIST;
+    root.add(binding);
+
+    group.add(root);
+    return { root, tipArm, tailArm };
+  }
+
+  const left = createShapedSki(-1);
+  const right = createShapedSki(1);
+  const leftSki = left.root, rightSki = right.root;
+
   // --- Scarf (issue #53, optional follow-up PR C) ---------------------------
   // A red wool scarf: a torus wrap at the narrow neck seam + a short two-segment tail
   // draped down the front. The tail is its own neck-pivoted group so the flex layer can
@@ -251,7 +272,12 @@ export function createSnowman(scene: THREE.Scene): THREE.Group {
     button1, button2, button3,
     leftArmGroup, rightArmGroup,
     hatBase, hatTop,
-    scarf, scarfTail
+    scarf, scarfTail,
+    // Ski flex arms (issue #189): the only ski transforms the flex layer writes
+    // (rotation.x bend). The ski ROOTS (leftSki/rightSki) stay off the registry so
+    // pose.ts keeps sole ownership of the wedge/edge/draw transform.
+    leftSkiTip: left.tipArm, leftSkiTail: left.tailArm,
+    rightSkiTip: right.tipArm, rightSkiTail: right.tailArm
   };
   // SHATTER roots: the flat list of TOP-LEVEL rigid pieces the PR-B debris system
   // flings, so accessories ride with their cluster instead of being double-spawned.
@@ -293,4 +319,117 @@ function recordBaseTransforms(parts: Record<string, THREE.Object3D>): Record<str
     };
   }
   return out;
+}
+
+// --- Ski longitudinal profile (issue #189) ----------------------------------
+// The ski is a loft along its length (absolute ski-z: -z = tail, +z = tip), driven by
+// two control-point curves smoothly interpolated by sampleProfile(). SKI_WIDTH is the
+// top-view half-width (the sidecut: wide shovel, narrow waist, medium tail, pinched to
+// rounded end caps); SKI_CENTER_Y is the side-profile centerline (a gentle camber bump
+// at the waist, a rising shovel toward the tip, and a small tail kick). Both arms sample
+// these in absolute z, so their shared waist cross-section matches exactly (no seam).
+const SKI_Z_TAIL = -2.9;
+const SKI_Z_TIP = 3.3;
+const SKI_Z_WAIST = -0.1;       // pivot / binding location
+const SKI_SEAM_OVERLAP = 0.28;  // how far each arm runs past the waist to hide the bend seam
+
+type ProfilePt = readonly [number, number]; // [ski-z, value]
+const SKI_WIDTH: ReadonlyArray<ProfilePt> = [
+  [-2.9, 0.06], [-2.5, 0.21], [-2.0, 0.25], [-0.1, 0.17],
+  [1.6, 0.29], [2.2, 0.30], [3.0, 0.19], [3.3, 0.06]
+];
+const SKI_CENTER_Y: ReadonlyArray<ProfilePt> = [
+  [-2.9, 0.17], [-2.4, 0.05], [-1.8, 0.0], [-0.1, 0.04],
+  [1.6, 0.0], [2.4, 0.13], [3.0, 0.31], [3.3, 0.47]
+];
+
+const smoothstep = (t: number): number => { const c = Math.max(0, Math.min(1, t)); return c * c * (3 - 2 * c); };
+
+/** Smoothly interpolate a control-point curve at ski-z (clamped, smoothstep between pts). */
+function sampleProfile(z: number, pts: ReadonlyArray<ProfilePt>): number {
+  if (z <= pts[0][0]) return pts[0][1];
+  const n = pts.length;
+  if (z >= pts[n - 1][0]) return pts[n - 1][1];
+  for (let i = 0; i < n - 1; i++) {
+    const [z0, v0] = pts[i], [z1, v1] = pts[i + 1];
+    if (z >= z0 && z <= z1) return v0 + (v1 - v0) * smoothstep((z - z0) / (z1 - z0));
+  }
+  return pts[n - 1][1];
+}
+
+/** Thickness taper -> 0 toward both ends so the caps round off instead of ending blunt. */
+function skiThicknessScale(z: number): number {
+  const fade = 0.55;
+  return 0.18 + 0.82 * Math.min(smoothstep((SKI_Z_TIP - z) / fade), smoothstep((z - SKI_Z_TAIL) / fade));
+}
+
+// Cross-section ring: 6 vertices (base-L, mid-L, top-L, top-R, mid-R, base-R). The mid
+// vertices are the widest line — the steel edge. The 6 ring edges map to materials:
+//   0:(0-1) lower-left  -> steel    3:(3-4) upper-right -> top-sheet
+//   1:(1-2) upper-left  -> top-sheet 4:(4-5) lower-right -> steel
+//   2:(2-3) top         -> top-sheet 5:(5-0) base        -> base
+const RING_MAT: ReadonlyArray<number> = [2, 0, 0, 0, 2, 1]; // 0=top-sheet,1=base,2=steel
+
+/** Build one ski arm as a lofted, capped BufferGeometry with three material groups
+ *  (top-sheet / base / steel-edge). `z0..z1` is the absolute ski-z span; vertices are
+ *  emitted in arm-local space (waist at z=0) so the mesh can pivot at the waist. */
+function buildSkiArm(z0: number, z1: number): THREE.BufferGeometry {
+  const STATIONS = 22;
+  const positions: number[] = [];
+  // Per-material triangle index buckets, concatenated into one index buffer + groups.
+  const buckets: number[][] = [[], [], []]; // top-sheet, base, steel
+
+  for (let s = 0; s < STATIONS; s++) {
+    const z = z0 + (z1 - z0) * (s / (STATIONS - 1));
+    const w = sampleProfile(z, SKI_WIDTH);
+    const cy = sampleProfile(z, SKI_CENTER_Y);
+    const ts = skiThicknessScale(z);
+    const topH = 0.05 * ts, baseH = 0.07 * ts;
+    const wTop = w * 0.82, wMid = w, wBase = w * 0.9;
+    const lz = z - SKI_Z_WAIST; // arm-local z (waist pivot at 0)
+    positions.push(
+      -wBase, cy - baseH, lz,   // 0 base-left
+      -wMid, cy, lz,            // 1 mid-left (steel)
+      -wTop, cy + topH, lz,     // 2 top-left
+      wTop, cy + topH, lz,      // 3 top-right
+      wMid, cy, lz,             // 4 mid-right (steel)
+      wBase, cy - baseH, lz     // 5 base-right
+    );
+  }
+
+  // Side quads between adjacent stations (consistent winding around the tube).
+  for (let s = 0; s < STATIONS - 1; s++) {
+    const a = s * 6, b = (s + 1) * 6;
+    for (let e = 0; e < 6; e++) {
+      const r0 = e, r1 = (e + 1) % 6;
+      const v00 = a + r0, v01 = a + r1, v10 = b + r0, v11 = b + r1;
+      buckets[RING_MAT[e]].push(v00, v10, v11, v00, v11, v01);
+    }
+  }
+
+  // End caps: a center vertex per end + a fan to its ring, so the arm reads solid and
+  // casts a clean shadow. Both caps ride with the top-sheet group.
+  const ringCenter = (s: number): number => {
+    const base = s * 6, idx = positions.length / 3;
+    // average the ring's 6 verts for a centroid cap vertex
+    let x = 0, y = 0, zz = 0;
+    for (let r = 0; r < 6; r++) { x += positions[(base + r) * 3]; y += positions[(base + r) * 3 + 1]; zz += positions[(base + r) * 3 + 2]; }
+    positions.push(x / 6, y / 6, zz / 6);
+    return idx;
+  };
+  const c0 = ringCenter(0);
+  for (let e = 0; e < 6; e++) buckets[0].push(c0, (e + 1) % 6, e);
+  const last = (STATIONS - 1) * 6;
+  const cN = ringCenter(STATIONS - 1);
+  for (let e = 0; e < 6; e++) buckets[0].push(cN, last + e, last + (e + 1) % 6);
+
+  const indices = [...buckets[0], ...buckets[1], ...buckets[2]];
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setIndex(indices);
+  geom.addGroup(0, buckets[0].length, 0);
+  geom.addGroup(buckets[0].length, buckets[1].length, 1);
+  geom.addGroup(buckets[0].length + buckets[1].length, buckets[2].length, 2);
+  geom.computeVertexNormals();
+  return geom;
 }

--- a/tests/snowman-flex-tests.js
+++ b/tests/snowman-flex-tests.js
@@ -41,7 +41,10 @@ function makeSnowman() {
     head: makePart(0, 1.0, 0),       // head is inside headGroup (local y)
     headGroup: makePart(0, 6.0, 0),
     leftArmGroup: makePart(1.35, 4.9, 0),
-    rightArmGroup: makePart(-1.35, 4.9, 0)
+    rightArmGroup: makePart(-1.35, 4.9, 0),
+    // Ski flex arms (issue #189): pivot at the waist (root-local z = -0.1).
+    leftSkiTip: makePart(0, 0, -0.1), leftSkiTail: makePart(0, 0, -0.1),
+    rightSkiTip: makePart(0, 0, -0.1), rightSkiTail: makePart(0, 0, -0.1)
   };
   return { userData: { parts, partBaseTransforms: recordBase(parts) } };
 }
@@ -126,6 +129,40 @@ async function main() {
       p.scale.y === base[k].scale.y && p.rotation.z === base[k].rotation.z && p.position.y === base[k].position.y);
     check('prefers-reduced-motion keeps the snowman rigid (== base)', rigid);
     if (prevWindow === undefined) delete global.window; else global.window = prevWindow;
+  }
+
+  // 7) Ski flex (issue #189): the arms bend (rotation.x) but the flex layer writes ONLY
+  //    transforms — position/scale of the ski arms stay at their neutral base.
+  {
+    const sm = makeSnowman();
+    const base = sm.userData.partBaseTransforms;
+    const skiKeys = ['leftSkiTip', 'leftSkiTail', 'rightSkiTip', 'rightSkiTail'];
+    // Glide for a bit: a gentle camber arch should appear (tip arm bends one way, tail the other).
+    for (let i = 0; i < 40; i++) Flex.update(sm, 1 / 60, { speed: 12, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false });
+    const tip = sm.userData.parts.leftSkiTip, tail = sm.userData.parts.leftSkiTail;
+    check('ski arms bend into a camber arch on glide', Math.abs(tip.rotation.x) > 1e-3 && Math.abs(tail.rotation.x) > 1e-3 && Math.sign(tip.rotation.x) !== Math.sign(tail.rotation.x));
+
+    // Transform-only: ski-arm position + scale must equal their base (no vertex/scale hacks).
+    let transformOnly = true;
+    for (const k of skiKeys) {
+      const p = sm.userData.parts[k], b = base[k];
+      if (p.position.x !== b.position.x || p.position.y !== b.position.y || p.position.z !== b.position.z) transformOnly = false;
+      if (p.scale.x !== b.scale.x || p.scale.y !== b.scale.y || p.scale.z !== b.scale.z) transformOnly = false;
+      if (p.rotation.y !== b.rotation.y || p.rotation.z !== b.rotation.z) transformOnly = false; // only rotation.x is written
+    }
+    check('ski flex writes rotation.x only (position/scale/yaw/roll == base)', transformOnly);
+
+    // A carve drives extra tip-pressure: the shovel presses DOWN (rotation.x goes more
+    // positive) relative to the glide arch — this passes through flat, so it's the SIGNED
+    // shift, not the magnitude, that grows. The margin is >> the chatter swing (~0.012).
+    const glideTip = sm.userData.parts.rightSkiTip.rotation.x;
+    for (let i = 0; i < 40; i++) Flex.update(sm, 1 / 60, { speed: 20, technique: 'carve', turnRate: 1, justLanded: false, landingForce: 0, isInAir: false });
+    check('carve presses the shovel down (tip-pressure)', sm.userData.parts.rightSkiTip.rotation.x > glideTip + 0.05);
+
+    // reset() restores ski arms exactly.
+    Flex.reset(sm);
+    const restored = skiKeys.every((k) => sm.userData.parts[k].rotation.x === base[k].rotation.x);
+    check('reset() restores ski arms to neutral', restored);
   }
 
   console.log(`\nSNOWMAN-FLEX TOTAL: ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Closes #189.

Redesigns the snowman's skis from two flat red boxes into real shaped ski geometry, and adds a cosmetic ski-flex layer — all **physics-invariant** (the no-input coasting path stays byte-identical; no baseline regeneration).

## What changed

**Geometry — `src/snowman/model.ts` (`buildSkiArm`)**
- Custom **lofted `BufferGeometry`** sampled along ~44 lengthwise stations: a **sidecut** top view (wide shovel → narrow waist → medium tail), a smooth **shovel/tip rise**, a small **tail kick**, **rounded end caps**, and a visible **binding** (metal plate + boot).
- Three materials via geometry groups: red **top-sheet**, dark **base**, **steel-edge** line accent at the widest line.
- Each ski is a **pose-owned root group** holding two pivot arms (tip + tail). The arms share the same waist cross-section and **overlap under the binding**, so the surface reads as one continuous ski with no visible seam. `pose.ts` keeps sole ownership of the root transform (snowplow wedge / parallel edge + draw); the arms only bend.

**Flex — `src/snowman-flex.ts`**
- New ski-flex pass writes **only the arms' `rotation.x`**: a gentle **camber arch** + speed-chatter while gliding, a **reverse-camber compression** spring on landings, **tip-pressure** in carves (scaled by turn rate), a flatter/planted snowplow, and a **de-cambered** airborne ski.
- Never touches position/velocity, clamped + NaN-safe, honors `prefers-reduced-motion`, and is restored exactly on `reset()`.

## Before / after

| | Before (flat boxes) | After (shaped) |
|---|---|---|
| 3/4 view | ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/before_quarter_glide.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/after_quarter_glide.png) |
| Side profile | ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/before_side_glide.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/after_side_glide.png) |

Sidecut + shovel/tail are clear from the side; the steel-edge line and dark base read on the after shots.

### Cosmetic flex states (after)

| Glide (camber arch) | Carve (tip-pressure) | Landing (reverse-camber compression) |
|---|---|---|
| ![glide](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/after_side_glide.png) | ![carve](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/after_side_carve.png) | ![land](https://raw.githubusercontent.com/den-run-ai/snowglider/eac00d609cc72625235f1fc48ad2374056590aba/after_side_land.png) |

## Acceptance criteria
- [x] Shaped geometry with sidecut, camber, shovel, tail kick, bindings
- [x] Continuous, smooth surface — arms overlap at the waist under the binding (no visible seam/gap); rounded caps, no sharp points
- [x] Visible flex on landings and carves
- [x] Snowplow-wedge and parallel poses still functional (`pose.ts` owns the root transform; flex only bends the arms)
- [x] Flex doesn't override root transforms
- [x] Physics-invariant harness passes unchanged (no baseline regeneration)
- [x] New cosmetic test asserting transform-only writes
- [x] Before/after screenshots included

## Testing
- `npm run typecheck` ✓ · `npm run lint` ✓ (0 errors)
- `npm test` ✓ (full Node suite, incl. physics-invariant harness OK + dom smoke)
- `npm run test:flex` ✓ (11/11, incl. the new ski-flex transform-only assertions)
- `npm run test:browser` ✓ (89/89, all 7 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
