### PR TITLE
Visual acceleration cues: tuck fold/crouch + snowplow squat

### DIFF
--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -29,7 +29,7 @@ and touch are fully interchangeable ([`ARCHITECTURE.md` §6](ARCHITECTURE.md#6-i
 | Input (keyboard) | Touch | Effect | Authoritative detail |
 |---|---|---|---|
 | **← / →** or **A / D** | Tap left / right of screen | **Steer.** Default is a *parallel (skidded)* turn; holding a smooth line locks it into a *carve* — see Techniques below | [`PHYSICS.md` §3.3](PHYSICS.md#33-ski-technique-the-skill-layer), §3.6 |
-| **↑ / W** | Tap top of screen | **Speed up.** With no steering this is the *tuck* (least friction, most speed, least control) | [`PHYSICS.md` §3.3](PHYSICS.md#33-ski-technique-the-skill-layer) |
+| **↑ / W** | Tap top of screen | **Speed up.** With no steering this is the *tuck* (least friction, most speed, least control); the snowman folds forward into a low aero crouch as the visible cue | [`PHYSICS.md` §3.3](PHYSICS.md#33-ski-technique-the-skill-layer) |
 | **↓ / S** | Tap bottom of screen | **Brake — snowplow / "pizza".** A hold ramp: a tap only trims speed, a sustained hold deepens the wedge to a full stop — but only on green/blue pitches; a black-diamond slope is too steep to stop (only slows). Clamped so it never reverses uphill | [`PHYSICS.md` §3.4](PHYSICS.md#34-snowplow-brake-stop-slow-down-and-steep-slope-failure) |
 | **Space** | Tap center of screen | **Jump.** A straight pop when not steering; a *player-initiated* jump is graded on landing and can earn a capped speed boost | [`PHYSICS.md` §4](PHYSICS.md#4-jumps--air), [`MEANINGFUL_JUMPS.md`](MEANINGFUL_JUMPS.md) |
 | **Space + ← / →** | (center + side) | **Hop turn.** A quick grounded edge-set pivot for tight, steep terrain: snaps the heading and scrubs speed with a small pop | [`PHYSICS.md` §4](PHYSICS.md#4-jumps--air) (hop turn) |
@@ -55,7 +55,7 @@ scrub, *and* its pose. Full model and constants in
 | **Parallel turn** (skidded) | Steer ← / → uncommitted (fresh, reversed, or abrupt) | Skis brush sideways and **scrub speed**; **tighter** arc, body upright. The entry turn |
 | **Carve** | Steer ← / → and *hold a smooth line* until the edge locks (`carveCharge > 0.6`) | The locked edge **holds speed**; **wider** arc with a deep body lean. The mastery turn above a parallel |
 | **Snowplow / pizza** | Brake (↓ / S) — tap to slow, hold to stop | Wedge the ski tips together: a tap trims speed, a held wedge deepens to a **stop**; sharp, planted turns. Too steep (black diamond ◆) and even a full wedge only slows — match the Slope HUD tier |
-| **Tuck** | Speed up (↑ / W) with **no steering** | Straight-line for **maximum speed** — least friction, least control |
+| **Tuck** | Speed up (↑ / W) with **no steering** | Straight-line for **maximum speed** — least friction, least control. The body folds forward into a low aero crouch (the visible speed cue) |
 | **Hop turn** | **Jump + Steer** (Space + ← / →, grounded) | A quick pivot that snaps the heading and scrubs ~18% speed; for tight, steep terrain |
 
 **Why it's a skill:** an always-on turn tax (faded out by a committed carve) keeps

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -176,8 +176,12 @@ brake commitment (`wedge = 0.18 + 0.32 * plowCharge` rad — a light check that 
 into a deep "pizza") with the **tips converging and the tails splayed out**; a **carve**
 rolls the skis hard onto their edges, draws them together, and inclines the whole body
 into the turn (lean clamp raised to ~0.42 rad); a **skidded parallel** turn keeps the
-skis flatter and the body upright. The pose is purely cosmetic — it never touches the
-physics. The always-on turn tax (faded out by a carve) keeps turning from ever being
+skis flatter and the body upright; a **tuck** (Up, no steer) folds the body forward
+into the fall line and crouches low over skis drawn parallel and narrow — an
+aerodynamic egg, the visible "go fast" cue (pitch clamp raised to ~0.5 rad, `scale.y`
+compressed about the foot-level origin); and a hard snowplow adds a knees-bent squat
+that deepens with `plowCharge` (a dig-in, not a lean back). The pose is purely
+cosmetic — it never touches the physics. The always-on turn tax (faded out by a carve) keeps turning from ever being
 entirely free, so straight-lining stays the fastest line and a clean carve still
 finishes far faster than chatter-skidding (≈30%+ in the verification harness, §6).
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
       </div>
       <div class="control-row">
         <span><span class="key">↑</span><span class="key">W</span></span>
-        <span>Tuck — straight-line (no steering) for maximum speed</span>
+        <span>Tuck — straight-line (no steering) for maximum speed; fold into a low aero crouch</span>
       </div>
       <div class="control-row">
         <span><span class="key">Space</span>+<span class="key">←</span><span class="key">→</span></span>
@@ -212,7 +212,7 @@
         </div>
         <div class="control-item">
           <span class="key-badge">↑/W</span>
-          <span>Tuck — straight-line for max speed</span>
+          <span>Tuck — fold into a low aero crouch for max speed</span>
         </div>
         <div class="control-item">
           <span class="key-badge">Space+←/→</span>

--- a/src/snowman/pose.ts
+++ b/src/snowman/pose.ts
@@ -57,6 +57,9 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
     let edge = 0.0, draw = 0.0;
     if (technique === 'carve') { edge = steering * 0.5; draw = 0.4; }
     else if (technique === 'parallel') { edge = steering * 0.1; draw = 0.05; }
+    // TUCK: skis stay flat (edge 0) but draw parallel and slightly narrow under the
+    // body for a clean aerodynamic stance — paired with the forward fold + crouch below.
+    else if (technique === 'tuck') { draw = 0.22; }
     const lbx = (snowman.userData.leftSkiBaseX ?? -1) + draw;
     const rbx = (snowman.userData.rightSkiBaseX ?? 1) - draw;
     ls.rotation.z += (edge - ls.rotation.z) * lerp;
@@ -105,7 +108,23 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   // Normalize rotation to 0-2pi range
   snowman.rotation.y = snowman.rotation.y % (Math.PI * 2);
   if (snowman.rotation.y < 0) snowman.rotation.y += Math.PI * 2;
-  
+
+  // Body crouch (cosmetic): fold the body lower for an aerodynamic TUCK and squat
+  // into a hard SNOWPLOW wedge (deeper as plowCharge builds, #54). Driven off
+  // scale.y about the foot-level origin — the skis sit at y≈0.1, so compressing y
+  // lowers the body toward the skis without lifting them off the snow (a real crouch,
+  // not a shrink). It is NOT a backward weight shift: a snowplow digs in with bent
+  // knees, not by leaning back. Relaxes to upright in the air. Never touches physics.
+  if (snowman.scale) { // real THREE.Object3D always has scale; the test mock may not
+    const plowCharge = (snowman.userData.plowCharge as number) || 0;
+    let crouchTarget = 1.0;
+    if (!isInAir) {
+      if (technique === 'tuck') crouchTarget = 0.86;                            // deep aero crouch
+      else if (technique === 'snowplow') crouchTarget = 1.0 - 0.10 * plowCharge; // squat into the wedge
+    }
+    snowman.scale.y += (crouchTarget - snowman.scale.y) * Math.min(1, delta * 8);
+  }
+
   // Calculate a tilt based on the slope and turning with improved smoothing
   // Use wider sample points for more stable gradients
   const sampleDist = 0.4; // Even wider sampling for stability
@@ -132,13 +151,23 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   // from a flatter, upright skidded parallel turn. Amplify the lean and raise the
   // clamp during a carve; every other technique keeps the original gentle lean.
   const isCarve = technique === 'carve';
+  const isTuck = technique === 'tuck';
   const turnTilt = velocity.x * turnTiltFactor * (isCarve ? 2.0 : 1.0);
+  // A TUCK folds the body forward into the fall line (nose-down = +rotation.x, the
+  // same sign as the descent jump lean) on top of the terrain pitch — the "going
+  // fast" cue that pairs with the crouch + drawn-in skis above. No-steer technique,
+  // so the roll axis stays ~0 here.
+  const tuckLean = isTuck ? 0.28 : 0.0; // ~16° forward fold over the terrain pitch
 
-  // Limit maximum tilt angles to prevent unrealistic leaning
-  const maxTiltAngle = isCarve ? 0.42 : 0.25; // ~24° into a carve, ~14° otherwise
-  
+  // Limit maximum tilt angles to prevent unrealistic leaning. Pitch (rotation.x) and
+  // roll (rotation.z) are clamped separately so a technique only relaxes the axis it
+  // needs: a carve inclines the body hard into the turn (roll), a tuck folds it
+  // forward (pitch). Carve/jump/coast pitch+roll are unchanged at 0.25 (0.42 carve).
+  const maxPitchAngle = isTuck ? 0.5 : (isCarve ? 0.42 : 0.25); // ~29° tuck fold, else as before
+  const maxRollAngle = isCarve ? 0.42 : 0.25;                   // ~24° into a carve, ~14° otherwise
+
   // Apply smoothing and clamping to rotation values
-  const targetRotX = gradZ * 0.3 + jumpTilt; // Add jump tilt to X rotation
+  const targetRotX = gradZ * 0.3 + jumpTilt + tuckLean; // terrain pitch + jump lean + tuck fold
   const targetRotZ = -gradX * 0.3 - turnTilt;
   
   // Significantly improve tilt smoothing
@@ -152,7 +181,7 @@ export function applySnowmanPose(snowman: THREE.Object3D, state: SnowmanPoseStat
   snowman.userData.currentRotX += (targetRotX - snowman.userData.currentRotX) * tiltSmoothing;
   snowman.userData.currentRotZ += (targetRotZ - snowman.userData.currentRotZ) * tiltSmoothing;
   
-  // Apply clamped rotations 
-  snowman.rotation.x = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotX));
-  snowman.rotation.z = Math.max(-maxTiltAngle, Math.min(maxTiltAngle, snowman.userData.currentRotZ));
+  // Apply clamped rotations
+  snowman.rotation.x = Math.max(-maxPitchAngle, Math.min(maxPitchAngle, snowman.userData.currentRotX));
+  snowman.rotation.z = Math.max(-maxRollAngle, Math.min(maxRollAngle, snowman.userData.currentRotZ));
 }


### PR DESCRIPTION
## What & why

Make **speed control read on the snowman**, the way the carve / parallel / snowplow *turns* already do. Acceleration in SnowGlider isn't a generic throttle — it's the **tuck** (↑/W, no steer) vs. the **snowplow brake** (↓/S). The snowplow already poses (the "pizza" wedge, deepened by #204), but the **tuck had no body language at all** — the fastest action was the one with zero visible cue. This adds that cue and a body crouch, and pairs the snowplow with a knees-bent squat.

Follow-up to / consistent with **#204** (graded snowplow): the snowplow squat scales with the **same `plowCharge`** as the wedge, so brake commitment now reads on body *and* skis together.

![tuck / snowplow pose cues](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/tuck-pose-shots/tuck-pose-cues-final.png)

*Left → right: coasting (upright) · **tuck** (folds forward into the fall line + crouches low over skis drawn parallel & narrow — the aero "egg") · **snowplow** (knees-bent squat + full wedge). Flat terrain, pose isolated.*

## How it works — all in `src/snowman/pose.ts` (purely cosmetic)

- **Tuck forward fold** — a forward pitch on `rotation.x` (nose-down, the same sign as the descent jump lean) added on top of the terrain pitch; the pitch clamp is raised to ~0.5 rad just for the tuck so it actually shows.
- **Body crouch** — `scale.y` is lerped down about the **foot-level origin** (the skis sit at `y≈0.1`, so compressing y lowers the body toward the skis *without lifting them* — a real crouch, not a shrink). Tuck → `0.86`; snowplow → `1 − 0.10·plowCharge` (a dig-in, **not** a backward lean — leaning back is a braking *fault*). Relaxes to upright in the air.
- **Drawn-in skis** — the tuck draws the skis parallel and slightly narrow (flat, `edge = 0`), reusing the existing ski-stance lerp.
- **Pitch/roll clamps split** — `maxPitchAngle` / `maxRollAngle` so a technique only relaxes the axis it needs (carve = roll, tuck = pitch). **Carve / jump / coast pitch+roll are unchanged** (0.25, 0.42 carve).

## Safety / scope

- **No physics touched, no baseline regen.** The pose layer only writes `rotation` / `scale` / child positions; the no-input coasting path stays byte-identical. `INVARIANT HARNESS: OK ✅`.
- The crouch is guarded on `snowman.scale` (the verification mock has no scale) — same tolerance pattern as the existing ski-pose block.
- Docs + in-game guide updated: `PHYSICS.md §3.3`, `CONTROLS.md`, `index.html` (↑/W tuck rows).

## Tests
- `npm run lint` — 0 errors · `npm run build` — ✓ · `npm run test:verify` — invariant OK + smoke 49/0
- Node suite — all green · **browser (puppeteer) — 94/94, 7/7 suites**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
