### PR TITLE
Replace Best Time with live Slope/incline in Game Stats HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,8 +147,8 @@
         <span id="currentTime" class="stat-value">0.0s</span>
       </div>
       <div class="stat-item">
-        <span class="stat-label">Best Time</span>
-        <span id="bestTimeValue" class="stat-value">--</span>
+        <span class="stat-label">Slope</span>
+        <span id="slopeValue" class="stat-value">0° (0%)</span>
       </div>
       <div class="stat-item">
         <span class="stat-label">Speed</span>

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -53,7 +53,7 @@ export function createLifecycle(deps: LifecycleDeps) {
     Controls.resetControls();
 
     state.startTime = performance.now(); // Reset the timer when starting a new run
-    updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
+    updateTimerDisplay(state.gameActive, state.startTime);
 
     // Reset course (gates/splits/ghost) and effects (avalanche UI, FOV, shake) for the new run
     if (CourseModule) CourseModule.reset();
@@ -89,12 +89,6 @@ export function createLifecycle(deps: LifecycleDeps) {
       const toggleBtn = document.getElementById('toggleStats');
       if (toggleBtn) {
         toggleBtn.textContent = '▲';
-      }
-
-      // Reset colors for best time display
-      const bestTimeElement = document.getElementById('bestTimeValue');
-      if (bestTimeElement) {
-        bestTimeElement.style.color = ''; // Reset to default color
       }
     }
 

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -65,8 +65,12 @@ export function createMainLoop(deps: MainLoopDeps) {
       bankAirScore: (points: number) => { if (CourseModule) CourseModule.addAirScore(points); }
     });
 
-    // Update game stats display (speed/position/technique)
-    updateStatsHud(result, pos, player.isInAir);
+    // Update game stats display (speed/altitude/slope/technique). The slope
+    // readout is the terrain steepness under the player: gradient magnitude
+    // (rise/run = tan θ), the same measure the terrain code uses for placement.
+    const grad = Snow.getTerrainGradient(pos.x, pos.z);
+    const slopeRatio = Math.sqrt(grad.x * grad.x + grad.z * grad.z);
+    updateStatsHud(result, pos, player.isInAir, slopeRatio);
 
     // Camera shake on a meaningful landing (scales with time spent aloft).
     if (result.justLanded && result.landingForce > 0.25 && EffectsModule) {
@@ -206,7 +210,7 @@ export function createMainLoop(deps: MainLoopDeps) {
       snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
 
       updateCamera();
-      updateTimerDisplay(state.gameActive, state.startTime, state.bestTime); // Update the timer display
+      updateTimerDisplay(state.gameActive, state.startTime); // Update the timer display
 
       // Camera juice: speed-based FOV + shake. Apply for the render only, then revert
       // the positional offset so the camera manager's own smoothing stays clean.

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -80,7 +80,7 @@ state.bestTime = readStoredBestTime();
 // Initialize the stats display when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
   console.log("DOM content loaded, initializing game stats");
-  initializeGameStats(state.bestTime);
+  initializeGameStats();
 });
 
 // Add best time to game over overlay
@@ -265,7 +265,7 @@ window.initializeGameWithAudio = function() {
   Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
   
   // Make sure game stats and controls are properly initialized and visible
-  initializeGameStats(state.bestTime);
+  initializeGameStats();
   initializeControlsToggle();
   
   // Initialize Game Stats
@@ -280,7 +280,7 @@ window.initializeGameWithAudio = function() {
     }
     
     // Update initial values
-    updateTimerDisplay(state.gameActive, state.startTime, state.bestTime);
+    updateTimerDisplay(state.gameActive, state.startTime);
   }
   
   // Initialize Controls

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,5 +1,5 @@
-// In-game HUD: the Game Stats panel (best time + collapse/swipe), the live run
-// timer, and the per-frame speed / position / technique readouts. Extracted from
+// In-game HUD: the Game Stats panel (collapse/swipe), the live run timer, and
+// the per-frame speed / altitude / slope / technique readouts. Extracted from
 // snowglider.ts; the orchestrator passes the run state in as parameters so this
 // module stays decoupled from the coordinator's bindings.
 
@@ -18,6 +18,13 @@ const M_TO_FT = 3.280839895;     // metres → feet
 // negative on the lower half of the run (terrain drops below the y=0 plane far
 // downhill). Cosmetic only — it shifts the readout, not the physics.
 const BASE_ELEVATION_M = 1500;
+const RAD_TO_DEG = 180 / Math.PI;
+// Slope steepness colour tiers, in gradient magnitude (rise/run = tan θ).
+// Calibrated to the measured run: the skiable line sits around 15–40° (median
+// ~24°), so gentle flats read green, the typical pitch yellow, and only the
+// genuinely steep black-diamond sections (≈30°+) read red.
+const SLOPE_MODERATE = 0.32;     // ≈18° / 32% — green → yellow
+const SLOPE_STEEP = 0.58;        // ≈30° / 58% — yellow → red
 
 // Format a run time for the Game Stats panel. One decimal is plenty of
 // precision for the live readout, and keeps the values consistent wherever the
@@ -26,13 +33,8 @@ export function formatStatTime(seconds: number): string {
   return seconds !== Infinity ? `${seconds.toFixed(1)}s` : '--';
 }
 
-// Seed the best-time readout and wire up the Game Stats panel collapse/swipe.
-export function initializeGameStats(bestTime: number): void {
-  const bestTimeElement = document.getElementById('bestTimeValue');
-  if (bestTimeElement) {
-    bestTimeElement.textContent = formatStatTime(bestTime);
-  }
-
+// Wire up the Game Stats panel collapse/swipe behavior.
+export function initializeGameStats(): void {
   // Game stats panel collapse/swipe behavior (shared with the Controls panel).
   setupCollapsiblePanel({
     name: 'game stats',
@@ -56,9 +58,10 @@ export function initializeControlsToggle(): void {
   });
 }
 
-// Per-frame stats readout: color-coded speed, altitude, and the ground /
-// jump / ski-technique indicator.
-export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: boolean): void {
+// Per-frame stats readout: color-coded speed, altitude, terrain slope, and the
+// ground / jump / ski-technique indicator. `slopeRatio` is the terrain gradient
+// magnitude under the player (rise/run = tan θ), supplied by the run loop.
+export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: boolean, slopeRatio: number): void {
   // Convert the metric world speed into real skiing units (km/h and mph).
   const speedMps = result.currentSpeed;
   const speedText = `${Math.round(speedMps * MPS_TO_KMH)} km/h (${Math.round(speedMps * MPS_TO_MPH)} mph)`;
@@ -87,6 +90,19 @@ export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: bo
     altitudeElement.textContent = `${Math.round(altitudeM)} m (${Math.round(altitudeM * M_TO_FT)} ft)`;
   }
 
+  // Slope / incline of the terrain under the player, in degrees and percent
+  // grade (rise/run × 100). Color-coded like speed: green = gentle, yellow =
+  // moderate, red = steep.
+  const slopeElement = document.getElementById('slopeValue');
+  if (slopeElement) {
+    const slopeDeg = Math.round(Math.atan(slopeRatio) * RAD_TO_DEG);
+    const slopePct = Math.round(slopeRatio * 100);
+    slopeElement.textContent = `${slopeDeg}° (${slopePct}%)`;
+    slopeElement.style.color = slopeRatio > SLOPE_STEEP ? '#FF5252'
+      : slopeRatio > SLOPE_MODERATE ? '#FFD700'
+      : '#4CAF50';
+  }
+
   const groundElement = document.getElementById('groundStatus');
   if (groundElement) {
     if (isInAir) {
@@ -110,8 +126,8 @@ export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: bo
   }
 }
 
-// Update the live timer (and keep the best-time value fresh) during gameplay.
-export function updateTimerDisplay(gameActive: boolean, startTime: number, bestTime: number): void {
+// Update the live run timer during gameplay.
+export function updateTimerDisplay(gameActive: boolean, startTime: number): void {
   if (gameActive) {
     const currentTime = (performance.now() - startTime) / 1000;
 
@@ -119,12 +135,6 @@ export function updateTimerDisplay(gameActive: boolean, startTime: number, bestT
     const currentTimeElement = document.getElementById('currentTime');
     if (currentTimeElement) {
       currentTimeElement.textContent = formatStatTime(currentTime);
-    }
-
-    // Keep best time updated
-    const bestTimeElement = document.getElementById('bestTimeValue');
-    if (bestTimeElement) {
-      bestTimeElement.textContent = formatStatTime(bestTime);
     }
   }
 }

--- a/src/ui/result-overlay.ts
+++ b/src/ui/result-overlay.ts
@@ -8,7 +8,6 @@ import { AudioModule } from '../audio.js';
 import { Sfx } from '../sfx.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
-import { formatStatTime } from './hud.js';
 
 // Add timer and best time tracking (state.startTime / state.bestTime)
 const MIN_VALID_SCORE_TIME = 4;
@@ -167,13 +166,6 @@ export function createShowGameOver(deps: ResultOverlayDeps): (reason: string) =>
         state.bestTime = currentTime;
         bestTimeDisplay.textContent = `New Best Time: ${state.bestTime.toFixed(2)}s`;
         bestTimeDisplay.style.color = '#ffff00'; // Highlight new record
-
-        // Update the best time in the game stats window too
-        const bestTimeElement = document.getElementById('bestTimeValue');
-        if (bestTimeElement) {
-          bestTimeElement.textContent = formatStatTime(state.bestTime);
-          bestTimeElement.style.color = '#ffff00'; // Highlight new record
-        }
       } else {
         bestTimeDisplay.textContent = `Your Time: ${currentTime.toFixed(2)}s (Best: ${state.bestTime.toFixed(2)}s)`;
         bestTimeDisplay.style.color = 'white';

--- a/tests/result-overlay-tests.js
+++ b/tests/result-overlay-tests.js
@@ -37,7 +37,7 @@ const { document } = window;
 // Reset the overlay DOM for one showGameOver scenario; returns the injected deps.
 function makeDeps({ bestTime = Infinity, startTime, onCrash } = {}) {
   document.body.innerHTML = `
-    <div id="gameStatsContainer"><button id="toggleStats">▲</button><span id="bestTimeValue">--</span></div>
+    <div id="gameStatsContainer"><button id="toggleStats">▲</button></div>
     <div id="leaderboard" style="display:none"></div>
     <div id="gameOverOverlay" style="display:none">
       <p id="gameOverDetail"></p>
@@ -101,7 +101,6 @@ async function main() {
     createShowGameOver(deps)(FINISH);
     check('finish records the score via AuthModule', typeof recorded === 'number');
     check('finish sets a new best time readout', /New Best Time/.test(deps.bestTimeDisplay.textContent));
-    check('finish updates the stats best-time element', document.getElementById('bestTimeValue').textContent.endsWith('s'));
     check('finish (not signed in) inserts the login prompt', !!document.getElementById('loginPrompt'));
     check('finish logs a complete_game analytics event', analyticsEvents.some(e => e[0] === 'complete_game'));
     check('overlay is shown', deps.gameOverOverlay.style.display === 'flex');


### PR DESCRIPTION
## What & why

The Game Stats panel's **Best Time** row duplicated the best time that's already shown on the result screen and the global leaderboard, while the live HUD told you nothing about the terrain you're skiing. This swaps that row for a live **Slope** readout — the steepness of the terrain under the snowman, in **degrees and percent grade** (rise/run), color-coded by pitch.

![Game Stats panel with Slope](https://raw.githubusercontent.com/den-run-ai/snowglider/b594d38842ea6cb5a359ce81ddcf8f64e574cb32/slope-hud-panel.png)

## Changes
- `index.html`: Best Time row → Slope row (`#bestTimeValue` → `#slopeValue`).
- `src/ui/hud.ts`: render the slope from the gradient magnitude the run loop supplies — `atan` → degrees, `×100` → percent. Color tiers (green/yellow/red) calibrated to the measured run (median pitch ~24°): green &lt;18°, yellow 18–30°, red &gt;30°. Drops the now-dead best-time HUD writes and the unused `bestTime` params from `initializeGameStats`/`updateTimerDisplay`.
- `src/game/main-loop.ts`: sample `Snow.getTerrainGradient` under the player and pass the magnitude to `updateStatsHud`.
- `src/game/lifecycle.ts` / `src/snowglider.ts`: update the call sites for the trimmed signatures; drop the dead best-time color reset.
- `src/ui/result-overlay.ts`: drop the dead `#bestTimeValue` write (the element is gone). **Best-time persistence (localStorage + Firestore), the result-screen readout, and the leaderboard are unchanged.**
- `tests/result-overlay-tests.js`: drop the assertion on the removed element.

## Testing
- `npm run lint` — 0 errors (pre-existing `any` warnings only)
- `npx tsc --noEmit` — clean
- `npm test` — all Node suites green (result-overlay 22/22, lifecycle 9/9, physics-invariant verify OK)
- `npm run test:browser` — 94/94, all 7 suites
- `npm run build` — dist emits `#slopeValue`
- Manual: ran the game and confirmed the live readout (screenshot above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)