### PR TITLE
fix(ui): stop start-screen leaderboard rows from being clipped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,19 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Fix: start-screen leaderboard rows clipped at full height
+- The **Global Top Times** preview (`#startLeaderboard`) on the start screen was
+  truncated — only the header and the first few of the top-5 rows showed, with the
+  rest cut off and no usable scrollbar. `#startGameContainer` is a column flexbox,
+  so the leaderboard (a flex item) was being shrunk *below its own `max-height`*
+  whenever the panel was taller than the viewport, clipping the bottom rows. Same
+  flex-overflow class of bug as the build badge (`#buildBadge`) fix.
+- Fix is CSS-only (`styles/main.css`): add `flex-shrink: 0` so the leaderboard
+  keeps its natural height and the container scrolls instead (`overflow-y: auto` +
+  `justify-content: safe center` already keep the top reachable), and bump
+  `max-height` 168px → 200px so the full top-5 (h3 + header + 5 rows) fits without
+  an internal scrollbar.
+
 ### Shaped skis — sidecut / camber / shovel / tail + cosmetic flex (#189)
 - The snowman's skis were two flat red `BoxGeometry` slabs with an angled box glued
   on the front. They are now real ski shapes built from a **custom lofted

--- a/styles/main.css
+++ b/styles/main.css
@@ -842,8 +842,15 @@ canvas { display: block; }
   margin-bottom: 12px;
   width: 100%;
   max-width: 360px;
-  max-height: 168px;
+  /* Tall enough to show the full top-5 (h3 + header + 5 rows) without an internal
+     scrollbar. */
+  max-height: 200px;
   overflow-y: auto;
+  /* #startGameContainer is a column flexbox; without this the leaderboard (a flex
+     item) is shrunk below its own max-height when the panel is taller than the
+     viewport, clipping the bottom rows with no usable scrollbar. Keep its natural
+     height and let the container scroll (justify-content: safe center) instead. */
+  flex-shrink: 0;
   text-align: center;
 }
 


### PR DESCRIPTION
## Problem

The **Global Top Times** preview (`#startLeaderboard`) on the start screen was truncated: only the header and the first few of the top-5 rows showed, the rest clipped off with no usable scrollbar. Reported as a follow-up to the build-badge overflow fix (#196).

Root cause is the same flex-overflow class of bug: `#startGameContainer` is a column flexbox, so `#startLeaderboard` (a flex item with default `flex-shrink: 1`) gets compressed **below its own `max-height`** whenever the start panel is taller than the viewport, clipping the bottom rows. Measured headlessly: the box rendered at `clientHeight: 128` (< its `max-height: 168px`) while `scrollHeight: 174` — 46px of rows clipped and unreachable.

## Fix (CSS-only, `styles/main.css`)

- `flex-shrink: 0` on `#startLeaderboard` so it keeps its natural height; the container already scrolls (`overflow-y: auto` + `justify-content: safe center` keep the top reachable) when the panel overflows.
- `max-height` 168px → 200px so the full top-5 (h3 + header + 5 rows ≈ 174px) fits with no internal scrollbar.

## Before / After (1200×820, top-5 injected)

| Before — rows 4–5 clipped | After — full top-5 |
| --- | --- |
| ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/5c0fb369a35513ec4a1f04ad65383f71347fa341/before.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/5c0fb369a35513ec4a1f04ad65383f71347fa341/after.png) |

## Verification

- Headless geometry: after the fix `clientHeight == scrollHeight` (174 == 174, no clip); board bottom is within the viewport.
- Short-viewport regimes (520 / 600 / 700px height): container stays scrollable / fits, leaderboard fully reachable, `#buildBadge` stays `position: fixed` at the bottom.
- `npm run lint` (0 errors), `npm test`, and `npm run test:browser` (**89/89, 7/7 suites**) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
