### PR TITLE
[DRAFT] Demo video: choreographed technique-showcase recorder

### DIFF
--- a/tools/build-demo-video.mjs
+++ b/tools/build-demo-video.mjs
@@ -1,0 +1,79 @@
+// Assembles the README demo video from a deterministic capture (tools/record-
+// deterministic.mjs). Picks the longest contiguous clean segment (loop alive +
+// non-blank + non-frozen), encodes it at the capture fps with no interpolation,
+// and muxes the game's music track. Run: node tools/build-demo-video.mjs
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+const IN = process.env.IN || '/tmp/demo-final';
+const OUT = process.env.OUT || '/tmp/snowglider_demo.mp4';
+const FPS = Number(process.env.FPS || 30);
+const MUSIC = process.env.MUSIC || path.resolve('assets/skullbeatz_bad_cat.mp3');
+const MIN_BYTES = 30000; // below this a frame is a blank sky/solid color
+
+// Static ffmpeg from the Python imageio-ffmpeg wheel (no system ffmpeg here).
+const ff = process.env.FFMPEG ||
+  execFileSync('python3', ['-c', 'import imageio_ffmpeg;print(imageio_ffmpeg.get_ffmpeg_exe())']).toString().trim();
+
+function md5(file) {
+  return execFileSync('md5sum', [file]).toString().split(' ')[0];
+}
+
+const ran = JSON.parse(fs.readFileSync(path.join(IN, 'ran.json'), 'utf8'));
+const N = ran.length;
+const sizes = [];
+for (let i = 0; i < N; i++) {
+  const f = path.join(IN, `f${String(i).padStart(5, '0')}.jpg`);
+  sizes[i] = fs.statSync(f).size;
+}
+
+// Longest contiguous segment where the loop was alive (ran>0) and the frame is
+// non-blank. (Restart boundaries have ran===0, so they split segments cleanly.)
+let best = { s: 0, e: -1 };
+let s = -1;
+for (let i = 0; i <= N; i++) {
+  const ok = i < N && ran[i] > 0 && sizes[i] >= MIN_BYTES;
+  if (ok && s < 0) s = i;
+  if (!ok && s >= 0) {
+    if (i - s > best.e - best.s + 1) best = { s, e: i - 1 };
+    s = -1;
+  }
+}
+if (best.e < best.s) { console.error('No usable segment found'); process.exit(1); }
+
+// Trim any frozen tail (frames identical to the last one) inside the segment.
+let { s: S, e: E } = best;
+const lastHash = md5(path.join(IN, `f${String(E).padStart(5, '0')}.jpg`));
+let cut = E;
+for (let i = E; i > S; i--) {
+  if (md5(path.join(IN, `f${String(i).padStart(5, '0')}.jpg`)) !== lastHash) { cut = i; break; }
+}
+E = Math.min(E, cut + 1);
+const count = E - S + 1;
+console.log(`Longest clean segment: frames ${S}..${E} (${count} frames = ${(count / FPS).toFixed(1)}s)`);
+
+// Stage the segment as a zero-based sequence so ffmpeg can read it with %05d.
+const STAGE = path.join(IN, 'seg');
+fs.rmSync(STAGE, { recursive: true, force: true });
+fs.mkdirSync(STAGE);
+for (let i = S, j = 0; i <= E; i++, j++) {
+  fs.copyFileSync(path.join(IN, `f${String(i).padStart(5, '0')}.jpg`), path.join(STAGE, `s${String(j).padStart(5, '0')}.jpg`));
+}
+
+const dur = count / FPS;
+const args = [
+  '-y',
+  '-framerate', String(FPS), '-i', path.join(STAGE, 's%05d.jpg'),
+  '-stream_loop', '-1', '-i', MUSIC,
+  '-map', '0:v', '-map', '1:a',
+  '-t', String(dur),
+  '-vf', 'format=yuv420p',
+  '-c:v', 'libx264', '-preset', 'slow', '-crf', '20', '-movflags', '+faststart',
+  '-c:a', 'aac', '-b:a', '160k',
+  '-af', `afade=t=in:st=0:d=0.5,afade=t=out:st=${Math.max(0, dur - 1).toFixed(2)}:d=1`,
+  OUT,
+];
+execFileSync(ff, args, { stdio: 'inherit' });
+const mb = (fs.statSync(OUT).size / 1e6).toFixed(2);
+console.log(`Wrote ${OUT} (${dur.toFixed(1)}s, ${mb} MB)`);

--- a/tools/record-deterministic.mjs
+++ b/tools/record-deterministic.mjs
@@ -1,0 +1,189 @@
+// Deterministic demo recorder for the README video. Not part of the test suite.
+//
+// The game renders at only a few fps under headless software-GL, so a real-time
+// screencast is choppy. Instead we install a *virtual clock*: requestAnimationFrame
+// and performance.now()/Date.now() are overridden so the page's animation only
+// advances when we "pump" it. During init we auto-pump (≈ real time) so loading and
+// the game-start sequence run normally; during capture we pump exactly one fixed
+// timestep per screenshot. Each screenshot is therefore a genuine render at an exact
+// game-time, so the assembled 30fps clip is perfectly smooth with no interpolation.
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import path from 'path';
+
+const URL = process.env.REC_URL || 'https://snowglider.ai/?intro=off';
+const OUT = process.env.REC_OUT || '/tmp/demo-det';
+const FPS = Number(process.env.REC_FPS || 30);
+const SECONDS = Number(process.env.REC_SECONDS || 20);
+const W = Number(process.env.REC_W || 1280), H = Number(process.env.REC_H || 720);
+const CLEAN = process.env.REC_CLEAN === '1';
+const PROBE = process.env.REC_PROBE === '1'; // fast survival probe: no screenshots, one run
+const SEED = process.env.REC_SEED != null ? Number(process.env.REC_SEED) : null;
+const DT = 1000 / FPS;
+const FRAMES = Math.round(FPS * SECONDS);
+
+fs.rmSync(OUT, { recursive: true, force: true });
+fs.mkdirSync(OUT, { recursive: true });
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+// Installed before any page script runs: freezes time and rAF behind a pump(),
+// and (optionally) seeds Math.random so tree layout / avalanche are reproducible.
+function installVirtualClock(seed) {
+  if (seed != null) {
+    let a = seed >>> 0;
+    Math.random = function () {
+      a |= 0; a = (a + 0x6D2B79F5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+  const cbs = [];
+  let vnow = 0, nid = 1;
+  window.requestAnimationFrame = function (cb) { const id = nid++; cbs.push([id, cb]); return id; };
+  window.cancelAnimationFrame = function (id) { const i = cbs.findIndex(e => e[0] === id); if (i >= 0) cbs.splice(i, 1); };
+  try { Object.defineProperty(performance, 'now', { value: () => vnow, configurable: true }); }
+  catch (e) { try { performance.now = () => vnow; } catch (_) {} }
+  const baseEpoch = Date.now();
+  try { Date.now = () => baseEpoch + vnow; } catch (e) {}
+  window.__vclock = {
+    pump(dt) { vnow += dt; const run = cbs.splice(0, cbs.length); for (const [, cb] of run) { try { cb(vnow); } catch (e) { console.error('raf', e); } } return run.length; },
+    now: () => vnow,
+    pending: () => cbs.length,
+  };
+}
+
+const browser = await puppeteer.launch({
+  headless: 'new', acceptInsecureCerts: true,
+  defaultViewport: { width: W, height: H, deviceScaleFactor: 1 },
+  args: [
+    '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    '--disable-web-security', '--autoplay-policy=no-user-gesture-required',
+    '--ignore-certificate-errors', '--allow-insecure-localhost',
+    '--use-gl=angle', '--use-angle=swiftshader', '--ignore-gpu-blocklist',
+    '--enable-webgl', `--window-size=${W},${H}`, '--hide-scrollbars',
+  ],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: W, height: H, deviceScaleFactor: 1 });
+  await page.evaluateOnNewDocument(installVirtualClock, SEED);
+  page.on('pageerror', (e) => console.error('PAGEERR', e.message));
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 45000 });
+
+  // Auto-pump (≈ real time) so async init / game-start can complete.
+  let autoPump = setInterval(() => { page.evaluate((dt) => window.__vclock.pump(dt), DT).catch(() => {}); }, 16);
+
+  await page.waitForFunction(() => typeof window.initializeGameWithAudio === 'function', { timeout: 30000 });
+  await page.waitForSelector('#startGameButton', { timeout: 10000 });
+  await page.click('#startGameButton');
+  await page.waitForFunction(() => {
+    const c = document.getElementById('startGameContainer');
+    return c && c.style.display === 'none';
+  }, { timeout: 10000 });
+
+  if (CLEAN) {
+    await page.addStyleTag({ content: `
+      #controlsInfo, #gameStatsContainer, #courseHud, #resetBtn, #cameraToggleBtn,
+      .touch-control, #authContainer, #introSkipBtn, #audioControlBtn,
+      #gameOverOverlay, #courseResult,
+      div[style*="z-index: 3000"] { display: none !important; }
+    ` });
+  }
+
+  await wait(1200); // let the opening settle under auto-pump
+  clearInterval(autoPump);
+  await wait(150); // let any in-flight auto-pump evaluate settle
+
+  // Pump until the game loop is actually alive (re-queuing in our virtual rAF) for
+  // a few consecutive frames, so death-detection doesn't fire on a cold-start frame.
+  const pump = (dt) => page.evaluate((d) => window.__vclock.pump(d), dt);
+  async function warmUntilAlive() {
+    let alive = 0;
+    for (let i = 0; i < 90 && alive < 6; i++) { const n = await pump(DT); if (n > 0) alive++; else alive = 0; }
+    return alive >= 6;
+  }
+  await warmUntilAlive();
+  // The very first start frame tends to register a spurious game-over under the
+  // virtual clock; a restart drops us into a clean, stable run (verified visually).
+  await page.evaluate(() => { if (typeof window.restartGame === 'function') window.restartGame(); });
+  await warmUntilAlive();
+
+  // Scripted gentle symmetric slalom on the virtual timeline (frame indices).
+  const held = new Set();
+  const setKey = async (key, down) => {
+    if (down && !held.has(key)) { held.add(key); await page.keyboard.down(key); }
+    if (!down && held.has(key)) { held.delete(key); await page.keyboard.up(key); }
+  };
+  // Per-frame steering plan: a short straight glide to build speed, then a gentle
+  // symmetric slalom that weaves around the fall line for skiing "life" without
+  // wandering into the side trees (a tuck bombs straight into them; this survives).
+  const plan = new Array(FRAMES).fill(null);
+  const glide = Math.round(FPS * 1.2);
+  const hold = Math.round(FPS * 0.7), gap = Math.round(FPS * 0.45);
+  let f = glide, dir = 'ArrowLeft';
+  while (f < FRAMES) {
+    for (let i = 0; i < hold && f < FRAMES; i++, f++) plan[f] = dir;
+    f += gap;
+    dir = dir === 'ArrowLeft' ? 'ArrowRight' : 'ArrowLeft';
+  }
+
+  // Fast survival probe: one pass, no screenshots, report how long the run lasts
+  // for this seed/plan. Used to pick a seed that survives well before the (slow)
+  // screenshot capture.
+  if (PROBE) {
+    let dead = 0, survived = 0;
+    for (let i = 0; i < FRAMES; i++) {
+      const want = plan[i];
+      await setKey('ArrowLeft', want === 'ArrowLeft');
+      await setKey('ArrowRight', want === 'ArrowRight');
+      await setKey('ArrowUp', want === 'ArrowUp');
+      const n = await pump(DT);
+      if (n === 0) { if (++dead >= 2) { survived = i - 1; break; } } else { dead = 0; survived = i; }
+    }
+    console.log(`SEED ${SEED} survived ${survived} frames (${(survived / FPS).toFixed(1)}s)`);
+    await browser.close();
+    process.exit(0);
+  }
+
+  console.log(`Deterministic capture: ${FRAMES} frames @ ${FPS}fps (${SECONDS}s game-time)...`);
+
+  // The run can die unpredictably (a tree, or burial by the randomly-seeded
+  // avalanche), which freezes the loop. To reliably harvest a long clean clip we
+  // capture a long session and auto-restart whenever the loop goes idle; the build
+  // step then extracts the longest contiguous segment of distinct frames.
+  const ran = new Array(FRAMES).fill(0);
+  let deadStreak = 0, runStart = 0, planIdx = 0;
+  for (let i = 0; i < FRAMES; i++) {
+    const want = plan[(planIdx++) % plan.length];
+    await setKey('ArrowLeft', want === 'ArrowLeft');
+    await setKey('ArrowRight', want === 'ArrowRight');
+    await setKey('ArrowUp', want === 'ArrowUp');
+    const n = await pump(DT);
+    ran[i] = n;
+    const buf = await page.screenshot({ type: 'jpeg', quality: 92 });
+    fs.writeFileSync(path.join(OUT, `f${String(i).padStart(5, '0')}.jpg`), buf);
+
+    if (n === 0) {
+      deadStreak++;
+      if (deadStreak >= 2) {
+        // Loop is dead/frozen → restart for a fresh run and re-prime the loop.
+        await setKey('ArrowLeft', false); await setKey('ArrowRight', false); await setKey('ArrowUp', false);
+        await page.evaluate(() => { if (typeof window.restartGame === 'function') window.restartGame(); });
+        await warmUntilAlive();
+        console.log(`  frame ${i}: run ended (lasted ~${((i - runStart) / FPS).toFixed(1)}s) — restarted`);
+        deadStreak = 0; runStart = i + 1; planIdx = 0;
+      }
+    } else {
+      deadStreak = 0;
+    }
+    if (i % 60 === 0) console.log(`  frame ${i}/${FRAMES}`);
+  }
+  await setKey('ArrowLeft', false); await setKey('ArrowRight', false); await setKey('ArrowUp', false);
+  fs.writeFileSync(path.join(OUT, 'ran.json'), JSON.stringify(ran));
+  console.log(`Done -> ${OUT} (${FRAMES} frames)`);
+} finally {
+  await browser.close();
+}

--- a/tools/record-deterministic.mjs
+++ b/tools/record-deterministic.mjs
@@ -85,11 +85,26 @@ try {
   }, { timeout: 10000 });
 
   if (CLEAN) {
+    // Keep the gameplay HUD (controls list, stats incl. the technique Status field,
+    // course progress + avalanche warning) so the clip actually shows the controls
+    // and technique; hide only account/dev chrome and end-of-run overlays. Pin the
+    // stats panel into a compact top-right box so it never covers the centred
+    // snowman, and keep the controls list tucked in the top-left corner.
     await page.addStyleTag({ content: `
-      #controlsInfo, #gameStatsContainer, #courseHud, #resetBtn, #cameraToggleBtn,
-      .touch-control, #authContainer, #introSkipBtn, #audioControlBtn,
-      #gameOverOverlay, #courseResult,
+      #resetBtn, #cameraToggleBtn, .touch-control, #authContainer, #introSkipBtn,
+      #audioControlBtn, #gameOverOverlay, #courseResult,
       div[style*="z-index: 3000"] { display: none !important; }
+      #gameStatsContainer {
+        top: 8px !important; right: 8px !important; left: auto !important;
+        max-width: 200px !important; font-size: 12px !important; padding: 6px 9px !important;
+        overflow: visible !important;
+      }
+      #gameStatsContent {
+        display: flex !important; flex-direction: column !important; gap: 4px !important;
+        max-height: none !important; overflow: visible !important;
+      }
+      .stat-item { display: flex !important; flex-direction: column !important; }
+      #controlsInfo { font-size: 12px !important; opacity: 0.92; }
     ` });
   }
 
@@ -111,35 +126,64 @@ try {
   await page.evaluate(() => { if (typeof window.restartGame === 'function') window.restartGame(); });
   await warmUntilAlive();
 
-  // Scripted gentle symmetric slalom on the virtual timeline (frame indices).
-  const held = new Set();
-  const setKey = async (key, down) => {
-    if (down && !held.has(key)) { held.add(key); await page.keyboard.down(key); }
-    if (!down && held.has(key)) { held.delete(key); await page.keyboard.up(key); }
-  };
-  // Per-frame steering plan: a short straight glide to build speed, then a gentle
-  // symmetric slalom that weaves around the fall line for skiing "life" without
-  // wandering into the side trees (a tuck bombs straight into them; this survives).
-  const plan = new Array(FRAMES).fill(null);
-  const glide = Math.round(FPS * 1.2);
-  const hold = Math.round(FPS * 0.7), gap = Math.round(FPS * 0.45);
-  let f = glide, dir = 'ArrowLeft';
-  while (f < FRAMES) {
-    for (let i = 0; i < hold && f < FRAMES; i++, f++) plan[f] = dir;
-    f += gap;
-    dir = dir === 'ArrowLeft' ? 'ArrowRight' : 'ArrowLeft';
+  // --- Choreography: a deliberate run that demonstrates each ski technique, a
+  // jump, then the avalanche giving chase — instead of an aimless slalom.
+  // Each segment is [technique, seconds]; 'parallel' alternates quick L/R turns,
+  // 'jump' pulses Space. Keys: ArrowUp=tuck, ArrowDown=snowplow, ArrowLeft/Right=
+  // carve/turn. A long closing tuck travels far enough to wake the avalanche.
+  const SEGMENTS = [
+    ['glide', 1.2],   // ease in, build speed
+    ['tuck', 2.3],    // ⬆ tuck — straight-line, aero crouch, top speed
+    ['right', 1.8],   // ➡ carve — hold a smooth wide arc
+    ['left', 1.8],    // ⬅ carve the other way
+    ['parallel', 1.6],// quick parallel turns (scrub speed)
+    ['tuck', 1.7],    // rebuild speed into the jump
+    ['jump', 1.5],    // ⎵ jump — launch at speed and get air
+    ['tuck', 1.8],    // land and bomb downhill (wakes the avalanche)
+    ['plow', 1.5],    // ⬇ snowplow / pizza — wedge and slow
+    ['tuck', 9.0],    // outrun, then get chased down by the avalanche
+  ];
+  const steer = new Array(FRAMES).fill(null); // per-frame turn/tuck/plow key or null
+  const jumpFrames = new Set();               // frames to hold Space (jump)
+  {
+    let f = 0;
+    for (const [tech, secs] of SEGMENTS) {
+      const len = Math.round(FPS * secs);
+      if (tech === 'parallel') {
+        let d = 'ArrowRight';
+        for (let i = 0; i < len; i++) {
+          if (i > 0 && i % Math.round(FPS * 0.55) === 0) d = d === 'ArrowRight' ? 'ArrowLeft' : 'ArrowRight';
+          if (f + i < FRAMES) steer[f + i] = d;
+        }
+      } else if (tech === 'jump') {
+        for (let i = 0; i < 3; i++) if (f + i < FRAMES) jumpFrames.add(f + i); // brief Space hold
+      } else {
+        const key = tech === 'tuck' ? 'ArrowUp' : tech === 'plow' ? 'ArrowDown'
+          : tech === 'left' ? 'ArrowLeft' : tech === 'right' ? 'ArrowRight' : null;
+        for (let i = 0; i < len && f + i < FRAMES; i++) steer[f + i] = key;
+      }
+      f += len;
+    }
   }
+  // Desired held keys for a given frame (steer key + Space during a jump).
+  const keysAt = (i) => {
+    const set = new Set();
+    if (steer[i]) set.add(steer[i]);
+    if (jumpFrames.has(i)) set.add('Space');
+    return set;
+  };
+  const held = new Set();
+  const applyKeys = async (target) => {
+    for (const k of [...held]) if (!target.has(k)) { held.delete(k); await page.keyboard.up(k); }
+    for (const k of target) if (!held.has(k)) { held.add(k); await page.keyboard.down(k); }
+  };
 
   // Fast survival probe: one pass, no screenshots, report how long the run lasts
-  // for this seed/plan. Used to pick a seed that survives well before the (slow)
-  // screenshot capture.
+  // for this seed/choreography. Used to pick a seed that survives the whole show.
   if (PROBE) {
     let dead = 0, survived = 0;
     for (let i = 0; i < FRAMES; i++) {
-      const want = plan[i];
-      await setKey('ArrowLeft', want === 'ArrowLeft');
-      await setKey('ArrowRight', want === 'ArrowRight');
-      await setKey('ArrowUp', want === 'ArrowUp');
+      await applyKeys(keysAt(i));
       const n = await pump(DT);
       if (n === 0) { if (++dead >= 2) { survived = i - 1; break; } } else { dead = 0; survived = i; }
     }
@@ -150,17 +194,12 @@ try {
 
   console.log(`Deterministic capture: ${FRAMES} frames @ ${FPS}fps (${SECONDS}s game-time)...`);
 
-  // The run can die unpredictably (a tree, or burial by the randomly-seeded
-  // avalanche), which freezes the loop. To reliably harvest a long clean clip we
-  // capture a long session and auto-restart whenever the loop goes idle; the build
-  // step then extracts the longest contiguous segment of distinct frames.
+  // The run can still die (a tree, or burial by the avalanche), freezing the loop.
+  // Auto-restart on death; the build step keeps the longest contiguous clean run.
   const ran = new Array(FRAMES).fill(0);
-  let deadStreak = 0, runStart = 0, planIdx = 0;
+  let deadStreak = 0, runStart = 0;
   for (let i = 0; i < FRAMES; i++) {
-    const want = plan[(planIdx++) % plan.length];
-    await setKey('ArrowLeft', want === 'ArrowLeft');
-    await setKey('ArrowRight', want === 'ArrowRight');
-    await setKey('ArrowUp', want === 'ArrowUp');
+    await applyKeys(keysAt(i));
     const n = await pump(DT);
     ran[i] = n;
     const buf = await page.screenshot({ type: 'jpeg', quality: 92 });
@@ -169,19 +208,18 @@ try {
     if (n === 0) {
       deadStreak++;
       if (deadStreak >= 2) {
-        // Loop is dead/frozen → restart for a fresh run and re-prime the loop.
-        await setKey('ArrowLeft', false); await setKey('ArrowRight', false); await setKey('ArrowUp', false);
+        await applyKeys(new Set());
         await page.evaluate(() => { if (typeof window.restartGame === 'function') window.restartGame(); });
         await warmUntilAlive();
         console.log(`  frame ${i}: run ended (lasted ~${((i - runStart) / FPS).toFixed(1)}s) — restarted`);
-        deadStreak = 0; runStart = i + 1; planIdx = 0;
+        deadStreak = 0; runStart = i + 1;
       }
     } else {
       deadStreak = 0;
     }
     if (i % 60 === 0) console.log(`  frame ${i}/${FRAMES}`);
   }
-  await setKey('ArrowLeft', false); await setKey('ArrowRight', false); await setKey('ArrowUp', false);
+  await applyKeys(new Set());
   fs.writeFileSync(path.join(OUT, 'ran.json'), JSON.stringify(ran));
   console.log(`Done -> ${OUT} (${FRAMES} frames)`);
 } finally {


### PR DESCRIPTION
## Temporary draft — README demo-video approach

A reproducible pipeline that records a fresh README demo from the **live game**, and the demo it produces. Opening for review of the *approach*; the mp4 itself isn't committed (media stays off the main tree per `CLAUDE.md`).

### Preview (GIF, ~17.6s)

![SnowGlider demo](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/demo-preview/snowglider_demo.gif)

A deliberate run that demonstrates each mechanic in turn — **tuck → carve L/R → quick parallel turns → jump → snowplow** — then gets chased down by the **avalanche**. The `Status` field labels the live technique, and Game Stats sits in a compact top-right box so it never covers the snowman.

| Carving | Jump | Avalanche |
|---|---|---|
| ![carve](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/demo-preview/carve.jpg) | ![jump](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/demo-preview/jump.jpg) | ![avalanche](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/demo-preview/avalanche.jpg) |

### How it works
The game renders at only a few fps under headless software-GL, so a real-time screen-grab is choppy. Instead the recorder drives the game behind a **virtual clock** — it overrides `requestAnimationFrame` / `performance.now()` so each screenshot is exactly one fixed timestep. Result: smooth 30 fps with **no motion interpolation** (HUD text stays crisp), independent of render speed.

- `tools/record-deterministic.mjs` — drives the live site (or a local Vite server) in headless Chrome behind the virtual clock. Seeds `Math.random` so terrain/tree layout is reproducible, runs a scripted technique choreography, keeps the gameplay HUD, and auto-restarts on a wipeout to harvest a clean run. A `--probe` mode finds a seed that survives the whole show.
- `tools/build-demo-video.mjs` — extracts the longest clean segment, encodes it at the capture fps, and muxes the in-repo music track.

Both are run manually; nothing is wired into `npm`/CI, and no binaries land in the tree.

### Recording the clip
```bash
# probe seeds, then capture + build (uses the static ffmpeg from imageio-ffmpeg)
REC_URL="https://snowglider.ai/?intro=off" REC_CLEAN=1 REC_SEED=2 \
  REC_W=1280 REC_H=720 REC_SECONDS=20 node tools/record-deterministic.mjs
IN=/tmp/demo3 OUT=/tmp/snowglider_demo.mp4 node tools/build-demo-video.mjs
```

### Not in scope
The README's video uses a `user-attachments` URL that can only be minted by dragging the mp4 into the GitHub UI — so swapping the README clip is a manual follow-up, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014irWf58tbGUNYEiyNKrF4c

---
_Generated by [Claude Code](https://claude.ai/code/session_014irWf58tbGUNYEiyNKrF4c)_