### PR TITLE
feat(audio): procedural Web Audio sound effects (skiing, snowman, avalanche, nature, crashes) (#158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 - `src/snowman.ts` - Snowman model and physics
 - `src/controls.ts` - Keyboard and touch controls implementation
 - `src/audio.ts` - Background music and audio controls
+- `src/sfx.ts` - Procedural Web Audio sound effects (wind/carve/jump/land/avalanche/crash/finish)
 - `src/auth.ts` - Firebase authentication implementation
 - `src/scores.ts` - User scoring and leaderboard functionality
 - `src/boot/` - Classic-script local-auth fallback + Firebase bootstrap (the only remaining `.js`), and `script-loader.ts` (startup driver)
@@ -120,6 +121,10 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 - The previous Howler.js API surface is kept as no-op/Promise stubs for backward compatibility (`preloadAudio`, `playPreloadedAudio`, `resumeAudioContext`, `changeTrack`, `addAudioListener`, …), so the existing callers in `index.html` keep working without change.
 - **Caveats:** the in-page audio control button CSS is still commented out in `index.html`, and while desktop and the automated suite pass, mobile playback (iOS Safari silent switch, Android Chrome) is **not yet verified on real devices** — test thoroughly there before relying on it.
 - Treat audio changes as high risk: mobile browsers require a user gesture to start audio and can suspend the context.
+- **Sound effects (`src/sfx.ts`, issue #158)** are a SEPARATE subsystem from the music: a procedural Web Audio engine that synthesises every effect at runtime (oscillators + filtered noise), so it ships **no binary assets**. Coverage: a speed-scaled wind/ambient bed, a ski-edge swish keyed off technique, an avalanche rumble that crescendos with proximity, and jump/land/crash/finish one-shots. Disable with `SFX_ENABLED = false` in `src/sfx.ts`.
+  - The Web Audio **context is created/resumed only inside the start/restart-button gesture** (`Sfx.unlock()`), which is what mobile autoplay policy requires. iOS still routes Web Audio through the hardware silent switch — same caveat as the music; **mobile not yet verified on real devices.**
+  - It is **inert without Web Audio** (Node/jsdom no-op) and **gated off under automation** (`window.isTestMode`/`navigator.webdriver`) unless a test opts in via `window.testHooks.sfxEnabled`, mirroring `debris`/`intro`, so existing tests keep their music-only, byte-identical path. Every hook reads the per-frame physics result only — never `pos`/`velocity` — so the physics-invariant harness is unaffected.
+  - The single mute button (`audio.ts`) mutes BOTH subsystems via the shared `snowgliderMuted` key. Gain-mapping math lives in exported pure functions (`windGainForSpeed`, `carveGainForTechnique`, `avalancheGainForDistance`, `landGainForForce`) so it unit-tests headlessly (`npm run test:sfx`); the live-context paths are covered by the browser audio suite.
 - The full audio history (Three.js → Howler.js → disabled → native) and the root-cause analysis live in [`CHANGELOG.md`](docs/CHANGELOG.md).
 - Use consistent UI patterns for collapsible panels (Game Controls and Game Stats)
 - Implement horizontal swipe gestures for mobile panel interaction

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,6 +111,7 @@ by name. The per-module `window.*` namespace bridges that used to link them were
 | `Flex` | `snowman-flex.ts` | object + fns | Cosmetic snowman flex (squash/jiggle, head-cluster bob/lean, landing settle); runs after physics, never touches the kernel (#53) |
 | `Physics` | `player-state.ts` | object + fns | Typed per-frame `PlayerState` container over the snowman kernel |
 | `AudioModule` | `audio.ts` | IIFE | Native HTML5 background music (gated by `AUDIO_ENABLED`) |
+| `Sfx` | `sfx.ts` | IIFE | Procedural Web Audio sound effects (wind/carve/jump/land/avalanche/crash/finish, gated by `SFX_ENABLED`); synthesised at runtime (no assets), unlocked on the start gesture, off under automation, reads physics result only (#158) |
 | `Controls` | `controls.ts` | object + fns | Keyboard + touch input → shared `controls` state |
 | `AvalancheSystem` | `avalanche.ts` | `class` | Instanced snow-boulder physics & burial |
 | `SnowTrails` | `snowtracks.ts` | `class` | Cosmetic **temporary** ski tracks: instanced grooves carved behind the skis that fade after a few seconds (transient feedback, not a snow-accumulation model); terrain-aware, reduced-motion-aware, never touches physics (#17) |
@@ -197,10 +198,12 @@ Per-frame order in `animate(time)` (each step depends on the previous):
 ```
 delta = min((time - lastTime)/1000, 0.1)        // clamp
 updateSnowman(delta)                             // input + physics → pos/velocity
+  Flex.update(...)                               // cosmetic flex (reads result only)
+  Sfx.jump()/land(force)/updateSkiing(...)       // SFX: takeoff/touchdown + wind/edge bed (reads result only)
 Snow.updateSnowflakes(...)
 snowTrails.update(delta, snowman, isInAir)       // carve/fade ski grooves (cosmetic, reads pos only)
 CourseModule.update(pos, elapsed, snowman)       // splits, progress HUD, ghost
-avalanche.trigger/update/checkBurial/hasPassed   // + EffectsModule.updateAvalanche
+avalanche.trigger/update/checkBurial/hasPassed   // + EffectsModule.updateAvalanche + Sfx.setAvalanche
 Snow.updateSnowSplash(...)  (position restored after, so particles can't move player)
 updateCamera()                                   // cameraManager follows snowman
 updateTimerDisplay()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -475,10 +475,34 @@ power-ups, and the AI-coach / natural-language course ideas.
 
 ## Audio
 
-Background music has a long, troubled history across three implementations. Audio
-is currently the **simplified native HTML5** implementation; the `AUDIO_ENABLED`
-flag in [`src/audio.js`](src/audio.js) gates it, and `CLAUDE.md` documents the
-operational guidance for re-enabling/testing on mobile.
+SnowGlider now has two independent audio subsystems: **background music** (a
+single track on a native HTML5 `<audio>` element — see below) and, new in #158,
+**procedural sound effects** (`src/sfx.ts`). Music has a long, troubled history
+across three implementations and is currently the **simplified native HTML5**
+implementation; the `AUDIO_ENABLED` flag in [`src/audio.js`](src/audio.js) gates
+it, and `CLAUDE.md` documents the operational guidance for re-enabling/testing on
+mobile.
+
+### Procedural sound effects (#158, Jun 2026)
+A new `src/sfx.ts` engine adds the long-open "sound effects beyond music" item:
+wind/whoosh that scales with speed, a ski-edge swish keyed off the carving
+technique, an avalanche rumble that crescendos as the slide closes in, and
+jump/land/crash/finish one-shots. Every effect is **synthesised at runtime** from
+Web Audio oscillators + filtered noise, so it ships **zero binary assets**.
+
+Deliberately separate from the music and from the THREE.Audio/Howler approaches
+that caused the failures below: effects need low-latency, overlapping one-shots,
+which raw Web Audio handles well and HTML5 `<audio>` does badly. The
+`AudioContext` is created/resumed only inside the start/restart-button gesture
+(`Sfx.unlock()`) — the thing modern mobile actually requires — and the single
+mute button now governs both subsystems (shared `snowgliderMuted` key). It is
+inert without Web Audio (Node/jsdom) and gated off under automation unless a test
+opts in (`window.testHooks.sfxEnabled`), mirroring `debris`/`intro`, so the
+physics-invariant harness and every existing suite keep their byte-identical,
+music-only path. Tests: `npm run test:sfx` (27 headless unit assertions on the
+exported gain-mapping pure functions + the defensive no-op/mute behaviour) plus a
+live-`AudioContext` section in the browser audio suite. **iOS silent-switch and
+real-device mobile playback are not yet verified** — same caveat as the music.
 
 ### Simplified native HTML5 audio (Jan 2026)
 A deliberate rewrite to the simplest thing that works: native `<audio>`, no

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ These exist today and generally don't need re-inventing — the gaps below build
 - Snow particle effects responsive to speed/turning
 - Tracking camera with toggleable views
 - Background music (simplified native HTML5 audio, single track)
+- Procedural sound effects (`src/sfx.ts`: wind, carving swish, jump/land, avalanche rumble, crash/finish)
 - Timer with best-time tracking
 - Firebase auth + global leaderboard (finishes can record scores when logged in)
 - Mobile touch controls
@@ -82,8 +83,8 @@ The biggest design gap: the game *slid with steering* rather than feeling like s
 
 The avalanche existed but wasn't well communicated, especially when it came from behind.
 
-- **Shipped:** a warning banner ("⚠ AVALANCHE — GO!" escalating when close), a "distance behind you" danger meter, a red vignette, and proximity-scaled camera shake.
-- **Remaining (○):** audio rumble/cue, an approaching snow cloud/shadow rendered in the scene.
+- **Shipped:** a warning banner ("⚠ AVALANCHE — GO!" escalating when close), a "distance behind you" danger meter, a red vignette, proximity-scaled camera shake, and a proximity-scaled audio rumble (#158, `src/sfx.ts`).
+- **Remaining (○):** an approaching snow cloud/shadow rendered in the scene.
 - **Open issues:** avalanche trigger notification + visibility from behind (**#49**), avalanche effects and controls (**#44**).
 
 ### 4. Jump usefulness and trick/reward mechanics — ○ open
@@ -116,11 +117,12 @@ A skiing game lives on speed readability and mountain atmosphere.
 - **Remaining (○):** a real **snow-accumulation model** (persistent `SnowDepthField`: snowfall raises depth, skis compact tracks, tracks refill over time — visual-only first, fed into the terrain material; the current ski tracks are transient feedback, not accumulation); replacing the periodic `sin(x*0.2)*cos(z*0.3)` terrain ridge with layered fBm/domain-warp so the geometry itself stops banding (a separate terrain PR — touches the height contract + physics tests); weather variation and a day→sunset→night skybox; stronger slope contrast and obstacle silhouettes; and depth cues.
 - **Open issues:** lighting/shadows and snow/tree/rock/snowman textures (**#17** snow surface + dynamic trails now ◐ partial). Intro fly-over (**#51**) ✅ shipped (`src/intro.ts`). Visible sky (**#2**) is ◐ partial — static sky + a bounded golden-hour↔midday sun cycle (#163) shipped; clouds / full night path remain.
 
-### 8. Audio consistency and completion — ○ open
+### 8. Audio consistency and completion — ◐ partial
 
-Audio has since been rewritten to a simplified, dependency-free native HTML5 implementation (single background-music track) and re-enabled (`AUDIO_ENABLED = true`); the full history is in [`CHANGELOG.md`](CHANGELOG.md). It remains **partially integrated**: the in-page audio control button is still disabled in `index.html` and mobile playback (iOS Safari silent switch, Android Chrome) is not yet verified on real devices.
+Audio has since been rewritten to a simplified, dependency-free native HTML5 implementation (single background-music track) and re-enabled (`AUDIO_ENABLED = true`); the full history is in [`CHANGELOG.md`](CHANGELOG.md). **Sound effects beyond music shipped (#158):** `src/sfx.ts`, a procedural Web Audio engine (no binary assets) covering speed-scaled wind, a technique-keyed carving swish, an avalanche rumble, and jump/land/crash/finish one-shots. It remains **partially integrated**: the in-page audio control button is still disabled in `index.html`, and mobile playback for both music and effects (iOS Safari silent switch, Android Chrome) is not yet verified on real devices.
 
-- **Add / finish:** sound effects beyond music — wind that scales with speed, satisfying carving sounds on sharp turns, a crash/thud on wipeout — and complete the mobile integration.
+- **Done:** sound effects beyond music — wind that scales with speed, carving swish on turns, a crash/thud on wipeout, plus jump/land and an avalanche rumble (**#158**, `src/sfx.ts`).
+- **Add / finish:** complete the mobile integration (real-device verification of music + SFX) and the in-page audio control button.
 - **Open issue:** mobile music-disable button not working (**#50**).
 
 ### 9. Pause/save and quality-of-life controls — ○ open

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -25,6 +25,7 @@
     "test:flex": "node --import ./tests/loaders/register-ts-resolve.mjs tests/snowman-flex-tests.js",
     "test:debris": "node tests/debris-tests.js",
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
+    "test:sfx": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sfx-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
     "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -23,6 +23,8 @@
 //
 // To disable: Set AUDIO_ENABLED = false
 
+import { Sfx } from './sfx.js';
+
 const AUDIO_ENABLED = true;
 
 /**
@@ -161,6 +163,11 @@ export const AudioModule = (function() {
 
       muted = !muted;
       savePreferences();
+
+      // The single mute button governs both subsystems: the background music here
+      // and the procedural sound effects (#158), which share the 'snowgliderMuted'
+      // preference key.
+      Sfx.setMuted(muted);
 
       if (audio) {
         if (muted) {

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -8,6 +8,7 @@ import { Controls } from '../controls.js';
 import { Snow } from '../snow.js';
 import { Flex } from '../snowman-flex.js';
 import { AudioModule } from '../audio.js';
+import { Sfx } from '../sfx.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
@@ -106,6 +107,10 @@ export function createLifecycle(deps: LifecycleDeps) {
     if (AudioModule) {
       AudioModule.enableSound(true);
     }
+
+    // Restart the SFX ambient bed (idempotent). The restart button is a user gesture,
+    // so resuming the Web Audio context here is allowed on mobile (#158).
+    Sfx.unlock();
 
     // Reset animation if it was stopped
     if (!state.animationRunning) {

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -11,6 +11,7 @@ import { Sky } from '../sky.js';
 import { Snowman } from '../snowman.js';
 import { Flex } from '../snowman-flex.js';
 import { CourseModule } from '../course.js';
+import { Sfx } from '../sfx.js';
 import { EffectsModule, type ShakeOffset } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
 import { updateStatsHud, updateTimerDisplay } from '../ui/hud.js';
@@ -31,6 +32,10 @@ export function createMainLoop(deps: MainLoopDeps) {
   } = deps;
   const pos = player.pos;
   const velocity = player.velocity;
+
+  // Previous-frame air state, so we can fire a takeoff whoosh on the ground→air
+  // transition (the kernel's UpdateResult exposes justLanded but no justJumped).
+  let prevInAir = false;
 
   // --- Update Snowman: Physics-based Movement ---
   function updateSnowman(delta: number) {
@@ -76,6 +81,16 @@ export function createMainLoop(deps: MainLoopDeps) {
       landingForce: result.landingForce,
       isInAir: player.isInAir
     });
+
+    // Sound effects (issue #158): a takeoff whoosh on the ground→air transition, a
+    // touchdown thump scaled by air time, and the continuous wind + ski-edge bed.
+    // Reads the per-frame result only — never pos/velocity — so the physics-invariant
+    // harness is unaffected, and every call is a no-op until the SFX context is
+    // unlocked by the start gesture.
+    if (result.isInAir && !prevInAir) Sfx.jump();
+    if (result.justLanded) Sfx.land(result.landingForce);
+    prevInAir = result.isInAir;
+    Sfx.updateSkiing(result.currentSpeed, result.technique, result.isInAir);
 
     // Update timer in the updateTimerDisplay function which is called separately
   }
@@ -160,6 +175,8 @@ export function createMainLoop(deps: MainLoopDeps) {
           const avActive = state.avalancheTriggered && avalanche.active;
           const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
           EffectsModule.updateAvalanche(avActive, avDist);
+          // Avalanche rumble crescendos with the same proximity the banner uses (#158).
+          Sfx.setAvalanche(avActive, avDist);
         }
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import './snow.js';
 import './snowman.js';
 import './snowman-flex.js';
 import './audio.js';
+import './sfx.js';
 import './sky.js';
 import './intro.js';
 

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,0 +1,343 @@
+// sfx.ts — procedural Web Audio sound effects for SnowGlider (issue #158).
+//
+// Separate from audio.ts (which owns the single background-music track on a native
+// HTML5 <audio> element). This module synthesises every effect at runtime from
+// oscillators + filtered noise, so it ships ZERO binary assets and stays tiny:
+//   - skiing dynamics .... a speed-scaled wind/whoosh bed + an edge swish on turns
+//   - snowman actions .... jump whoosh, landing thump
+//   - avalanche .......... a low rumble that crescendos as the slide closes in
+//   - snowing / wind / nature  the always-on ambient wind bed (loud = fast, soft = idle)
+//   - crashes / finish ... a wipeout whoomph and a success chime
+//
+// Why procedural (and not THREE.Audio / Howler / recorded clips)? The project's
+// audio history (docs/CHANGELOG.md "Audio") is a graveyard of mobile failures with
+// THREE.Audio and Howler on old engines. Effects need low-latency, overlapping,
+// one-shot playback — exactly what raw Web Audio does well and HTML5 <audio> does
+// badly. The modern AudioContext is well-behaved on current mobile *as long as it
+// is created/resumed inside a user gesture*, which is why the public entry point is
+// `unlock()`, called from the start-button handler (see snowglider.ts). iOS still
+// routes Web Audio through the hardware silent switch — that caveat is documented
+// in CLAUDE.md and shared with the background music.
+//
+// Design constraints, mirroring intro.ts / debris:
+//   - **Automation-safe.** `unlock()` no-ops under ?test= browser suites
+//     (window.isTestMode) and webdriver runs (Playwright/Puppeteer) unless the
+//     dedicated test opts in via window.testHooks.sfxEnabled — so every existing
+//     test keeps its current (music-only) audio path and stays byte-identical.
+//   - **Headless-testable.** The gain-mapping math lives in exported pure functions
+//     (windGainForSpeed, carveGainForTechnique, avalancheGainForDistance,
+//     landGainForForce) that need no AudioContext, so they unit-test in Node.
+//   - **Defensive.** Without a Web Audio implementation (jsdom/Node) every method is
+//     an inert no-op; node creation is wrapped so a hostile environment can't throw
+//     into the game loop.
+//
+// To disable entirely: set SFX_ENABLED = false (all methods early-exit).
+
+const SFX_ENABLED = true;
+
+// --- Tunable mapping constants -------------------------------------------------
+// Speeds here are the planar speed the physics kernel reports (currentSpeed); ~18
+// is "fast" (matches SPEED_REF in snowman-flex.ts), low double digits are cruising.
+const SPEED_REF = 20;            // speed at which the wind term saturates
+const WIND_BASE = 0.05;          // ambient wind floor while barely moving (nature bed)
+const WIND_SPEED_GAIN = 0.40;    // extra wind at full speed
+const CARVE_SPEED_REF = 12;      // edge swish fades out below this speed
+const AVAL_NEAR = 8;             // distance (world units) at which rumble is full
+const AVAL_FAR = 80;             // distance beyond which the slide is inaudible
+const AVAL_MAX_GAIN = 0.6;       // loudest the avalanche bed gets
+const MASTER_GAIN = 0.85;        // overall SFX headroom (leaves room for the music)
+const RAMP_TAU = 0.08;           // s; smoothing time-constant for continuous beds
+
+/** Per-technique base loudness of the ski-edge swish (before the speed taper).
+ *  A skid scrapes hardest; a locked carve/parallel hisses; gliding straight is silent. */
+function techniqueEdge(technique: string): number {
+  switch (technique) {
+    case 'skid': return 0.30;
+    case 'snowplow': return 0.26;
+    case 'carve': return 0.22;
+    case 'parallel': return 0.16;
+    default: return 0; // glide / tuck / air / hop — no sustained edge noise
+  }
+}
+
+const clamp01 = (n: number): number => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+/** Ambient + speed wind bed gain (0..~0.45). Always at least WIND_BASE while a run
+ *  is active so the slope never sounds dead; rises toward the top speed. */
+export function windGainForSpeed(speed: number): number {
+  const s = Number.isFinite(speed) ? Math.max(0, speed) : 0;
+  return WIND_BASE + clamp01(s / SPEED_REF) * WIND_SPEED_GAIN;
+}
+
+/** Ski-edge swish gain (0..~0.3). Gated by technique and tapered to silence as the
+ *  snowman slows, so a parked snowman makes no scraping noise. */
+export function carveGainForTechnique(technique: string, speed: number): number {
+  const s = Number.isFinite(speed) ? Math.max(0, speed) : 0;
+  return techniqueEdge(technique) * clamp01(s / CARVE_SPEED_REF);
+}
+
+/** Avalanche rumble gain (0..AVAL_MAX_GAIN). Silent when inactive; otherwise grows
+ *  as the closest boulder closes the distance behind the player. */
+export function avalancheGainForDistance(active: boolean, distance: number): number {
+  if (!active) return 0;
+  const d = Number.isFinite(distance) ? distance : AVAL_FAR;
+  const t = clamp01((AVAL_FAR - d) / (AVAL_FAR - AVAL_NEAR));
+  return t * AVAL_MAX_GAIN;
+}
+
+/** Landing-thump peak gain (0..~0.7) from airTime (seconds aloft). Returns 0 for
+ *  trivial touchdowns so micro-bumps stay silent. */
+export function landGainForForce(force: number): number {
+  const f = Number.isFinite(force) ? force : 0;
+  if (f < 0.12) return 0;
+  return 0.18 + clamp01(f / 1.2) * 0.52;
+}
+
+// --- Web Audio engine ----------------------------------------------------------
+// Everything below is the live engine; it is entirely inert without an AudioContext.
+
+interface NoiseBed {
+  filter: BiquadFilterNode;
+  gain: GainNode;
+}
+
+type WebAudioCtor = typeof AudioContext;
+
+export const Sfx = (function() {
+  let ctx: AudioContext | null = null;
+  let master: GainNode | null = null;
+  let noiseBuffer: AudioBuffer | null = null;
+  let wind: NoiseBed | null = null;
+  let carve: NoiseBed | null = null;
+  let avalanche: NoiseBed | null = null;
+  let running = false;     // true between startRun/unlock and endRun (continuous bed live)
+  let muted = false;
+  let prefsLoaded = false;
+
+  function getAudioCtor(): WebAudioCtor | null {
+    if (typeof window === 'undefined') return null;
+    const w = window as unknown as { AudioContext?: WebAudioCtor; webkitAudioContext?: WebAudioCtor };
+    return w.AudioContext || w.webkitAudioContext || null;
+  }
+
+  function loadPreferences() {
+    if (prefsLoaded) return;
+    prefsLoaded = true;
+    try {
+      // Share the single mute preference with the background music (audio.ts).
+      const stored = localStorage.getItem('snowgliderMuted');
+      if (stored !== null) muted = stored === 'true';
+    } catch { /* localStorage unavailable — keep default */ }
+  }
+
+  function automated(): boolean {
+    if (typeof window === 'undefined') return true;
+    return !!window.isTestMode ||
+      (typeof navigator !== 'undefined' && !!navigator.webdriver);
+  }
+
+  function allowed(): boolean {
+    if (!SFX_ENABLED) return false;
+    if (typeof window === 'undefined') return false; // no DOM (Node) — stay inert
+    // Mirror the debris / intro gate: off under automation unless explicitly opted in.
+    if (automated() && !(window.testHooks && window.testHooks.sfxEnabled)) return false;
+    return true;
+  }
+
+  function makeNoiseBuffer(context: AudioContext, seconds = 2): AudioBuffer {
+    const len = Math.floor(context.sampleRate * seconds);
+    const buf = context.createBuffer(1, len, context.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+    return buf;
+  }
+
+  // A looping filtered-noise bed whose gain we modulate per frame. Started once at
+  // unlock and left running (gain at 0 = silent), so there is no start/stop latency.
+  function makeBed(context: AudioContext, buf: AudioBuffer, dest: AudioNode,
+                   type: BiquadFilterType, freq: number, q: number): NoiseBed {
+    const src = context.createBufferSource();
+    src.buffer = buf;
+    src.loop = true;
+    const filter = context.createBiquadFilter();
+    filter.type = type;
+    filter.frequency.value = freq;
+    filter.Q.value = q;
+    const gain = context.createGain();
+    gain.gain.value = 0;
+    src.connect(filter);
+    filter.connect(gain);
+    gain.connect(dest);
+    src.start();
+    return { filter, gain };
+  }
+
+  function buildGraph(context: AudioContext) {
+    master = context.createGain();
+    master.gain.value = muted ? 0 : MASTER_GAIN;
+    master.connect(context.destination);
+
+    noiseBuffer = makeNoiseBuffer(context);
+    wind = makeBed(context, noiseBuffer, master, 'lowpass', 500, 0.7);
+    carve = makeBed(context, noiseBuffer, master, 'bandpass', 2500, 0.8);
+    avalanche = makeBed(context, noiseBuffer, master, 'lowpass', 110, 0.6);
+  }
+
+  function rampTo(param: AudioParam, value: number) {
+    if (!ctx) return;
+    param.setTargetAtTime(value, ctx.currentTime, RAMP_TAU);
+  }
+
+  // --- one-shot helpers --------------------------------------------------------
+  function envelopedGain(peak: number, attack: number, decay: number): GainNode {
+    const g = ctx!.createGain();
+    const t = ctx!.currentTime;
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.linearRampToValueAtTime(peak, t + attack);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + attack + decay);
+    return g;
+  }
+
+  function noiseBurst(type: BiquadFilterType, f0: number, f1: number,
+                      peak: number, attack: number, decay: number, q: number) {
+    if (!ctx || !master || !noiseBuffer) return;
+    const t = ctx.currentTime;
+    const src = ctx.createBufferSource();
+    src.buffer = noiseBuffer;
+    const filter = ctx.createBiquadFilter();
+    filter.type = type;
+    filter.Q.value = q;
+    filter.frequency.setValueAtTime(f0, t);
+    filter.frequency.linearRampToValueAtTime(f1, t + attack + decay);
+    const g = envelopedGain(peak, attack, decay);
+    src.connect(filter);
+    filter.connect(g);
+    g.connect(master);
+    src.start(t);
+    src.stop(t + attack + decay + 0.05);
+  }
+
+  function tone(type: OscillatorType, f0: number, f1: number,
+                peak: number, attack: number, decay: number, when = 0) {
+    if (!ctx || !master) return;
+    const t = ctx.currentTime + when;
+    const osc = ctx.createOscillator();
+    osc.type = type;
+    osc.frequency.setValueAtTime(f0, t);
+    if (f1 !== f0) osc.frequency.exponentialRampToValueAtTime(Math.max(1, f1), t + attack + decay);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.linearRampToValueAtTime(peak, t + attack);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + attack + decay);
+    osc.connect(g);
+    g.connect(master);
+    osc.start(t);
+    osc.stop(t + attack + decay + 0.05);
+  }
+
+  return {
+    isEnabled: () => SFX_ENABLED,
+
+    // Create + resume the AudioContext and start the ambient bed. MUST be called from
+    // a user-gesture handler (start/restart button) so mobile autoplay policy lets the
+    // context run. Idempotent: builds the node graph once, then just resumes + ramps up.
+    unlock: function() {
+      if (!allowed()) return;
+      loadPreferences();
+      try {
+        if (!ctx) {
+          const Ctor = getAudioCtor();
+          if (!Ctor) return;            // no Web Audio (Node/jsdom) — stay inert
+          ctx = new Ctor();
+          buildGraph(ctx);
+        }
+        if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+        running = true;
+        // Bring the ambient wind bed up to its idle floor.
+        if (wind) rampTo(wind.gain.gain, windGainForSpeed(0));
+      } catch (e) {
+        console.warn('[Sfx] unlock failed:', (e as Error).message);
+        ctx = null;
+      }
+    },
+
+    // Per-frame continuous skiing bed: wind scales with speed, edge swish with the
+    // active technique. No-op until unlocked. `isInAir` silences the ground edge.
+    updateSkiing: function(speed: number, technique: string, isInAir: boolean) {
+      if (!running || !ctx || muted) return;
+      if (wind) {
+        rampTo(wind.gain.gain, windGainForSpeed(speed));
+        // A faster glide brightens the wind (rising whoosh).
+        rampTo(wind.filter.frequency, 300 + clamp01(speed / SPEED_REF) * 700);
+      }
+      if (carve) {
+        const g = isInAir ? 0 : carveGainForTechnique(technique, speed);
+        rampTo(carve.gain.gain, g);
+      }
+    },
+
+    // Per-frame avalanche rumble. Pass the same (active, closestDistance) the effects
+    // banner uses. No-op until unlocked.
+    setAvalanche: function(active: boolean, distance: number) {
+      if (!running || !ctx || muted) return;
+      if (avalanche) rampTo(avalanche.gain.gain, avalancheGainForDistance(active, distance));
+    },
+
+    // One-shot: snowman leaves the ground. A short upward-sweeping whoosh.
+    jump: function() {
+      if (!running || !ctx || muted) return;
+      noiseBurst('bandpass', 600, 1900, 0.35, 0.02, 0.22, 1.2);
+    },
+
+    // One-shot: snowman touches down. A low thump + snow-compression puff scaled by
+    // how long it was airborne (force). Trivial touchdowns are silent.
+    land: function(force: number) {
+      if (!running || !ctx || muted) return;
+      const peak = landGainForForce(force);
+      if (peak <= 0) return;
+      tone('sine', 120, 55, peak, 0.005, 0.18);
+      noiseBurst('lowpass', 900, 400, peak * 0.6, 0.005, 0.14, 0.7);
+    },
+
+    // End of a run: silence the continuous beds and play the outcome cue. 'finish' is
+    // a rising 3-note chime; 'crash' is a heavier wipeout whoomph (trees/rocks/fall/
+    // avalanche burial all share it — the avalanche rumble already set the scene).
+    endRun: function(outcome: 'finish' | 'crash') {
+      if (!ctx) { running = false; return; }
+      running = false;
+      if (wind) rampTo(wind.gain.gain, 0);
+      if (carve) rampTo(carve.gain.gain, 0);
+      if (avalanche) rampTo(avalanche.gain.gain, 0);
+      if (muted) return;
+      if (outcome === 'finish') {
+        // C5 – E5 – G5 arpeggio.
+        tone('triangle', 523.25, 523.25, 0.3, 0.01, 0.30, 0.00);
+        tone('triangle', 659.25, 659.25, 0.3, 0.01, 0.30, 0.12);
+        tone('triangle', 783.99, 783.99, 0.3, 0.01, 0.40, 0.24);
+      } else {
+        tone('sine', 90, 40, 0.5, 0.005, 0.45);
+        noiseBurst('lowpass', 1200, 200, 0.5, 0.005, 0.40, 0.5);
+      }
+    },
+
+    // Mute/unmute (driven by the shared mute button via audio.ts). Silences the whole
+    // SFX bus; continuous beds keep running underneath so unmute is instant.
+    setMuted: function(value: boolean) {
+      muted = value;
+      if (master && ctx) master.gain.setTargetAtTime(value ? 0 : MASTER_GAIN, ctx.currentTime, 0.02);
+    },
+
+    isMuted: () => muted,
+
+    // For tests / diagnostics. `active` reflects whether the context is live.
+    getStatus: function() {
+      return {
+        enabled: SFX_ENABLED,
+        active: !!ctx,
+        running,
+        muted,
+        contextState: ctx ? ctx.state : 'none'
+      };
+    }
+  };
+})();

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -31,6 +31,7 @@ import { Controls } from './controls.js';
 import { Snow } from './snow.js';
 import { Snowman } from './snowman.js';
 import { AudioModule } from './audio.js';
+import { Sfx } from './sfx.js';
 import { Physics } from './player-state.js';
 import { IntroModule, prefersReducedMotion } from './intro.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
@@ -251,7 +252,12 @@ window.initializeGameWithAudio = function() {
   
   // TODO: AUDIO DISABLED - Start audio (will show welcome message but skip music)
   AudioModule.startAudio();
-  
+
+  // Unlock the procedural sound-effects engine (#158). This runs in the start
+  // button's user-gesture context, which is what mobile autoplay policy requires to
+  // create/resume the Web Audio context. No-op under automation / without Web Audio.
+  Sfx.unlock();
+
   // Reset the snowman to starting position
   resetSnowman();
   

--- a/src/ui/result-overlay.ts
+++ b/src/ui/result-overlay.ts
@@ -5,6 +5,7 @@
 // element ownership (those nodes move to game/scene-setup.ts in a later step).
 
 import { AudioModule } from '../audio.js';
+import { Sfx } from '../sfx.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
 import { formatStatTime } from './hud.js';
@@ -104,6 +105,11 @@ export function createShowGameOver(deps: ResultOverlayDeps): (reason: string) =>
     if (onCrash && reason !== FINISH_REASON) {
       try { onCrash(reason); } catch (e) { console.warn("Crash effect failed:", (e as Error).message); }
     }
+
+    // Sound effects (#158): silence the continuous skiing/avalanche bed and play the
+    // outcome cue — a success chime on a finish, a wipeout whoomph on any crash
+    // (tree/rock/fall/avalanche burial). No-op until the SFX engine is unlocked.
+    try { Sfx.endRun(reason === FINISH_REASON ? 'finish' : 'crash'); } catch { /* never block the overlay */ }
 
     // Capture the best time BEFORE the finish branch updates it, so the result
     // screen can report the delta and whether this run set a new record.

--- a/tests/audio-tests.js
+++ b/tests/audio-tests.js
@@ -7,6 +7,7 @@
 // loaded via `<script type="module">` by the boot script-loader. It still
 // publishes window.runAudioTests so the unified runner can invoke it.
 import { AudioModule } from '../src/audio.js';
+import { Sfx } from '../src/sfx.js';
 
 (function() {
   if (window.location.search.includes('test=') && !window._unifiedTestRunnerActive) {
@@ -277,6 +278,67 @@ import { AudioModule } from '../src/audio.js';
       }
     }
     
+    // TEST 7: Procedural sound-effects engine (Sfx) — issue #158.
+    // This drives a REAL AudioContext (browser only), covering the graph build +
+    // one-shot synthesis paths the Node unit test (tests/sfx-tests.js) cannot reach.
+    function testSfxEngine() {
+      console.warn('TEST 7: SFX Engine');
+
+      assert(
+        typeof Sfx.unlock === 'function' && typeof Sfx.isEnabled === 'function',
+        'SFX API',
+        'Sfx module exposes unlock()/isEnabled()'
+      );
+
+      if (!Sfx.isEnabled || !Sfx.isEnabled()) {
+        assert(true, 'SFX Disabled', 'Skipped - SFX disabled');
+        return;
+      }
+
+      // Opt in so unlock() is allowed under the automated harness (it is gated off by
+      // default like debris/intro), then create a live AudioContext.
+      window.testHooks = window.testHooks || {};
+      window.testHooks.sfxEnabled = true;
+
+      try {
+        Sfx.unlock();
+        const status = Sfx.getStatus();
+        assert(status.active === true, 'SFX Unlock', `AudioContext created (state: ${status.contextState})`);
+        assert(status.running === true, 'SFX Running', 'continuous bed marked running after unlock');
+      } catch (e) {
+        assert(false, 'SFX Unlock', `Error: ${e.message}`);
+      }
+
+      // Exercise the event + continuous surface against the live context.
+      try {
+        Sfx.updateSkiing(18, 'carve', false);
+        Sfx.updateSkiing(0, 'glide', false);
+        Sfx.setAvalanche(true, 12);
+        Sfx.setAvalanche(false, Infinity);
+        Sfx.jump();
+        Sfx.land(0.8);
+        Sfx.endRun('crash');
+        Sfx.endRun('finish');
+        assert(true, 'SFX Playback', 'jump/land/updateSkiing/setAvalanche/endRun run without error');
+      } catch (e) {
+        assert(false, 'SFX Playback', `Error: ${e.message}`);
+      }
+
+      // Mute round-trip on the live bus.
+      try {
+        Sfx.setMuted(true);
+        const m1 = Sfx.isMuted();
+        Sfx.setMuted(false);
+        const m2 = Sfx.isMuted();
+        assert(m1 === true && m2 === false, 'SFX Mute', 'setMuted()/isMuted() round-trip');
+      } catch (e) {
+        assert(false, 'SFX Mute', `Error: ${e.message}`);
+      }
+
+      // Don't leak the opt-in into the other suites in the unified runner.
+      delete window.testHooks.sfxEnabled;
+    }
+
     // Run all tests
     try {
       testBasicModule();
@@ -285,6 +347,7 @@ import { AudioModule } from '../src/audio.js';
       testCompatibilityStubs();
       testUICreation();
       testMessageDisplay();
+      testSfxEngine();
       
       // Summary
       setTimeout(() => {

--- a/tests/sfx-tests.js
+++ b/tests/sfx-tests.js
@@ -1,0 +1,82 @@
+// sfx-tests.js — headless unit tests for the procedural sound-effects engine (#158).
+//
+// Sfx (src/sfx.ts) synthesises everything from Web Audio at runtime, so it has no
+// asset dependency and — crucially — is fully inert without an AudioContext. That
+// lets us unit-test the gain-mapping math (exported pure functions) and the engine's
+// defensive no-op / mute behaviour in plain Node, with no browser. Run via:
+//   node --import ./tests/loaders/register-ts-resolve.mjs tests/sfx-tests.js
+//
+// What we guard:
+//  - the pure gain maps are clamped, monotonic where they should be, and NaN-safe;
+//  - the engine no-ops (never throws) without Web Audio, even under automation;
+//  - getStatus() reports an inert engine in Node;
+//  - setMuted()/isMuted() track state without a context (so the shared mute button
+//    can drive SFX before the context is ever unlocked).
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+const approx = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
+
+async function main() {
+  const Sfx = await import('../src/sfx.js');
+  const { windGainForSpeed, carveGainForTechnique, avalancheGainForDistance, landGainForForce } = Sfx;
+
+  // --- wind bed gain -----------------------------------------------------------
+  check('wind: idle floor at speed 0 (slope never silent)', windGainForSpeed(0) > 0 && windGainForSpeed(0) < 0.1);
+  check('wind: rises with speed', windGainForSpeed(20) > windGainForSpeed(5));
+  check('wind: saturates (clamped) past the reference speed', approx(windGainForSpeed(100), windGainForSpeed(20)));
+  check('wind: NaN-safe', Number.isFinite(windGainForSpeed(NaN)) && windGainForSpeed(NaN) === windGainForSpeed(0));
+  check('wind: negative speed treated as 0', windGainForSpeed(-50) === windGainForSpeed(0));
+
+  // --- ski-edge swish gain -----------------------------------------------------
+  check('carve: glide is silent', carveGainForTechnique('glide', 18) === 0);
+  check('carve: air is silent', carveGainForTechnique('air', 18) === 0);
+  check('carve: a skid scrapes louder than a locked parallel', carveGainForTechnique('skid', 18) > carveGainForTechnique('parallel', 18));
+  check('carve: tapers to silence when nearly stopped', carveGainForTechnique('skid', 0) === 0);
+  check('carve: louder fast than slow (same technique)', carveGainForTechnique('carve', 12) > carveGainForTechnique('carve', 3));
+  check('carve: speed taper saturates (clamped)', approx(carveGainForTechnique('skid', 50), carveGainForTechnique('skid', 12)));
+
+  // --- avalanche rumble gain ---------------------------------------------------
+  check('avalanche: silent when inactive', avalancheGainForDistance(false, 5) === 0);
+  check('avalanche: louder when closer', avalancheGainForDistance(true, 10) > avalancheGainForDistance(true, 60));
+  check('avalanche: full when very close, clamped', avalancheGainForDistance(true, 0) === avalancheGainForDistance(true, 8) && avalancheGainForDistance(true, 8) > 0);
+  check('avalanche: zero once far enough away', avalancheGainForDistance(true, 200) === 0);
+  check('avalanche: NaN distance does not explode', Number.isFinite(avalancheGainForDistance(true, NaN)));
+
+  // --- landing thump gain ------------------------------------------------------
+  check('land: trivial touchdown is silent', landGainForForce(0.05) === 0);
+  check('land: a real landing makes noise', landGainForForce(0.5) > 0);
+  check('land: harder landing is louder', landGainForForce(1.0) > landGainForForce(0.3));
+  check('land: clamped at the top end', approx(landGainForForce(5), landGainForForce(1.2)));
+  check('land: NaN-safe', landGainForForce(NaN) === 0);
+
+  // --- engine: inert + defensive in Node (no AudioContext) ---------------------
+  const engine = Sfx.Sfx;
+  check('engine: isEnabled() true', engine.isEnabled() === true);
+  let threw = false;
+  try {
+    engine.unlock();                         // gated off (no window) — must not throw
+    engine.updateSkiing(18, 'carve', false); // no-op without a context
+    engine.setAvalanche(true, 10);
+    engine.jump();
+    engine.land(0.8);
+    engine.endRun('finish');
+    engine.endRun('crash');
+  } catch { threw = true; }
+  check('engine: every method is a safe no-op without Web Audio', !threw);
+
+  const status = engine.getStatus();
+  check('engine: reports inert (no context active) in Node', status.active === false && status.running === false);
+  check('engine: contextState is "none" in Node', status.contextState === 'none');
+
+  // --- mute tracking works before any context exists ---------------------------
+  engine.setMuted(true);
+  check('engine: setMuted(true) reflected by isMuted()', engine.isMuted() === true);
+  engine.setMuted(false);
+  check('engine: setMuted(false) reflected by isMuted()', engine.isMuted() === false);
+
+  console.log(`\nSFX TESTS: ${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
Adds **simple sound effects** for skiing dynamics, snowman actions, the avalanche, snowing/wind/nature, and crashes — closing the long-open "sound effects beyond music" item (issue #158, Roadmap §8).

A new **procedural Web Audio engine** (`src/sfx.ts`) synthesises every effect at runtime from oscillators + filtered noise, so it ships **zero binary assets**. It is a separate subsystem from the background music (`audio.ts`, untouched except for the shared mute).

### Effects
- **Skiing dynamics** — wind/whoosh bed that scales with speed (doubles as the ambient nature/snow bed), plus a ski-edge swish keyed to technique (skid scrapes loudest → locked parallel hisses → glide silent), tapering out as you slow.
- **Snowman actions** — takeoff whoosh on jumps, touchdown thump scaled by air time.
- **Avalanche** — low rumble that crescendos with the same proximity the warning banner uses.
- **Crashes / finish** — wipeout whoomph on any crash (tree/rock/fall/burial), a 3-note success chime on a clean finish.

## Why procedural (re: the buggy old mobile audio)
The CHANGELOG's mobile failures came from THREE.Audio and Howler on old engines. This avoids both: raw Web Audio handles low-latency overlapping one-shots well, and the `AudioContext` is **created/resumed only inside the start/restart-button gesture** (`Sfx.unlock()`) — exactly what modern mobile autoplay policy requires. The single existing mute button now governs both subsystems via the shared `snowgliderMuted` key.

> ⚠️ iOS silent-switch / real-device mobile playback is **not yet verified** — same documented caveat as the music.

## Safety / invariants
- Every game hook reads the per-frame physics **result only** (never `pos`/`velocity`), so coasting stays **byte-identical** (invariant harness: `IDENTICAL ✅`).
- **Inert** without Web Audio (Node/jsdom no-op) and **gated off under automation** (`window.isTestMode`/`navigator.webdriver`) unless a test opts in via `window.testHooks.sfxEnabled` — mirrors `debris`/`intro`, so every existing suite keeps its music-only path.
- Gain-mapping math lives in exported pure functions for headless unit testing.

## Tests
- `npx tsc --noEmit` clean; eslint clean on all touched files.
- **Node:** `npm test` → green, incl. new `test:sfx` (27/27).
- **Browser:** unified puppeteer suite **94/94, 7/7 suites**, incl. a new section that unlocks a real `AudioContext` (state: `running`) and exercises every effect.
- `npm run build` succeeds; SFX code present in the bundle.

## Commits (logical steps)
1. `feat(sfx)` — the engine (`src/sfx.ts`)
2. `feat(sfx)` — wire into the game loop / gestures / mute
3. `test(sfx)` — Node unit + browser coverage
4. `docs(sfx)` — CLAUDE.md / CHANGELOG / ROADMAP / ARCHITECTURE

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)