### PR TITLE
Graded snowplow: stop vs. slow-down + steep-slope failure (#54)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,43 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Snowplow: stop vs. slow-down + steep-slope failure, aligned to the Slope HUD (#54)
+- The snowplow was a single on/off "pizza" brake that stopped you on **any** skiable
+  pitch. It is now a **graded wedge** with two real behaviors, tied to the terrain.
+- **Stop vs. slow-down (hold ramp).** A new `plowCharge ∈ [0,1]` on `snowman.userData`
+  builds while Brake (↓ / S) is held and decays on release (mirroring `carveCharge`).
+  The brake deceleration scales with it, so a **tap only trims speed** while a
+  **sustained hold deepens the wedge to a full stop**. The ski-wedge pose deepens with
+  the same charge (`wedge = 0.18 + 0.32·plowCharge`), so the intent reads on the skis.
+- **Steep-slope failure.** The full wedge's deceleration is **capped**, so where the
+  slope's gravity component exceeds it the wedge can only hold a slow **terminal
+  speed**, not stop — "you can't pizza a black diamond." This falls straight out of the
+  force balance (no special-casing) and makes the steep upper mountain / avalanche
+  escape demand carving or hop turns instead of a free stop anywhere.
+- **Aligned to the Slope HUD tiers (#201).** The two thresholds are the slope gravity
+  at the HUD's tier edges (`0.32 ≈ 18°` → `3.14 m/s²`, `0.58 ≈ 30°` → `5.68 m/s²`), so
+  the readout doubles as a "can I stop here?" cue: 🟢 green (<18°) a tap stops you;
+  🔵 blue (18–30°) needs a full wedge; ◆ black diamond (>30°) can only be slowed.
+- **Slope HUD relabeled to ski difficulty.** The Game Stats slope readout now shows the
+  familiar trail marks — `● Green` / `■ Blue` / `◆ Black` — instead of generic
+  green/yellow/red, matching the snowplow thresholds (`src/ui/hud.ts`).
+- **Slope readout de-flickered.** The raw per-frame gradient is noisy, so the readout
+  (and its tier) used to jump several degrees every frame. It is now an exponential
+  moving average, with hysteresis on the tier edges so the difficulty mark only flips
+  once the pitch is clearly past a boundary. Display-only — the physics still uses the
+  raw per-frame gradient.
+- Removed the old fixed `+3 m/s²` uphill nudge that rode alongside the brake: as a
+  constant it applied even to a feather-light wedge, which both stopped you on terrain
+  too steep to wedge and pushed the stop threshold past anything the run skis (defeating
+  both the gradation and the steep failure). The no-reverse guarantee comes from the
+  impulse clamp, which is retained.
+- **Invariant-safe**: all of this is gated on `controls.down`, so the no-input coasting
+  path stays byte-identical to the frozen baseline (no `snowman_baseline.js` regen).
+  New gating harness checks: the stop-vs-slow-down gradation (hold < tap < coast) and
+  steep-slope failure (a full wedge stalls on a black-diamond constant slope but stops
+  on a gentler one). Model + tier table in
+  [`PHYSICS.md` §3.4](PHYSICS.md#34-snowplow-brake-stop-slow-down-and-steep-slope-failure).
+
 ### Realistic rock colours + cliff outcrops + terrain/tree biome alignment
 - **Varied stone colours** — rocks no longer share one uniform grey. `createRock`
   now draws each rock's bare-stone base from a small weighted palette of realistic

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -30,7 +30,7 @@ and touch are fully interchangeable ([`ARCHITECTURE.md` §6](ARCHITECTURE.md#6-i
 |---|---|---|---|
 | **← / →** or **A / D** | Tap left / right of screen | **Steer.** Default is a *parallel (skidded)* turn; holding a smooth line locks it into a *carve* — see Techniques below | [`PHYSICS.md` §3.3](PHYSICS.md#33-ski-technique-the-skill-layer), §3.6 |
 | **↑ / W** | Tap top of screen | **Speed up.** With no steering this is the *tuck* (least friction, most speed, least control) | [`PHYSICS.md` §3.3](PHYSICS.md#33-ski-technique-the-skill-layer) |
-| **↓ / S** | Tap bottom of screen | **Brake — snowplow / "pizza".** Sheds real speed along the travel direction; clamped so it never reverses uphill from a standstill | [`PHYSICS.md` §3.4](PHYSICS.md#34-snowplow-brake-and-why-it-is-clamped) |
+| **↓ / S** | Tap bottom of screen | **Brake — snowplow / "pizza".** A hold ramp: a tap only trims speed, a sustained hold deepens the wedge to a full stop — but only on green/blue pitches; a black-diamond slope is too steep to stop (only slows). Clamped so it never reverses uphill | [`PHYSICS.md` §3.4](PHYSICS.md#34-snowplow-brake-stop-slow-down-and-steep-slope-failure) |
 | **Space** | Tap center of screen | **Jump.** A straight pop when not steering; a *player-initiated* jump is graded on landing and can earn a capped speed boost | [`PHYSICS.md` §4](PHYSICS.md#4-jumps--air), [`MEANINGFUL_JUMPS.md`](MEANINGFUL_JUMPS.md) |
 | **Space + ← / →** | (center + side) | **Hop turn.** A quick grounded edge-set pivot for tight, steep terrain: snaps the heading and scrubs speed with a small pop | [`PHYSICS.md` §4](PHYSICS.md#4-jumps--air) (hop turn) |
 | **V** | — | **Toggle camera view** (follow ↔ alternate) | [`ARCHITECTURE.md` §6](ARCHITECTURE.md#6-input) |
@@ -54,7 +54,7 @@ scrub, *and* its pose. Full model and constants in
 |---|---|---|
 | **Parallel turn** (skidded) | Steer ← / → uncommitted (fresh, reversed, or abrupt) | Skis brush sideways and **scrub speed**; **tighter** arc, body upright. The entry turn |
 | **Carve** | Steer ← / → and *hold a smooth line* until the edge locks (`carveCharge > 0.6`) | The locked edge **holds speed**; **wider** arc with a deep body lean. The mastery turn above a parallel |
-| **Snowplow / pizza** | Hold Brake (↓ / S) | Wedge the ski tips together to scrub speed and **stop**; sharp, planted turns |
+| **Snowplow / pizza** | Brake (↓ / S) — tap to slow, hold to stop | Wedge the ski tips together: a tap trims speed, a held wedge deepens to a **stop**; sharp, planted turns. Too steep (black diamond ◆) and even a full wedge only slows — match the Slope HUD tier |
 | **Tuck** | Speed up (↑ / W) with **no steering** | Straight-line for **maximum speed** — least friction, least control |
 | **Hop turn** | **Jump + Steer** (Space + ← / →, grounded) | A quick pivot that snaps the heading and scrubs ~18% speed; for tight, steep terrain |
 

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -128,7 +128,7 @@ they read clearly differently to drive and to watch.
 |-----------|---------|--------|
 | **Parallel (skidded)** | Left/Right, uncommitted (fresh, *reversed*, or abrupt) | Skis brush sideways and **scrub speed** (`skidScrub` near full); **tighter** turn (`turnForce → 19`); skis stay flatter, body upright |
 | **Carve** | Left/Right, *committed* (held smoothly, `carveCharge > 0.6`) | **Holds speed** — the locked edge sheds ~92% of the wash-out; **wider** arc (`turnForce → 10`); skis roll onto edge + draw together with a deep body lean. The mastery turn above a parallel |
-| **Snowplow** | Down | Sheds real speed, but sharper, planted turns (`turnForce = 24`, grip = 1.0); skis form a wedge |
+| **Snowplow** | Down (hold ramp) | Sheds real speed, sharper planted turns (`turnForce = 24`, grip = 1.0); skis form a wedge that **deepens the longer you hold** (`plowCharge`): a tap only trims speed, a full wedge stops you — but only where the slope isn't too steep (§3.4) |
 | **Tuck**  | Up, no steer | Least friction, most speed, least control (`accel = 10` on `-z`) |
 | **Hop turn** | Jump **+** Left/Right (grounded) | A quick edge-set pivot: snaps heading ~0.4 rad toward the steer, scrubs ~18% speed, small pop; lands on a fresh edge (see §4) |
 
@@ -171,8 +171,9 @@ skidScrub = 0  unless (steering && currentSpeed > 4):
 
 `technique` is classified each frame and returned for the HUD and ski pose: a steered
 turn reads as **`parallel`** (skidded) until the edge locks in, then **`carve`** once
-`carveCharge > CARVE_LOCK` (0.6). The snowplow forms a ski wedge (`wedge = 0.35 rad`)
-with the **tips converging and the tails splayed out** (a real "pizza"); a **carve**
+`carveCharge > CARVE_LOCK` (0.6). The snowplow forms a ski wedge whose depth tracks the
+brake commitment (`wedge = 0.18 + 0.32 * plowCharge` rad — a light check that opens
+into a deep "pizza") with the **tips converging and the tails splayed out**; a **carve**
 rolls the skis hard onto their edges, draws them together, and inclines the whole body
 into the turn (lean clamp raised to ~0.42 rad); a **skidded parallel** turn keeps the
 skis flatter and the body upright. The pose is purely cosmetic — it never touches the
@@ -180,23 +181,56 @@ physics. The always-on turn tax (faded out by a carve) keeps turning from ever b
 entirely free, so straight-lining stays the fastest line and a clean carve still
 finishes far faster than chatter-skidding (≈30%+ in the verification harness, §6).
 
-### 3.4 Snowplow brake (and why it is clamped)
+### 3.4 Snowplow brake: stop, slow-down, and steep-slope failure
 
 Snowplow decelerates **along the actual direction of travel**, so it bleeds
-genuine speed rather than only downhill velocity:
+genuine speed rather than only downhill velocity. The wedge is a **hold ramp**, not an
+on/off brake: `plowCharge ∈ [0,1]` builds while Down is held and decays when released
+(mirroring `carveCharge`), and the deceleration scales with it. A tap gives a shallow
+wedge that only trims speed; a sustained hold deepens it into a full "pizza" that can
+bring you to a stop.
 
 ```
-if (snowplow && currentSpeed > 0.001):
-    brakeImpulse = min(14.0 * delta, currentSpeed)   // clamp: never reverse velocity
-    velocity -= (velocity / currentSpeed) * brakeImpulse
-    if (brakeImpulse < currentSpeed):                // only while still moving
-        velocity.z += 10.0 * delta * 0.3             // slight uphill control bias
+// wedge depth (per-frame, on snowman.userData; cleared by resetSnowman):
+plowCharge = snowplow ? min(1, plowCharge + delta * 1.6)   // ~0.6 s of holding => full wedge
+                      : max(0, plowCharge - delta * 4.0)   // relaxes quickly on release
+
+brakeSpeed = |velocity|                                    // AFTER this frame's gravity
+if (snowplow && brakeSpeed > 0.001):
+    brakeDecel   = 3.14 + (5.68 - 3.14) * plowCharge        // light -> full wedge
+    brakeImpulse = min(brakeDecel * delta, brakeSpeed)      // clamp: never reverse velocity
+    velocity    -= (velocity / brakeSpeed) * brakeImpulse
 ```
 
-The `min(..., currentSpeed)` clamp and the `brakeImpulse < currentSpeed` guard are
-load-bearing: without them, at low speed the subtraction overshoots zero and the
-control bias drives the snowman **uphill from a standstill**, letting players stall
-or climb the timed course by braking.
+The `min(..., brakeSpeed)` clamp is load-bearing: without it, at low speed the
+subtraction overshoots zero and drives the snowman **uphill from a standstill**,
+letting players stall or climb the timed course by braking. `brakeSpeed` is recomputed
+here from the **post-gravity** velocity (not the stale start-of-frame speed): scaling
+by the smaller pre-gravity speed over-removed velocity as it dropped, which pinned the
+snowman to a stop well past the cap (~36° rather than 30°), so a pitch the HUD calls
+black could still be fully stopped. Recomputing keeps the removed impulse exactly
+`brakeDecel · delta`, so the stop/fail boundary lands on the tier edge. (The earlier fixed
+`+3 m/s²` uphill nudge that rode alongside the brake was removed — as a *constant* it
+applied even to a feather-light wedge, which both stopped you on terrain too steep to
+wedge and pushed the stop threshold past anything the run actually skis; it is folded
+into `PLOW_MAX_DECEL`, and the clamp alone is what prevents reversal.)
+
+**Steep-slope failure.** Because the full wedge's deceleration is *capped*
+(`PLOW_MAX_DECEL`), it cannot stop you where the slope's gravity component
+`steepness × g` exceeds it — there it only holds a slow **terminal speed**. The two
+thresholds are pinned to the Slope-HUD colour tiers (PR #201, `src/ui/hud.ts`:
+`SLOPE_MODERATE = 0.32 ≈ 18°`, `SLOPE_STEEP = 0.58 ≈ 30°`) by setting each decel to the
+slope gravity at the tier edge (`0.32 × 9.8 = 3.14`, `0.58 × 9.8 = 5.68`), so the live
+readout doubles as a "can I stop here?" cue:
+
+| Slope HUD | Pitch | Light wedge (tap) | Full wedge (hold) |
+|-----------|-------|-------------------|-------------------|
+| 🟢 green  | < 18° | stops you | stops you |
+| 🟡 yellow | 18–30° | only slows | stops you |
+| 🔴 red    | > 30° | only slows | **only slows** (can't stop) |
+
+This graceful degradation is what makes the steep upper mountain — and outrunning an
+avalanche — actually demand carving/hopping instead of a free "pizza" anywhere (#54).
 
 ### 3.5 Automatic turning (idle wander)
 
@@ -507,7 +541,8 @@ then reverted so the camera manager's smoothing never re-ingests its own shake.
 | Base / max coast friction | 0.012 / 0.032 | `snowman.js` |
 | Turn force (parallel/snowplow/carve) | 19 / 24 / 10 (×0.85 over 18 u/s) | `snowman.js` |
 | Accel (tuck) | 10 | `snowman.js` |
-| Brake decel | 14 | `snowman.js` |
+| Brake decel (light → full wedge) | 3.14 → 5.68 (lerp by `plowCharge`) | `snowman.js` |
+| Plow build / release rate | 1.6 / 4.0 per s | `snowman.js` |
 | Max skid scrub (uncommitted) | 0.10 + 0.008 tax | `snowman.js` |
 | Carve scrub relief | 0.92 | `snowman.js` |
 | Carve build / release rate | 1.5 / 3.0 per s | `snowman.js` |

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
       </div>
       <div class="control-row">
         <span><span class="key">↓</span><span class="key">S</span></span>
-        <span>Snowplow / pizza — wedge the ski tips together to scrub speed &amp; stop</span>
+        <span>Snowplow / pizza — wedge the tips together: tap to slow, hold to stop (too steep = only slows)</span>
       </div>
       <div class="control-row">
         <span><span class="key">↑</span><span class="key">W</span></span>
@@ -208,7 +208,7 @@
         </div>
         <div class="control-item">
           <span class="key-badge">↓/S</span>
-          <span>Snowplow / pizza — tips together to brake &amp; stop</span>
+          <span>Snowplow / pizza — tap to slow, hold to stop (too steep = only slows)</span>
         </div>
         <div class="control-item">
           <span class="key-badge">↑/W</span>

--- a/src/snowman/physics.ts
+++ b/src/snowman/physics.ts
@@ -56,6 +56,8 @@ export function resetSnowman(
     // Clear edge-engagement state so a new run starts with no locked carve.
     snowman.userData.carveCharge = 0;
     snowman.userData.lastSteerDir = 0;
+    // Clear the snowplow wedge depth so a new run starts with no charged brake.
+    snowman.userData.plowCharge = 0;
     // Clear jump provenance so a new run never inherits a stale "this air phase was
     // a deliberate jump" flag from the previous run (meaningful jumps #47, §3.1).
     snowman.userData.playerJump = false;
@@ -242,7 +244,27 @@ export function stepSnowmanPhysics(
       if (snowman.userData) snowman.userData.playerJump = true;
     }
   }
-  
+
+  // --- Snowplow wedge depth: stop vs. slow-down, and steep-slope failure -----
+  // `plowCharge` (0..1) is a hold ramp (mirroring carveCharge): tapping Brake forms a
+  // shallow wedge that only trims speed, while holding it deepens into a full wedge
+  // that can stop you — on moderate terrain. It is driven by `controls.down` EVERY
+  // frame (incl. airborne) so the tap-vs-hold contract survives a jump: releasing Brake
+  // in the air relaxes the wedge for the landing, and holding it pre-builds the charge.
+  // The actual braking is still applied only while grounded (see the brake block
+  // below, gated on `snowplow = down && !isInAir`). It is read/written every frame but
+  // only ever alters velocity under a grounded Brake, so the no-input coasting path
+  // stays byte-identical to the frozen baseline; resetSnowman clears it between runs.
+  const PLOW_BUILD_RATE = 1.6;    // ~0.6s of holding Brake to reach a full wedge
+  const PLOW_RELEASE_RATE = 4.0;  // wedge relaxes quickly once you ease off Brake
+  {
+    const ud = snowman.userData || (snowman.userData = {});
+    const charge = ud.plowCharge || 0;
+    ud.plowCharge = controls.down
+      ? Math.min(1, charge + delta * PLOW_BUILD_RATE)
+      : Math.max(0, charge - delta * PLOW_RELEASE_RATE);
+  }
+
   // Update vertical position and velocity when in air
   if (isInAir) {
     // Track time in air
@@ -328,6 +350,9 @@ export function stepSnowmanPhysics(
     }
     ud.carveCharge = carveCharge;
     ud.lastSteerDir = lastSteerDir;
+    // Snowplow wedge depth was already advanced this frame (before the air/ground
+    // split, so it tracks Brake through a jump); read it back for the brake + pose.
+    const plowCharge = ud.plowCharge || 0;
 
     // Steering authority sets the turn RADIUS, and it is the inverse of commitment:
     //   - a skidded PARALLEL turn pivots tight (high authority) but scrubs speed;
@@ -348,28 +373,54 @@ export function stepSnowmanPhysics(
       velocity.x += turnForce * delta;
     }
 
-    // Forward input / straight-line tuck.
+    // Forward input / straight-line tuck. Brake overrides accelerate: Up and Down are
+    // independent key states, and the accelerate impulse (10) is stronger than even a
+    // full wedge's brake cap (5.68), so without this gate holding W+S would accelerate
+    // downhill instead of braking. A wedge and a forward push are mutually exclusive
+    // anyway, so the snowplow simply ignores Up.
     const accelerationForce = 10.0;
-    if (controls.up) {
+    if (controls.up && !snowplow) {
       velocity.z -= accelerationForce * delta;
     }
 
-    // Snowplow braking: decelerate along the actual direction of travel so it
-    // bleeds genuine speed (not just downhill velocity), with a little extra dig.
-    // Clamp the impulse to the current speed so braking can bring the snowman to a
-    // stop but never reverse the velocity vector - otherwise at low speed the
-    // subtraction overshoots zero and the control bias below drives it back uphill,
-    // letting players climb/stall the timed course by braking.
-    if (snowplow && currentSpeed > 0.001) {
-      const brakeDecel = 14.0;
-      const brakeImpulse = Math.min(brakeDecel * delta, currentSpeed);
-      velocity.x -= (velocity.x / currentSpeed) * brakeImpulse;
-      velocity.z -= (velocity.z / currentSpeed) * brakeImpulse;
-      // Only nudge the slight uphill control bias while still moving; never after the
-      // brake has stopped the snowman (that would push it uphill from a standstill).
-      if (brakeImpulse < currentSpeed) {
-        velocity.z += accelerationForce * delta * 0.3;
-      }
+    // Snowplow braking: decelerate along the actual direction of travel so it bleeds
+    // genuine speed (not just downhill velocity). The deceleration scales with wedge
+    // depth (plowCharge): a light wedge (PLOW_MIN_DECEL) only trims speed, a full
+    // wedge (PLOW_MAX_DECEL) can stop you. PLOW_MAX_DECEL is the strongest brake there
+    // is, so on steep pitches where gravity-along-slope exceeds it even a full wedge
+    // can only hold a slow terminal speed — steep-slope failure falls straight out of
+    // the force balance, no special-casing. (The old fixed +3 m/s² uphill nudge that
+    // used to ride alongside the brake is folded into PLOW_MAX_DECEL: as a constant it
+    // applied even to a feather-light wedge, which both stopped you on terrain too
+    // steep to wedge and pushed the stop threshold past anything the run actually
+    // skis, defeating the gradation and the steep-slope failure.) Clamp the impulse to
+    // the current speed so braking can bring the snowman to a stop but never reverse
+    // the velocity vector — at low speed an unclamped subtraction would overshoot zero
+    // and let players creep/stall the timed course uphill by braking.
+    //
+    // Thresholds are aligned to the ski-difficulty tiers the Slope HUD shows (PR #201,
+    // src/ui/hud.ts boundaries SLOPE_MODERATE 0.32 ≈ 18° and SLOPE_STEEP 0.58 ≈ 30°),
+    // so the readout doubles as a "can I stop here?" cue — and "you can't pizza a black
+    // diamond" holds literally: on a GREEN run (<18°) even a light wedge stops you; on a
+    // BLUE run (18–30°) you need a committed full wedge; on a BLACK-DIAMOND pitch (>30°)
+    // even a full wedge can only check your speed, not halt you. Each decel is the slope
+    // gravity at a tier edge (steepness × 9.8 m/s²: 0.32→3.14, 0.58→5.68). For the stop
+    // boundary to land *exactly* on the tier edge the brake must remove precisely
+    // `brakeDecel·delta` along travel, so it is computed from the speed AFTER this
+    // frame's gravity, not the stale start-of-frame `currentSpeed`. (Scaling by the
+    // stale, smaller pre-gravity speed over-removed velocity as speed dropped, pinning
+    // the snowman to a stop well past the cap — ~36° instead of 30° — so a pitch the HUD
+    // calls black could still be stopped. Recomputing here keeps the brake honest; the
+    // per-frame coast friction below then vanishes as v→0, so it does not shift the
+    // boundary.)
+    const PLOW_MIN_DECEL = 3.14;    // light wedge: stops on green (<18°), only slows above
+    const PLOW_MAX_DECEL = 5.68;    // full wedge: stops up to the black-diamond line (~30°), fails above
+    const brakeSpeed = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
+    if (snowplow && brakeSpeed > 0.001) {
+      const brakeDecel = PLOW_MIN_DECEL + (PLOW_MAX_DECEL - PLOW_MIN_DECEL) * plowCharge;
+      const brakeImpulse = Math.min(brakeDecel * delta, brakeSpeed);
+      velocity.x -= (velocity.x / brakeSpeed) * brakeImpulse;
+      velocity.z -= (velocity.z / brakeSpeed) * brakeImpulse;
     }
 
     // Edge skid / carve drag: only meaningful while steering. A skidded parallel

--- a/src/snowman/pose.ts
+++ b/src/snowman/pose.ts
@@ -36,7 +36,11 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   if (!isInAir && snowman.userData && snowman.userData.leftSki && snowman.userData.rightSki) {
     const ls = snowman.userData.leftSki, rs = snowman.userData.rightSki;
     const lerp = Math.min(1, delta * 10);
-    const wedge = technique === 'snowplow' ? 0.35 : 0.0; // radians; converge the tips ("pizza")
+    // Wedge depth tracks how hard the player is braking (plowCharge, set in physics):
+    // a light wedge for a quick speed check that opens into a deep "pizza" for a full
+    // stop, so the snowplow's stop-vs-slow-down intent reads on the skis (issue #54).
+    const plowCharge = (snowman.userData.plowCharge as number) || 0;
+    const wedge = technique === 'snowplow' ? 0.18 + 0.32 * plowCharge : 0.0; // radians; converge the tips ("pizza")
     // Each ski's tip is at local +z and the skis sit at x = ∓1, so a POSITIVE
     // rotation.y swings the left ski's tip toward center and a NEGATIVE one swings
     // the right ski's tip toward center — tips meet, tails splay out (a real

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -19,12 +19,30 @@ const M_TO_FT = 3.280839895;     // metres → feet
 // downhill). Cosmetic only — it shifts the readout, not the physics.
 const BASE_ELEVATION_M = 1500;
 const RAD_TO_DEG = 180 / Math.PI;
-// Slope steepness colour tiers, in gradient magnitude (rise/run = tan θ).
-// Calibrated to the measured run: the skiable line sits around 15–40° (median
-// ~24°), so gentle flats read green, the typical pitch yellow, and only the
-// genuinely steep black-diamond sections (≈30°+) read red.
-const SLOPE_MODERATE = 0.32;     // ≈18° / 32% — green → yellow
-const SLOPE_STEEP = 0.58;        // ≈30° / 58% — yellow → red
+// Slope steepness tiers, in gradient magnitude (rise/run = tan θ), shown with the
+// familiar ski-trail difficulty marks (● green / ■ blue / ◆ black diamond).
+// Difficulty is relative to this run (the skiable line sits around 15–40°, median
+// ~24°, which is steep in absolute terms), and the boundaries double as the
+// snowplow's "can I stop here?" cue — the wedge can fully stop you up to the black
+// line and only checks speed beyond it (PHYSICS.md §3.4, issue #54).
+const SLOPE_MODERATE = 0.32;     // ≈18° / 32% — green (●) → blue (■)
+const SLOPE_STEEP = 0.58;        // ≈30° / 58% — blue (■) → black diamond (◆)
+// The raw per-frame gradient is noisy (high-frequency terrain detail makes it jump
+// several degrees frame-to-frame as the snowman moves), which made the readout — and
+// its difficulty tier — flicker. Smooth the *display* value with an exponential
+// moving average so it reads steadily; the physics is untouched (it uses its own raw
+// per-frame gradient). `null` until the first sample seeds it; reset on a new run.
+const SLOPE_SMOOTH = 0.12;       // EMA weight on each new sample (~0.4s settle @60fps)
+const SLOPE_TIER_HYST = 0.03;    // deadband around each tier edge so the label/colour
+                                 // doesn't dither when the pitch hovers on a boundary
+const SLOPE_TIERS = [
+  { mark: '●', name: 'Green', color: '#4CAF50' },
+  { mark: '■', name: 'Blue', color: '#4FC3F7' },
+  { mark: '◆', name: 'Black', color: '#FFFFFF' }, // white: a true-black glyph is invisible on the dark panel
+];
+const SLOPE_EDGES = [SLOPE_MODERATE, SLOPE_STEEP]; // green|blue edge, blue|black edge
+let smoothedSlope: number | null = null;
+let slopeTierIdx = 0;
 
 // Format a run time for the Game Stats panel. One decimal is plenty of
 // precision for the live readout, and keeps the values consistent wherever the
@@ -35,6 +53,9 @@ export function formatStatTime(seconds: number): string {
 
 // Wire up the Game Stats panel collapse/swipe behavior.
 export function initializeGameStats(): void {
+  // Re-seed the slope EMA + tier so a new run doesn't drift in from the last run.
+  smoothedSlope = null;
+  slopeTierIdx = 0;
   // Game stats panel collapse/swipe behavior (shared with the Controls panel).
   setupCollapsiblePanel({
     name: 'game stats',
@@ -90,17 +111,30 @@ export function updateStatsHud(result: UpdateResult, pos: PlayerPos, isInAir: bo
     altitudeElement.textContent = `${Math.round(altitudeM)} m (${Math.round(altitudeM * M_TO_FT)} ft)`;
   }
 
-  // Slope / incline of the terrain under the player, in degrees and percent
-  // grade (rise/run × 100). Color-coded like speed: green = gentle, yellow =
-  // moderate, red = steep.
+  // Slope / incline of the terrain under the player, in degrees and percent grade
+  // (rise/run × 100), tagged with the ski-trail difficulty mark for that pitch:
+  // ● green (gentle), ■ blue (moderate), ◆ black diamond (steep). The value is an
+  // EMA of the noisy per-frame gradient, and the difficulty tier only changes once
+  // the smoothed pitch is past an edge by SLOPE_TIER_HYST, so neither flickers.
   const slopeElement = document.getElementById('slopeValue');
   if (slopeElement) {
-    const slopeDeg = Math.round(Math.atan(slopeRatio) * RAD_TO_DEG);
-    const slopePct = Math.round(slopeRatio * 100);
-    slopeElement.textContent = `${slopeDeg}° (${slopePct}%)`;
-    slopeElement.style.color = slopeRatio > SLOPE_STEEP ? '#FF5252'
-      : slopeRatio > SLOPE_MODERATE ? '#FFD700'
-      : '#4CAF50';
+    smoothedSlope = smoothedSlope === null
+      ? slopeRatio
+      : smoothedSlope + (slopeRatio - smoothedSlope) * SLOPE_SMOOTH;
+    const slope = smoothedSlope;
+    // Hysteresis: step up only when clearly above the current band's top edge, and
+    // down only when clearly below its bottom edge (one step per frame; the EMA
+    // never jumps a whole band in a frame).
+    if (slopeTierIdx < SLOPE_EDGES.length && slope > SLOPE_EDGES[slopeTierIdx] + SLOPE_TIER_HYST) {
+      slopeTierIdx++;
+    } else if (slopeTierIdx > 0 && slope < SLOPE_EDGES[slopeTierIdx - 1] - SLOPE_TIER_HYST) {
+      slopeTierIdx--;
+    }
+    const tier = SLOPE_TIERS[slopeTierIdx];
+    const slopeDeg = Math.round(Math.atan(slope) * RAD_TO_DEG);
+    const slopePct = Math.round(slope * 100);
+    slopeElement.textContent = `${slopeDeg}° (${slopePct}%) ${tier.mark} ${tier.name}`;
+    slopeElement.style.color = tier.color;
   }
 
   const groundElement = document.getElementById('groundStatus');

--- a/tests/verification/physics_invariant_harness.js
+++ b/tests/verification/physics_invariant_harness.js
@@ -109,6 +109,31 @@ function simulateCtrl(updateFn, ctrl, seed, { steps = 120, dt = 1 / 60, z0 = -40
   return { finalSpeed: Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z), x: pos.x };
 }
 
+// Like simulateCtrl(), but on a CONSTANT-slope terrain (downhill is -z, steepness ==
+// `slope`) instead of the radial test hill. The radial hill gentles out underneath a
+// descending snowman, which masks the snowplow's steady-state force balance; a constant
+// slope shows it cleanly (e.g. a full wedge holding a terminal speed on a steep pitch).
+// currentTurnDirection starts at 0 and only flips after the ~3s auto-turn cooldown, so
+// for the short windows used here there is no auto-turn lateral velocity (vx stays 0).
+function simulateSlope(updateFn, ctrl, { slope, vz0 = -8, steps = 60, dt = 1 / 60, seed = 7 }) {
+  const gH = (x, z) => slope * z;          // z more negative => lower => downhill in -z
+  const gG = () => ({ x: 0, z: slope });
+  const gD = () => ({ x: 0, z: -1 });
+  Math.random = makeRng(seed);
+  const snowman = fakeSnowman();
+  const pos = { x: 0, z: 0, y: gH(0, 0) };
+  const velocity = { x: 0, z: vz0 };
+  let st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: gH(0, 0),
+             airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+  for (let i = 0; i < steps; i++) {
+    const c = typeof ctrl === 'function' ? ctrl(i) : ctrl;
+    st = updateFn(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity,
+      st.lastTerrainHeight, st.airTime, st.jumpCooldown, c,
+      st.turnPhase, st.currentTurnDirection, st.turnChangeCooldown, 3.0, gH, gG, gD, [], false, function () {});
+  }
+  return { finalSpeed: Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z), z: pos.z };
+}
+
 // The frozen baseline is still a classic script, so it loads via vm.runInContext.
 // src/snowman is now an ES module (issue #84, PR 2.8) and can't be evaluated
 // that way, so import the REAL module and read its updateSnowman directly. The
@@ -168,6 +193,90 @@ console.log('  plow  finalSpeed:', plow.finalSpeed.toFixed(2), 'distance:', plow
 console.log('  PASS:', brakeOk ? 'brake slows you ✅' : 'no slowdown ❌');
 console.log('  PASS:', noReverse ? 'brake does not reverse uphill ✅' : `reverses uphill (distance ${plow.distance.toFixed(2)}) ❌`);
 if (!brakeOk || !noReverse) hardFail = true;
+
+// 2b) Snowplow stop-vs-slow-down gradation [GATING]. The wedge is a hold ramp
+// (plowCharge): a quick TAP forms a shallow wedge that only trims speed, while a
+// sustained HOLD deepens into a full wedge that brakes far harder. Over one fixed
+// short window on the same moderate (~27deg) pitch the ordering must be
+// hold < tap < coast — deeper/longer wedge => more speed shed. (Issue #54.)
+const TAP_FRAMES = 18; // ~0.3s tap => a shallow wedge that only trims speed
+const gradOpt = { slope: 0.5, vz0: -5, steps: 45 };
+const gCoast = simulateSlope(mod, () => NONE, gradOpt).finalSpeed;
+const gTap   = simulateSlope(mod, (i) => (i < TAP_FRAMES ? DOWN : NONE), gradOpt).finalSpeed;
+const gHold  = simulateSlope(mod, () => DOWN, gradOpt).finalSpeed;
+const gradOk = gHold < gTap - 0.1 && gTap < gCoast - 0.1;
+console.log('\n--- Snowplow gradation: hold (full wedge) < tap (light wedge) < coast [GATING] ---');
+console.log('  coast:', gCoast.toFixed(2), '| tap:', gTap.toFixed(2), '| hold:', gHold.toFixed(2));
+console.log('  PASS:', gradOk ? 'deeper/longer wedge sheds more speed ✅' : 'gradation not monotonic ❌');
+if (!gradOk) hardFail = true;
+
+// 2c) Steep-slope failure, with the stop/fail boundary pinned to the Slope-HUD edge
+// [GATING]. The full wedge's deceleration is capped at the blue→black-diamond tier
+// edge (steepness 0.58 ≈ 30°), so the boundary must land *there*: a BLUE pitch just
+// under it stops, a BLACK pitch just over it can only be slowed, and steeper black is
+// faster still. The brake removes exactly its capped decel along travel (computed from
+// the post-gravity speed), and the coast friction vanishes as v→0, so neither pushes
+// the boundary past the HUD edge — this guards the regression codex flagged on #204
+// where the boundary sat ~36° and a "black" pitch could still be fully stopped. Run on
+// CONSTANT slopes so the steady state shows without the radial hill gentling out. This
+// graceful degradation is what makes the steep upper mountain (and avalanche escape)
+// actually demand real technique (#54).
+const blueStop   = simulateSlope(mod, () => DOWN, { slope: 0.54, vz0: -8, steps: 240 }).finalSpeed; // ~28°, blue
+const blackEdge  = simulateSlope(mod, () => DOWN, { slope: 0.62, vz0: -8, steps: 240 }).finalSpeed; // ~32°, just into black
+const blackSteep = simulateSlope(mod, () => DOWN, { slope: 0.85, vz0: -8, steps: 240 }).finalSpeed; // ~40°, deep black
+const steepFailOk = blueStop < 0.15 && blackEdge > 0.30 && blackSteep > blackEdge + 0.30;
+console.log('\n--- Snowplow steep-slope failure (boundary pinned to the 30° black edge) [GATING] ---');
+console.log('  blue  (~28°) full-plow finalSpeed:', blueStop.toFixed(2), '(should be ~0: stops)');
+console.log('  black (~32°) full-plow finalSpeed:', blackEdge.toFixed(2), '(should be > 0: cannot stop)');
+console.log('  black (~40°) full-plow finalSpeed:', blackSteep.toFixed(2), '(steeper => faster terminal)');
+console.log('  PASS:', steepFailOk ? 'stops on blue, only slows on black, monotonic on steeper ✅' : 'boundary not at the black edge ❌');
+if (!steepFailOk) hardFail = true;
+
+// 2d) Plow charge tracks Brake through the air [GATING]. The wedge depth must advance
+// from controls.down EVERY frame, not freeze while airborne — so releasing Brake on a
+// jump relaxes the wedge for the landing and holding it pre-builds. Otherwise tap-vs-hold
+// breaks around jumps (the regression codex flagged on #204). Braking itself stays
+// grounded-only; this only governs the charge level. Force a sustained airborne phase
+// (high above terrain, climbing) and read snowman.userData.plowCharge before/after.
+function airCharge(startCharge, ctrl, frames = 12) {
+  const sn = fakeSnowman(); sn.userData.plowCharge = startCharge;
+  const pos = { x: 0, z: -15, y: getTerrainHeight(0, -15) + 30 }; // well above ground => stays airborne
+  const vel = { x: 0, z: -3 };
+  let st = { isInAir: true, verticalVelocity: 5, lastTerrainHeight: getTerrainHeight(0, -15),
+             airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+  for (let i = 0; i < frames; i++) {
+    st = mod(sn, 1 / 60, pos, vel, st.isInAir, st.verticalVelocity, st.lastTerrainHeight, st.airTime,
+      st.jumpCooldown, ctrl, st.turnPhase, st.currentTurnDirection, st.turnChangeCooldown, 3.0,
+      getTerrainHeight, getTerrainGradient, getDownhillDirection, [], false, function () {});
+  }
+  return { plowCharge: sn.userData.plowCharge, airborne: st.isInAir };
+}
+const airReleased = airCharge(1.0, NONE);  // Brake released in the air => wedge relaxes
+const airHeld     = airCharge(0.0, DOWN);  // Brake held in the air => wedge pre-builds
+const airChargeOk = airReleased.airborne && airHeld.airborne
+  && airReleased.plowCharge < 0.7 && airHeld.plowCharge > 0.1;
+console.log('\n--- Snowplow charge tracks Brake through the air [GATING] ---');
+console.log('  released-in-air plowCharge 1.0 ->', airReleased.plowCharge.toFixed(2), '(should fall: wedge relaxes)');
+console.log('  held-in-air     plowCharge 0.0 ->', airHeld.plowCharge.toFixed(2), '(should rise: wedge pre-builds)');
+console.log('  PASS:', airChargeOk ? 'charge follows Brake mid-air, not frozen ✅' : 'charge frozen in air ❌');
+if (!airChargeOk) hardFail = true;
+
+// 2e) Brake overrides accelerate [GATING]. Up and Down are independent key states, and
+// the accelerate impulse (10) is stronger than a full wedge's brake cap (5.68); without
+// the snowplow gate on Up, holding W+S would accelerate downhill instead of braking. On
+// a green slope a full wedge + held Up must still STOP (not exceed plain coasting), and
+// must end far slower than Up-only (tuck). Guards the regression codex flagged on #204.
+const UP = { left: false, right: false, up: true, down: false, jump: false };
+const DOWNUP = { left: false, right: false, up: true, down: true, jump: false };
+const greenOpt = { slope: 0.30, vz0: -10, steps: 150 }; // ~17°, green: a full wedge stops here
+const brakeUp = simulateSlope(mod, () => DOWNUP, greenOpt).finalSpeed;
+const tuckUp  = simulateSlope(mod, () => UP, greenOpt).finalSpeed;
+const overrideOk = brakeUp < 0.5 && brakeUp < tuckUp - 2.0;
+console.log('\n--- Snowplow brake overrides accelerate (W+S held together) [GATING] ---');
+console.log('  brake+up (green) finalSpeed:', brakeUp.toFixed(2), '(should be ~0: brake wins)');
+console.log('  up-only  (tuck)  finalSpeed:', tuckUp.toFixed(2), '(accelerates)');
+console.log('  PASS:', overrideOk ? 'brake overrides simultaneous accelerate ✅' : 'accelerate beats brake ❌');
+if (!overrideOk) hardFail = true;
 
 // 3) Carve vs skid: a committed carve must hold meaningfully more speed than
 // panic-steering [GATING]. This is the speed-management trade-off from issues


### PR DESCRIPTION
## What & why

The snowplow was a single on/off "pizza" brake that stopped you on **any** skiable pitch, with no notion of *how hard* you're braking or *how steep* the slope is. This makes it a **graded wedge tied to the terrain**, answering issue #54 ("more realistic speed control"):

- **Stop vs. slow-down** — pressing Brake (↓ / S) is now a *hold ramp*. A **tap** forms a light wedge that only **trims speed**; a sustained **hold** deepens it into a full wedge that **stops** you.
- **Steep-slope failure** — the full wedge's deceleration is **capped**, so where the slope's gravity component exceeds it the wedge can only hold a slow **terminal speed**, not stop. *You can't pizza a black diamond.* This forces carving / hop turns (and real avalanche escapes) on the steep upper mountain instead of a free stop anywhere.

Aligned to the **Slope HUD difficulty tiers** (just merged in #201), so the readout doubles as a "can I stop here?" cue:

| Slope HUD | Pitch | Tap (light wedge) | Hold (full wedge) |
|---|---|---|---|
| 🟢 **Green** | < 18° | stops you | stops you |
| 🟦 **Blue** | 18–30° | only slows | stops you |
| ◆ **Black diamond** | > 30° | only slows | **only slows** (can't stop) |

## Screenshots

**Full wedge on ● Green → stops (0 km/h).** Note the deepened "pizza" pose and the `Snowplow` status.

![Full snowplow stops on a green slope](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/snowplow-combo-shots/green-stop.png)

**Full wedge on ◆ Black → still sliding (13 km/h).** Same full snowplow, but the slope is too steep to stop — it only checks your speed.

![Snowplow cannot stop on a black diamond](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/snowplow-combo-shots/black-fail.png)

## How it works
- **`plowCharge` ∈ [0,1]** on `snowman.userData` (mirrors `carveCharge`): builds while Brake is held (~0.6 s to full), decays on release. The brake deceleration and the ski-wedge pose both scale with it.
- **Capped brake** `brakeDecel = 3.14 + (5.68 − 3.14)·plowCharge`. The two numbers are the slope gravity at the HUD tier edges (`0.32 × 9.8`, `0.58 × 9.8`), so the stop boundary lands exactly on the difficulty flip — steep failure falls out of the force balance, no special-casing.
- **Removed the old fixed `+3 m/s²` uphill nudge** that rode alongside the brake: as a constant it applied even to a feather-light wedge, which both stopped you on terrain too steep to wedge and pushed the stop threshold past anything the run actually skis (it defeated both the gradation and the steep failure). The no-reverse guarantee comes from the impulse clamp, which is kept.
- **Slope HUD** relabeled to ski-trail marks (🟢 Green / 🟦 Blue / ◆ Black) and **de-flickered** with an EMA + tier-edge hysteresis (display-only — physics still uses the raw per-frame gradient).

## Invariant safety
All of it is gated on `controls.down`, so the **no-input coasting path stays byte-identical** to the frozen baseline — the physics-invariant harness still reports coasting IDENTICAL (no `snowman_baseline.js` regen).

## Testing
- `npm run test:verify` — physics-invariant harness OK, incl. **two new gating checks**: stop-vs-slow-down gradation (`hold < tap < coast`) and steep-slope failure (full wedge stalls on a black-diamond constant slope but stops on a gentler one).
- `npm test` Node suites green (physics 9/9, regression 10/10, controls 28/28, contract 44/44, terrain 9/9).
- `npm run test:browser` — **94/94, all 7 suites**.
- `npx tsc --noEmit` clean; `npm run lint` 0 errors; `npm run build` OK.
- Manual: captured the screenshots above from the running game.

Docs: model + tier table in [`PHYSICS.md` §3.4](docs/PHYSICS.md), control copy in `index.html` + [`CONTROLS.md`](docs/CONTROLS.md), [`CHANGELOG.md`](docs/CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)