### PR TITLE
fix(physics): make drag frame-rate independent (can't blow past obstacles at low FPS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -35,6 +35,7 @@
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",
+    "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test",

--- a/src/snowman/physics.ts
+++ b/src/snowman/physics.ts
@@ -96,11 +96,32 @@ export function stepSnowmanPhysics(
   getTerrainGradient: TerrainVecFn,
   getDownhillDirection: TerrainVecFn
 ): SnowmanPhysicsStepOutput {
+  // --- Frame-rate-independent drag (issue: "floor it forward and blow past the
+  // obstacles") ----------------------------------------------------------------
+  // The coasting/cruising drag below is a *per-frame* multiplier (velocity *= 1-k).
+  // The driving forces (gravity, accelerate, turn) are all scaled by `delta`, so as
+  // the frame time grows the forces keep up but a fixed per-frame drag does NOT —
+  // it is applied fewer times per second. That made terminal speed scale inversely
+  // with frame rate: ~8 m/s at 60 FPS but ~32 m/s at 10 FPS (the capped 0.1 s delta),
+  // which on a slow/mobile device lets a player just hold Up and rocket straight
+  // down the fall line, fast enough to slip between (and at the worst frame times
+  // tunnel through) the trees without ever steering.
+  //
+  // Fix: treat each `1-k` as a 60 Hz per-frame factor and raise it to the number of
+  // 60 Hz frames this delta represents, so the drag integrates to the same amount of
+  // speed lost per *second* at any frame rate. `dragFactor(k)` is byte-identical at
+  // the 60 Hz baseline — delta*60 == 1 exactly when delta === 1/60, and
+  // Math.pow(x, 1) === x — so the physics-invariant harness (which steps at 1/60)
+  // stays bit-for-bit unchanged; only off-60 Hz frames are corrected.
+  const FRICTION_REF_HZ = 60;
+  const dragFrames = delta * FRICTION_REF_HZ;
+  const dragFactor = (k: number): number => Math.pow(1 - k, dragFrames);
+
   // Update jump cooldown
   if (jumpCooldown > 0) {
     jumpCooldown -= delta;
   }
-  
+
   // Outer-scope outputs surfaced in the return value (HUD + camera juice).
   let technique: SkiTechnique = isInAir ? 'air' : 'glide';
   let justLanded = false;
@@ -284,9 +305,9 @@ export function stepSnowmanPhysics(
       velocity.x += 5.0 * delta;
     }
     
-    // Less friction in air
-    velocity.x *= (1 - 0.01);
-    velocity.z *= (1 - 0.01);
+    // Less friction in air (frame-rate-independent; see dragFactor above)
+    velocity.x *= dragFactor(0.01);
+    velocity.z *= dragFactor(0.01);
   } else {
     // Update velocity based on gravity, gradient, and an improved friction model
     const gravity = 9.8;
@@ -491,8 +512,9 @@ export function stepSnowmanPhysics(
     // (skidScrub == 0), so straight-line/coasting behaviour is identical to before;
     // hard turns at speed add edge-skid drag on top.
     const totalFriction = friction + skidScrub;
-    velocity.x *= (1 - totalFriction);
-    velocity.z *= (1 - totalFriction);
+    const totalDrag = dragFactor(totalFriction);
+    velocity.x *= totalDrag;
+    velocity.z *= totalDrag;
     
     // Update y position to terrain height when not in air
     pos.y = terrainHeightAtPosition;

--- a/tests/verification/forward_stress_harness.js
+++ b/tests/verification/forward_stress_harness.js
@@ -1,0 +1,178 @@
+// forward_stress_harness.js
+// Robustness stress test for the "floor it forward and blow past the obstacles"
+// class of bug (PR #209). Unlike physics_invariant_harness.js — which pins coasting
+// on a synthetic constant slope — this drives the REAL physics kernel
+// (Snowman.updateSnowman) over the REAL analytic terrain with the REAL procedurally
+// placed trees + rocks, holding ONLY Up (forward, never steering), across several
+// frame rates and tree layouts. It guards two properties that broke before the
+// frame-rate-independent drag fix:
+//
+//   1. NO TUNNELING — the collision check is a discrete point-vs-radius test, so a
+//      per-frame step larger than the tree radius can skip a tree disk entirely. The
+//      harness replays each frame's prev->cur segment against every tree disk and
+//      asserts zero uncaught pass-throughs, and that the worst per-frame step stays
+//      below the collision radius, at every tested frame rate (incl. the capped
+//      0.1 s delta = ~10 FPS).
+//
+//   2. FRAME-RATE-BOUNDED SPEED — terminal cruise speed holding Up must not balloon
+//      at low frame rate. Before the fix it scaled ~4x (8 -> 32 m/s) from 60 to
+//      10 FPS, which is what let a slow-device player rocket straight down the fall
+//      line past the trees. The gate caps the 10-FPS/60-FPS max-speed ratio.
+//
+// Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js
+const { pathToFileURL } = require('url');
+const path = require('path');
+
+// Minimal browser globals the kernel + tree/rock placement touch (no DOM/WebGL).
+global.window = { location: { search: '' }, matchMedia: () => ({ matches: false }), terrainMesh: null };
+global.document = undefined; // trees/rocks skip canvas textures when document is absent
+try { Object.defineProperty(global, 'navigator', { value: { webdriver: false }, configurable: true }); } catch { /* keep existing */ }
+
+// Seeded PRNG so tree/rock placement and the auto-turn are reproducible.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+// Distance from point (px,pz) to segment a->b (for the tunneling probe).
+function pointSegmentDistance(px, pz, ax, az, bx, bz) {
+  const abx = bx - ax, abz = bz - az;
+  const ab2 = abx * abx + abz * abz;
+  let t = ab2 > 0 ? ((px - ax) * abx + (pz - az) * abz) / ab2 : 0;
+  t = Math.max(0, Math.min(1, t));
+  const cx = ax + abx * t, cz = az + abz * t;
+  return Math.hypot(px - cx, pz - cz);
+}
+
+function makeScene() {
+  const children = [];
+  return { children, add(o) { children.push(o); }, remove(o) { const i = children.indexOf(o); if (i >= 0) children.splice(i, 1); }, userData: {} };
+}
+
+function fakeSnowman() {
+  const ski = () => ({ position: { x: 0 }, rotation: { x: 0, y: 0, z: 0 } });
+  return {
+    position: { x: 0, y: 0, z: 0, set(x, y, z) { this.x = x; this.y = y; this.z = z; } },
+    rotation: { x: 0, y: Math.PI, z: 0 },
+    userData: { targetRotationY: Math.PI, currentRotX: 0, currentRotZ: 0,
+                leftSki: ski(), rightSki: ski(), leftSkiBaseX: -1, rightSkiBaseX: 1 },
+  };
+}
+
+(async () => {
+  await import(pathToFileURL(path.join(__dirname, '..', 'loaders', 'register-ts-resolve.mjs')).href);
+  const { Snowman } = await import('../../src/snowman.ts');
+  const terrain = await import('../../src/mountains/terrain.ts');
+  const { Trees } = await import('../../src/mountains/trees.ts');
+  const { addRocks } = await import('../../src/mountains/rocks.ts');
+  const { getTerrainHeight, getTerrainGradient, getDownhillDirection } = terrain;
+
+  const TREE_RADIUS = 2.5;            // mirrors collision.ts default treeCollisionRadius
+  const UP = { left: false, right: false, up: true, down: false, jump: false };
+  const SEEDS = [12345, 777, 42, 9001];
+  const FRAME_RATES = [1 / 60, 1 / 30, 1 / 10]; // 60, 30, and the capped-delta 10 FPS
+
+  // One descent holding Up. Trees/rocks are generated from `layoutSeed` (fixed per
+  // seed so every frame rate skis the SAME mountain); the auto-turn uses a fixed
+  // descent seed so the only variable across the FRAME_RATES loop is dt.
+  function runDescent(layoutSeed, dt) {
+    Math.random = makeRng(layoutSeed);
+    const scene = makeScene();
+    // Silence the unconditional placement logs (Trees.addTrees / addRocks) so the
+    // harness output stays readable; restore immediately after.
+    const _log = console.log, _warn = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const treePositions = Trees.addTrees(scene);
+    const rockPositions = addRocks(scene);
+    console.log = _log; console.warn = _warn;
+
+    Math.random = makeRng(0xC0FFEE ^ layoutSeed); // deterministic auto-turn, independent of dt
+    const snowman = fakeSnowman();
+    const pos = { x: 0, z: -15, y: getTerrainHeight(0, -15) };
+    const velocity = { x: 0, z: -3 };
+    snowman.position.set(pos.x, pos.y, pos.z);
+
+    let reason = null;
+    const showGameOver = (r) => { if (!reason) reason = r; };
+    let st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, -15),
+               airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+
+    let maxSpeed = 0, maxStep = 0, tunnelFrames = 0;
+    const MAX_FRAMES = Math.ceil(120 / dt); // 2 min of in-game wall clock cap
+    for (let f = 0; f < MAX_FRAMES; f++) {
+      const prevX = pos.x, prevZ = pos.z;
+      st = Snowman.updateSnowman(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity,
+        st.lastTerrainHeight, st.airTime, st.jumpCooldown, UP, st.turnPhase, st.currentTurnDirection,
+        st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
+        treePositions, true, showGameOver, rockPositions);
+      snowman.position.set(pos.x, pos.y, pos.z);
+
+      const speed = Math.hypot(velocity.x, velocity.z);
+      if (speed > maxSpeed) maxSpeed = speed;
+      const step = Math.hypot(pos.x - prevX, pos.z - prevZ);
+      if (step > maxStep) maxStep = step;
+
+      // Tunneling probe: did the prev->cur segment pass THROUGH a tree disk that
+      // neither endpoint sampled inside (so the point-based check missed it)?
+      for (const t of treePositions) {
+        if (pointSegmentDistance(t.x, t.z, prevX, prevZ, pos.x, pos.z) < TREE_RADIUS &&
+            Math.hypot(prevX - t.x, prevZ - t.z) >= TREE_RADIUS &&
+            Math.hypot(pos.x - t.x, pos.z - t.z) >= TREE_RADIUS) {
+          tunnelFrames++;
+        }
+      }
+
+      if (reason || pos.z < -195) break;
+    }
+    return { maxSpeed, maxStep, tunnelFrames, reason, trees: treePositions.length, rocks: rockPositions.length };
+  }
+
+  let hardFail = false;
+
+  // --- 1) No tunneling at any frame rate / layout [GATING] ---
+  let totalTunnel = 0, worstStep = 0, worstStepDt = 0;
+  // --- 2) Frame-rate-bounded speed [GATING] ---
+  let worstSpeedRatio = 0, worstSpeedSeed = 0;
+  const rows = [];
+  for (const seed of SEEDS) {
+    const byDt = {};
+    for (const dt of FRAME_RATES) {
+      const r = runDescent(seed, dt);
+      byDt[dt] = r;
+      totalTunnel += r.tunnelFrames;
+      if (r.maxStep > worstStep) { worstStep = r.maxStep; worstStepDt = dt; }
+      rows.push({ seed, fps: Math.round(1 / dt), ...r });
+    }
+    const ratio = byDt[1 / 10].maxSpeed / byDt[1 / 60].maxSpeed;
+    if (ratio > worstSpeedRatio) { worstSpeedRatio = ratio; worstSpeedSeed = seed; }
+  }
+
+  console.log('=== Forward-only stress: real terrain + trees + rocks, holding Up ===');
+  console.log('  seed     FPS  trees rocks  maxSpeed  maxStep  tunnel  outcome');
+  for (const r of rows) {
+    console.log('  %s  %s   %s   %s   %s   %s    %s    %s',
+      String(r.seed).padStart(6), String(r.fps).padStart(3), String(r.trees).padStart(4),
+      String(r.rocks).padStart(4), r.maxSpeed.toFixed(2).padStart(6), r.maxStep.toFixed(3).padStart(6),
+      String(r.tunnelFrames).padStart(4), r.reason || `z<-195 (finish)`);
+  }
+
+  const noTunneling = totalTunnel === 0 && worstStep < TREE_RADIUS;
+  console.log('\n--- No collision tunneling at any frame rate [GATING] ---');
+  console.log('  total uncaught pass-throughs:', totalTunnel,
+    '| worst per-frame step:', worstStep.toFixed(3), `(at ${Math.round(1 / worstStepDt)} FPS)`, '| tree radius:', TREE_RADIUS);
+  console.log('  PASS:', noTunneling ? 'every step stays inside the collision radius ✅' : 'a frame stepped past a tree disk ❌');
+  if (!noTunneling) hardFail = true;
+
+  // Before the fix this ratio was ~4 (8 -> 32 m/s); 1.6 leaves margin for the small
+  // discrete-integration drift while still failing hard on a per-frame-drag regression.
+  const SPEED_RATIO_CAP = 1.6;
+  const speedBounded = worstSpeedRatio < SPEED_RATIO_CAP;
+  console.log('\n--- Cruise speed does not balloon at low frame rate [GATING] ---');
+  console.log('  worst 10-FPS / 60-FPS max-speed ratio:', worstSpeedRatio.toFixed(2),
+    `(seed ${worstSpeedSeed})`, '| cap:', SPEED_RATIO_CAP);
+  console.log('  PASS:', speedBounded ? 'low-FPS speed stays bounded ✅' : 'speed scales with frame rate ❌');
+  if (!speedBounded) hardFail = true;
+
+  console.log(`\nFORWARD STRESS HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (no tunneling; speed frame-rate bounded)'}`);
+  process.exit(hardFail ? 1 : 0);
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/tests/verification/physics_invariant_harness.js
+++ b/tests/verification/physics_invariant_harness.js
@@ -483,6 +483,39 @@ console.log('  auto landing:', 'quality', autoLand.quality, '| airScore', autoLa
 console.log('  PASS:', provenanceGated ? 'non-player landing not rewarded ✅' : 'reward leaked to a non-player landing ❌');
 if (!provenanceGated) hardFail = true;
 
+// 11) Frame-rate independence of cruising speed [GATING]. The coast/cruise drag is a
+// per-frame multiplier (velocity *= 1-k) while the forces are delta-scaled, so before
+// the dragFactor() fix the terminal speed scaled with frame rate: ~8 m/s at 60 FPS but
+// ~32 m/s at the capped 0.1 s delta (~10 FPS). On a slow / mobile device that let a
+// player just hold Up and rocket straight down the fall line — fast enough to slip
+// between (and at the worst frame times tunnel through) the trees without ever
+// steering (the "floor it forward, pass the obstacles without dodging" report). The
+// fix raises each `1-k` to delta*60 so the drag integrates to the same speed lost per
+// SECOND at any frame rate; the 60 Hz path is byte-identical (delta*60 == 1 exactly
+// when delta === 1/60, and Math.pow(x,1) === x), guarded by check 1 above. Hold Up on
+// a constant slope for a fixed ~6 s of wall-clock at three frame rates; the terminal
+// speeds must now agree closely instead of diverging with the frame time.
+const UP_CRUISE = { left: false, right: false, up: true, down: false, jump: false };
+const cruiseSeconds = 6;
+const cruiseSpeedAt = (dt) => simulateSlope(mod, () => UP_CRUISE,
+  { slope: 0.3, vz0: -7, steps: Math.round(cruiseSeconds / dt), dt, seed: 7 }).finalSpeed;
+const cruise60 = cruiseSpeedAt(1 / 60);
+const cruise30 = cruiseSpeedAt(1 / 30);
+const cruise10 = cruiseSpeedAt(1 / 10);
+const cruiseMax = Math.max(cruise60, cruise30, cruise10);
+const cruiseMin = Math.min(cruise60, cruise30, cruise10);
+const cruiseSpread = (cruiseMax - cruiseMin) / cruise60;
+// Within 10% across a 6x frame-rate range (measured ~4-5%); the un-fixed per-frame
+// drag diverged ~300% (8 -> 32 m/s), so this gate is robust, not flaky.
+const frameRateIndependent = cruiseSpread < 0.10;
+console.log('\n--- Frame-rate independence: holding Up cruises at the same speed at any FPS [GATING] ---');
+console.log('  60 FPS:', cruise60.toFixed(2), '| 30 FPS:', cruise30.toFixed(2), '| 10 FPS:', cruise10.toFixed(2),
+  '| spread:', (cruiseSpread * 100).toFixed(1) + '%');
+console.log('  PASS:', frameRateIndependent
+  ? 'cruise speed is frame-rate independent ✅'
+  : `cruise speed scales with frame rate (spread ${(cruiseSpread * 100).toFixed(0)}%) ❌`);
+if (!frameRateIndependent) hardFail = true;
+
 console.log(`\nINVARIANT HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (safety invariant + technique gating checks hold)'}`);
 process.exit(hardFail ? 1 : 0);
 })();


### PR DESCRIPTION
## Reported issues (stress test)

> "If you floor it forward, you can drive through without dodging the obstacles. And then the game freezes at the end."

Reproduced and fixed the root cause behind the first symptom (which also drives the second on slow devices).

## Root cause: frame-rate-dependent physics

In `stepSnowmanPhysics` the coasting/cruising **drag** is a *per-frame* multiplier (`velocity *= 1 - friction`), while every driving **force** (gravity, accelerate, turn) is scaled by `delta`. As the frame time grows, the forces keep up but a fixed per-frame drag is applied *fewer times per second* — so terminal speed scaled **inversely with frame rate**.

Holding **Up** straight down the fall line (headless sim over the real terrain + real tree/rock layout):

| Frame rate | delta | max speed | per-frame step |
|---|---|---|---|
| 60 FPS | 0.0167 | **8.2 m/s** | 0.14 m |
| 30 FPS | 0.033 | 13.1 m/s | 0.43 m |
| 20 FPS | 0.05 | 19.6 m/s | 0.98 m |
| 10 FPS | 0.1 (the capped delta) | **31.7 m/s** | **3.17 m** |

On a slow / mobile device this lets a player just hold Up and rocket down the clear center lane — fast enough to slip between, and at the worst frame times **tunnel through**, the trees without ever steering (per-frame step 3.17 m > the 2.5 m tree collision radius, since collision is a discrete point-vs-radius check).

Sweep over 40 random tree layouts, forward-only, no steering:

| | reached FINISH untouched | tunneling seeds |
|---|---|---|
| 60 FPS | 9 / 40 | 0 |
| 10 FPS (**before fix**) | **22 / 40** | **2** |
| 10 FPS (**after fix**) | 11 / 40 | 0 |

## The fix

Treat each `1 - k` drag as a **60 Hz per-frame factor** and raise it to the number of 60 Hz frames the current `delta` represents:

```ts
const dragFactor = (k) => Math.pow(1 - k, delta * 60);
```

so the drag integrates to the same speed lost **per second** at any frame rate. Applied to the two continuous drags (air friction and ground `friction + skidScrub`); one-shot landing scrubs and the already-`delta`-scaled forces are untouched.

The 60 Hz path is **byte-identical** — `delta*60 === 1` exactly when `delta === 1/60`, and `Math.pow(x, 1) === x` — so the physics-invariant harness (which steps at 1/60) stays bit-for-bit unchanged. Only off-60-Hz frames are corrected.

### After the fix
- Cruise speed holds **~7.5 m/s across 60 / 30 / 20 / 10 FPS** (spread 4.5%, was ~300%).
- Verified in a **CPU-throttled real browser** (Chrome, 4× slowdown, holding ArrowUp): max speed **16.7 → 7.5 m/s**.
- Tunneling eliminated at every frame rate; low-FPS finish-untouched rate back in line with 60 FPS.

## On the "freezes at the end"
No separate infinite-loop / hang was found (checked the snowtracks/avalanche stamp loops — all bounded; no NaN at speed; the game-over path is synchronous and finite). The most plausible cause is the slow-device experience the same root bug aggravates: a runaway-fast snowman generating a load spike at the bottom of the run, then the game-over stop reading as a "freeze." Keeping speeds sane removes that spike. Flagging it so it can be re-checked on a real device.

## Tests
- Full `npm test` green; `npm run lint` 0 errors; `npm run build` clean.
- **`physics_invariant_harness.js`** — new gating frame-rate-independence check: holds Up on a constant slope for a fixed wall-clock at 60/30/10 FPS and asserts terminal speeds agree (< 10% spread). Fails at ~125% spread on the old code, passes at ~4.5% on the fixed code.
- **`tests/verification/forward_stress_harness.js` (new, `npm run test:stress`, wired into `npm test`)** — committed robustness stress harness that replaces the throwaway repro script. Drives the real kernel over the real terrain + real procedurally-placed trees/rocks, holding only Up, across 4 layouts × 3 frame rates, and gates on (1) **zero collision tunneling** (replays each frame's prev→cur segment vs every tree disk) and (2) **frame-rate-bounded speed** (caps the 10-FPS/60-FPS max-speed ratio). Verified it **fails on the pre-fix kernel** (tunneling + 3.83× ratio) and **passes on the fixed kernel**; runs headless in ~2 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp4QnFSxUoL1e3cGYd99Ti