### PR TITLE
Avalanche frame-rate friction fix + broadened stress matrix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,21 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   front-travel ratio stays near 1 and all boulder state stays finite. Verified to **fail
   on the pre-fix kernel (ratio ≈ 2.9) and pass on the fix (≈ 0.95)** — a passing test on
   the old code would have proven nothing.
+- **Forward stress harness broadened to an input × frame-rate matrix.**
+  `tests/verification/forward_stress_harness.js` (also `npm run test:stress`) — which PR
+  #209 added as a hold-Up-only probe — now sweeps five input policies (hold-Up,
+  deterministic slalom, time-keyed wander, an adversarial steer-into-the-nearest-tree,
+  and jump-spam) across 60/30/10 FPS **plus a bursty frame-hitching run** (60 FPS with
+  occasional 0.1 s GC-pause spikes). New gating checks beyond the original
+  tree-tunneling + speed-ratio: **rock tunneling** (the segment probe now replays every
+  rock disk at its `rockCollisionRadius`, not just trees), **speed-bounded under every
+  policy** (not just hold-Up), **no NaN/Infinity** in any run, and **every descent
+  terminates** (finish/crash/off-side, never spins — the closest reproducible proxy for
+  the "freezes at the end" report). The broadened matrix found **no new defects** (the
+  steered slalom path is frame-rate-sensitive by coarse-dt Euler integration, not a bug —
+  the steer force is delta-scaled — so it is reported as a diagnostic, not gated).
+  Verified to still fail hard on a reverted drag fix (3.16 m step → tunneling; speed
+  ratio 3.83).
 
 ### Snowplow: stop vs. slow-down + steep-slope failure, aligned to the Slope HUD (#54)
 - The snowplow was a single on/off "pizza" brake that stopped you on **any** skiable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,26 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Avalanche friction made frame-rate independent (follow-up to PR #209)
+- The snowman drag fix in PR #209 corrected a per-frame multiplier mixed in with
+  dt-scaled forces. Stress-testing turned up the **same bug class still live in the
+  avalanche kernel**: `src/avalanche.ts` applied the ground `friction = 0.98` once per
+  frame instead of integrating it per second. So boulders decayed ~4× less at the
+  capped 10 FPS delta than at 60 FPS, and the grounded-slide terminal speed
+  `2·dt / (1 − friction)` scaled ~6× with frame time — the avalanche reached farther
+  and faster on slow devices, **skewing burial (game-over) fairness by frame rate**.
+- **Fix:** `friction → frictionFactor = Math.pow(0.98, dt * 60)`, mirroring the
+  snowman's `dragFactor`. Byte-identical at the 60 Hz baseline (`dt·60 == 1` when
+  `dt == 1/60`, `x ** 1 === x`), so the existing avalanche tests are unchanged; only
+  off-60 Hz frames are corrected. The debris/powder loop (`_updatePowder`) already
+  drag-scaled correctly — this brings the boulders in line.
+- **New gate:** `tests/verification/avalanche_framerate_harness.js` (`npm run
+  test:stress`, also in `npm test`) triggers one deterministic, seeded avalanche on flat
+  terrain (so the grounded-slide regime dominates cleanly) and asserts the 10-FPS/60-FPS
+  front-travel ratio stays near 1 and all boulder state stays finite. Verified to **fail
+  on the pre-fix kernel (ratio ≈ 2.9) and pass on the fix (≈ 0.95)** — a passing test on
+  the old code would have proven nothing.
+
 ### Snowplow: stop vs. slow-down + steep-slope failure, aligned to the Slope HUD (#54)
 - The snowplow was a single on/off "pizza" brake that stopped you on **any** skiable
   pitch. It is now a **graded wedge** with two real behaviors, tied to the terrain.

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -451,17 +451,31 @@ size  = 0.4 + rand*1.2
 
 ```
 gravity = 18 ; friction = 0.98 ; bounce = 0.25
+frictionFactor = friction ** (dt * 60)         // per-second decay (see note below)
 vel.y -= gravity * dt ; pos += vel * dt
 floorY = getTerrainHeight(pos.x, pos.z)        // requires setTerrainFunction()
 if (pos.y < floorY + radius):                  // ground contact
     pos.y = floorY + radius
     vel.y *= -bounce
-    vel.x *= friction ; vel.z *= friction
+    vel.x *= frictionFactor ; vel.z *= frictionFactor
     vel.z -= 2 * dt                            // downhill slide acceleration
 ```
 
 `setTerrainFunction(fn)` must be called before `update()` or boulders fall to
 `y = 0` instead of following the slope.
+
+**Frame-rate-independent friction.** Ground friction is a continuous per-second
+decay, so — like the snowman's coast drag (§3.4, `dragFactor`) — it is raised to
+`dt * 60` rather than applied once per frame. Applying the raw `0.98` each frame
+made boulders decay ~4× less at the capped 10 FPS delta than at 60 FPS, so the
+grounded-slide terminal speed `2·dt / (1 − friction)` scaled ~6× with frame time —
+the avalanche reached farther and faster on slow devices, skewing burial (game-over)
+fairness by frame rate. This is the same bug class as the snowman drag fix (PR #209).
+`frictionFactor` is byte-identical at the 60 Hz baseline (`dt·60 == 1` exactly when
+`dt == 1/60`, and `x ** 1 === x`), so existing avalanche tests are unchanged; only
+off-60 Hz frames are corrected. Gated by
+[`tests/verification/avalanche_framerate_harness.js`](tests/verification/avalanche_framerate_harness.js)
+(`npm run test:stress`), which fails hard on the per-frame-friction regression.
 
 ### 7.4 Queries (used by gameplay & UI)
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",
-    "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js",
+    "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/avalanche_framerate_harness.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test",

--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -208,6 +208,17 @@ export class AvalancheSystem {
     const friction = 0.98;
     const bounce = 0.25;
 
+    // Ground friction is a continuous per-second decay, so it must scale with the
+    // frame time the same way the snowman drag does (see snowman/physics.ts
+    // `dragFactor`). Applying the raw 0.98 once per frame made boulders decay ~4x
+    // less at the capped 10 FPS delta than at 60 FPS — the same frame-rate-dependent
+    // bug class as PR #209, here inflating avalanche reach/speed (and thus burial
+    // fairness) on slow devices. `frictionFactor` is byte-identical at the 60 Hz
+    // baseline (dt*60 === 1 when dt === 1/60, and Math.pow(x, 1) === x). The debris
+    // loop in _updatePowder already drag-scales correctly; this brings the boulders
+    // in line. (bounce stays a per-contact impulse, not a continuous decay.)
+    const frictionFactor = Math.pow(friction, dt * 60);
+
     for (let i = 0; i < this.count; i++) {
       const idx = i * 3;
 
@@ -232,9 +243,9 @@ export class AvalancheSystem {
         this.positions[idx + 1] = floorY + radius;
         this.velocities[idx + 1] *= -bounce;
 
-        // Apply friction on ground
-        this.velocities[idx] *= friction;
-        this.velocities[idx + 2] *= friction;
+        // Apply friction on ground (frame-rate-independent; see frictionFactor above)
+        this.velocities[idx] *= frictionFactor;
+        this.velocities[idx + 2] *= frictionFactor;
 
         // Slide acceleration (downhill push in -Z direction)
         this.velocities[idx + 2] -= 2 * dt;

--- a/tests/README.md
+++ b/tests/README.md
@@ -248,11 +248,32 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   and rolls/draws the skis together, and — via linked turns around the fall line —
   the carve holds clearly more speed. Run via `npm run test:turn-styles` (also
   included in `npm test`).
+- **`forward_stress_harness.js`** — frame-rate robustness gate for the "floor it
+  forward and blow past the obstacles" bug class (PR #209), broadened in the #209
+  follow-up to a full **input × frame-rate matrix**: it drives the real kernel over the
+  real terrain + procedurally placed trees **and** rocks under five input policies
+  (hold-Up, deterministic slalom, time-keyed wander, an adversarial steer-into-the-
+  nearest-tree, and jump-spam) at 60/30/10 FPS plus a bursty frame-hitching run (60 FPS
+  with occasional 0.1 s GC-pause spikes). Gates: **no collision tunneling** (trees and
+  rocks; replays each prev→cur segment against every obstacle disk), **speed does not
+  balloon at low FPS under any policy** (the #209 drag bug), **no NaN/Infinity**, and
+  **every descent terminates** (finish/crash/off-side, never spins — the closest proxy
+  for the "freezes at the end" report). Steered-path convergence is reported as a
+  diagnostic, not gated (coarse-dt Euler on the radial fall line drifts the slalom path
+  by design). Run via `npm run test:stress` (also in `npm test`).
+- **`avalanche_framerate_harness.js`** — frame-rate-independence gate for the avalanche
+  boulder kernel (`AvalancheSystem.update`). Triggers one deterministic, seeded
+  avalanche on **flat** terrain (so the grounded-slide regime — where the friction term
+  dominates — shows cleanly, mirroring how the invariant harness pins the snowman on a
+  synthetic slope) and asserts the 10-FPS/60-FPS front-travel ratio stays near 1 and all
+  boulder state stays finite. Guards the per-frame-friction regression fixed alongside
+  this harness (the same bug class as PR #209). Also run via `npm run test:stress`.
 - **`results.txt`** — the recorded output from the last full verification run.
 
 ```bash
 npm run test:verify        # physics_invariant_harness.js + dom_smoke_test.js
 npm run test:turn-styles   # carve vs. parallel turn side-by-side comparison
+npm run test:stress        # forward_stress_harness.js + avalanche_framerate_harness.js
 ```
 
 ## Playwright E2E (cross-browser + mobile)

--- a/tests/verification/avalanche_framerate_harness.js
+++ b/tests/verification/avalanche_framerate_harness.js
@@ -117,7 +117,7 @@ function makeRng(seed) {
     if (ratio > worstReachRatio) { worstReachRatio = ratio; worstReachSeed = seed; }
   }
 
-  console.log('=== Avalanche frame-rate independence: real terrain, one triggered slide ===');
+  console.log('=== Avalanche frame-rate independence: flat terrain, one triggered slide ===');
   console.log('  seed     FPS  frontTravel   leadZ    meanZ   finite');
   for (const r of rows) {
     console.log('  %s  %s   %s   %s  %s    %s',

--- a/tests/verification/avalanche_framerate_harness.js
+++ b/tests/verification/avalanche_framerate_harness.js
@@ -1,0 +1,146 @@
+// avalanche_framerate_harness.js
+// Frame-rate-independence gate for the avalanche boulder kernel (AvalancheSystem.update).
+//
+// Sibling to forward_stress_harness.js (PR #209). The snowman drag fix in that PR
+// corrected a per-frame multiplier mixed in with dt-scaled forces; the SAME bug class
+// lived on in src/avalanche.ts, where the ground `friction = 0.98` was applied once
+// per frame instead of integrated per second. That made boulders decay ~4x less at the
+// capped 10 FPS delta than at 60 FPS, so on a slow device the avalanche reached FARTHER
+// and FASTER — directly skewing burial (game-over) fairness by frame rate.
+//
+// This harness triggers ONE deterministic avalanche (seeded Math.random so every frame
+// rate gets byte-identical initial boulder state + terrain) and steps it for a fixed
+// amount of IN-GAME time at several frame rates. It then compares how far downhill the
+// boulder front travelled. It guards two properties:
+//
+//   1. FRAME-RATE-BOUNDED REACH — the 10-FPS / 60-FPS front-travel ratio must stay near
+//      1. Before the fix it ballooned well past the cap (low FPS = less friction = more
+//      reach); the fix (friction -> Math.pow(0.98, dt*60)) brings every frame rate in
+//      line, byte-identical at the 1/60 baseline.
+//   2. NO NaN/Infinity — every boulder position/velocity stays finite at every frame
+//      rate, including the capped 0.1 s delta.
+//
+// Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/avalanche_framerate_harness.js
+const { pathToFileURL } = require('url');
+const path = require('path');
+
+// Minimal browser globals the kernel + terrain touch (no DOM/WebGL).
+global.window = { location: { search: '' }, matchMedia: () => ({ matches: false }), terrainMesh: null };
+global.document = undefined;
+try { Object.defineProperty(global, 'navigator', { value: { webdriver: false }, configurable: true }); } catch { /* keep existing */ }
+
+// Seeded PRNG so boulder spawn (trigger() calls Math.random) is reproducible and the
+// only variable across the FRAME_RATES loop is dt.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+(async () => {
+  await import(pathToFileURL(path.join(__dirname, '..', 'loaders', 'register-ts-resolve.mjs')).href);
+  const THREE = await import('three');
+  const { AvalancheSystem } = await import('../../src/avalanche.ts');
+
+  // FLAT terrain on purpose — like physics_invariant_harness.js pins the snowman on a
+  // synthetic slope rather than the real mountain. On the real downhill slope, boulder
+  // reach is dominated by ballistic gravity + (correctly dt-scaled) slide, so the
+  // grounded FRICTION term — the buggy one — barely shows. On flat ground the boulders
+  // settle and enter the grounded-slide regime where terminal slide speed is
+  // -2*dt/(1-friction): ~6x larger at 10 FPS than 60 FPS pre-fix, ~flat post-fix. That
+  // is the clean, large, reliable signal this gate needs.
+  const getTerrainHeight = () => 0;
+
+  const SEEDS = [12345, 777, 42, 9001];
+  const FRAME_RATES = [1 / 60, 1 / 30, 1 / 10]; // 60, 30, and the capped-delta 10 FPS
+  // Long enough that boulders settle into the grounded-slide regime, where the
+  // frame-rate dependence is strongest (see terrain note above).
+  const SIM_SECONDS = 12;                        // in-game wall clock to integrate per run
+  const PLAYER = { x: 0, y: 2, z: -60 };
+
+  // Trigger one avalanche from a fixed seed, step it for SIM_SECONDS at `dt`, and report
+  // how far downhill (-Z) the boulder front and mean reached, plus a finiteness flag.
+  function runAvalanche(seed, dt) {
+    Math.random = makeRng(seed);
+    // Silence the unconditional trigger() log so harness output stays readable.
+    const _log = console.log;
+    console.log = () => {};
+    const scene = new THREE.Scene();
+    const av = new AvalancheSystem(scene, 120);
+    av.setTerrainFunction(getTerrainHeight);
+    av.trigger(PLAYER);
+    console.log = _log;
+
+    // Snapshot the spawned front Z (max -Z reached so far = most downhill = min z).
+    const startLeadZ = Math.min(...sampleZ(av));
+
+    let finite = true;
+    const steps = Math.round(SIM_SECONDS / dt);
+    for (let f = 0; f < steps; f++) {
+      av.update(dt);
+      if (finite) {
+        for (let i = 0; i < av.count; i++) {
+          const idx = i * 3;
+          if (!Number.isFinite(av.positions[idx]) || !Number.isFinite(av.positions[idx + 1]) ||
+              !Number.isFinite(av.positions[idx + 2]) || !Number.isFinite(av.velocities[idx + 2])) {
+            finite = false; break;
+          }
+        }
+      }
+    }
+
+    const zs = sampleZ(av);
+    const leadZ = Math.min(...zs);
+    const meanZ = zs.reduce((a, b) => a + b, 0) / zs.length;
+    // Travel = how much further downhill (more negative Z) the front advanced.
+    const frontTravel = startLeadZ - leadZ;
+    return { frontTravel, leadZ, meanZ, finite };
+  }
+
+  function sampleZ(av) {
+    const zs = [];
+    for (let i = 0; i < av.count; i++) zs.push(av.positions[i * 3 + 2]);
+    return zs;
+  }
+
+  let hardFail = false;
+  let worstReachRatio = 0, worstReachSeed = 0, allFinite = true;
+  const rows = [];
+  for (const seed of SEEDS) {
+    const byDt = {};
+    for (const dt of FRAME_RATES) {
+      const r = runAvalanche(seed, dt);
+      byDt[dt] = r;
+      if (!r.finite) allFinite = false;
+      rows.push({ seed, fps: Math.round(1 / dt), ...r });
+    }
+    const ratio = byDt[1 / 10].frontTravel / byDt[1 / 60].frontTravel;
+    if (ratio > worstReachRatio) { worstReachRatio = ratio; worstReachSeed = seed; }
+  }
+
+  console.log('=== Avalanche frame-rate independence: real terrain, one triggered slide ===');
+  console.log('  seed     FPS  frontTravel   leadZ    meanZ   finite');
+  for (const r of rows) {
+    console.log('  %s  %s   %s   %s  %s    %s',
+      String(r.seed).padStart(6), String(r.fps).padStart(3),
+      r.frontTravel.toFixed(2).padStart(8), r.leadZ.toFixed(1).padStart(7),
+      r.meanZ.toFixed(1).padStart(7), r.finite ? 'yes' : 'NO ❌');
+  }
+
+  // Before the fix this ratio ran well above 1 (low FPS = less friction = more reach).
+  // 1.6 mirrors the forward harness's speed cap: tight enough to fail hard on a per-frame
+  // friction regression, loose enough for honest coarse-dt integration drift.
+  const REACH_RATIO_CAP = 1.6;
+  const reachBounded = worstReachRatio < REACH_RATIO_CAP;
+  console.log('\n--- Avalanche reach does not balloon at low frame rate [GATING] ---');
+  console.log('  worst 10-FPS / 60-FPS front-travel ratio:', worstReachRatio.toFixed(2),
+    `(seed ${worstReachSeed})`, '| cap:', REACH_RATIO_CAP);
+  console.log('  PASS:', reachBounded ? 'low-FPS reach stays bounded ✅' : 'reach scales with frame rate ❌');
+  if (!reachBounded) hardFail = true;
+
+  console.log('\n--- No NaN/Infinity in boulder state at any frame rate [GATING] ---');
+  console.log('  PASS:', allFinite ? 'all boulder positions/velocities finite ✅' : 'a boulder went non-finite ❌');
+  if (!allFinite) hardFail = true;
+
+  console.log(`\nAVALANCHE FRAME-RATE HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (reach frame-rate bounded; all finite)'}`);
+  process.exit(hardFail ? 1 : 0);
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/tests/verification/forward_stress_harness.js
+++ b/tests/verification/forward_stress_harness.js
@@ -1,23 +1,34 @@
 // forward_stress_harness.js
 // Robustness stress test for the "floor it forward and blow past the obstacles"
-// class of bug (PR #209). Unlike physics_invariant_harness.js — which pins coasting
-// on a synthetic constant slope — this drives the REAL physics kernel
-// (Snowman.updateSnowman) over the REAL analytic terrain with the REAL procedurally
-// placed trees + rocks, holding ONLY Up (forward, never steering), across several
-// frame rates and tree layouts. It guards two properties that broke before the
-// frame-rate-independent drag fix:
+// class of bug (PR #209) — broadened in the #209 follow-up to a full INPUT x
+// FRAME-RATE matrix. It drives the REAL physics kernel (Snowman.updateSnowman) over
+// the REAL analytic terrain with the REAL procedurally placed trees + rocks, across
+// several input policies, frame rates (incl. bursty frame hitching), and layouts.
 //
-//   1. NO TUNNELING — the collision check is a discrete point-vs-radius test, so a
-//      per-frame step larger than the tree radius can skip a tree disk entirely. The
-//      harness replays each frame's prev->cur segment against every tree disk and
-//      asserts zero uncaught pass-throughs, and that the worst per-frame step stays
-//      below the collision radius, at every tested frame rate (incl. the capped
-//      0.1 s delta = ~10 FPS).
+// Unlike physics_invariant_harness.js — which pins coasting byte-for-byte and gates
+// straight-line cruise speed on a synthetic constant slope — this exercises the kernel
+// against the actual mountain and obstacle field, where discrete point-vs-radius
+// collision and coarse integration can interact. It guards:
 //
-//   2. FRAME-RATE-BOUNDED SPEED — terminal cruise speed holding Up must not balloon
-//      at low frame rate. Before the fix it scaled ~4x (8 -> 32 m/s) from 60 to
-//      10 FPS, which is what let a slow-device player rocket straight down the fall
-//      line past the trees. The gate caps the 10-FPS/60-FPS max-speed ratio.
+//   1. NO TUNNELING (trees AND rocks) — the collision checks are discrete point-vs-
+//      radius tests, so a per-frame step larger than an obstacle radius can skip the
+//      disk entirely. The harness replays each frame's prev->cur segment against every
+//      tree disk (radius 2.5) and every rock disk (per-rock rockCollisionRadius) and
+//      asserts zero uncaught pass-throughs, at every frame rate and under every policy.
+//   2. FRAME-RATE-BOUNDED SPEED — terminal speed must not balloon at low frame rate
+//      under ANY policy (the #209 drag bug; ~8 -> ~32 m/s from 60 to 10 FPS before the
+//      fix). Gated as the 10-FPS/60-FPS max-speed ratio across the whole input matrix —
+//      max-speed is the robust frame-rate observable; a per-frame mistake in any force
+//      path (steer/accelerate/jump/brake) would inflate it.
+//   3. NO NaN/Infinity — every pos/velocity stays finite, every policy, every rate.
+//   4. TERMINATION — every descent ENDS (finish / crash / off-side) within the frame
+//      cap rather than spinning. Closest reproducible proxy for the reported "the game
+//      freezes at the end" (issue 2): a runaway/stuck state would exhaust the cap here.
+//
+// NOT gated (reported as a diagnostic): steered-path convergence. A deterministic slalom
+// does NOT trace the same path at every FPS — coarse-dt Euler on the radial fall line
+// drifts it tens of units — but that is honest integration sensitivity (the steer force
+// is delta-scaled), too chaotic to gate without flaking.
 //
 // Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js
 const { pathToFileURL } = require('url');
@@ -28,7 +39,8 @@ global.window = { location: { search: '' }, matchMedia: () => ({ matches: false 
 global.document = undefined; // trees/rocks skip canvas textures when document is absent
 try { Object.defineProperty(global, 'navigator', { value: { webdriver: false }, configurable: true }); } catch { /* keep existing */ }
 
-// Seeded PRNG so tree/rock placement and the auto-turn are reproducible.
+// Seeded PRNG so tree/rock placement, the auto-turn, and the wander schedule are
+// reproducible.
 function makeRng(seed) {
   let s = seed >>> 0;
   return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
@@ -64,27 +76,67 @@ function fakeSnowman() {
   const { Snowman } = await import('../../src/snowman.ts');
   const terrain = await import('../../src/mountains/terrain.ts');
   const { Trees } = await import('../../src/mountains/trees.ts');
-  const { addRocks } = await import('../../src/mountains/rocks.ts');
+  const { addRocks, rockCollisionRadius } = await import('../../src/mountains/rocks.ts');
   const { getTerrainHeight, getTerrainGradient, getDownhillDirection } = terrain;
 
   const TREE_RADIUS = 2.5;            // mirrors collision.ts default treeCollisionRadius
-  const UP = { left: false, right: false, up: true, down: false, jump: false };
   const SEEDS = [12345, 777, 42, 9001];
   const FRAME_RATES = [1 / 60, 1 / 30, 1 / 10]; // 60, 30, and the capped-delta 10 FPS
 
-  // One descent holding Up. Trees/rocks are generated from `layoutSeed` (fixed per
-  // seed so every frame rate skis the SAME mountain); the auto-turn uses a fixed
-  // descent seed so the only variable across the FRAME_RATES loop is dt.
-  function runDescent(layoutSeed, dt) {
+  const UP = { left: false, right: false, up: true, down: false, jump: false };
+  const mk = (over) => ({ left: false, right: false, up: true, down: false, jump: false, ...over });
+
+  // --- Input policies. Each returns the controls for a frame given the in-game time
+  // `t` (seconds), live pos/velocity, the tree field, and the per-descent schedule.
+  // Steering keyed to IN-GAME TIME (not frame index) so a given seed skis the same
+  // *pattern* at every frame rate; policies that set left/right bypass the kernel's
+  // auto-turn (and its Math.random), keeping them deterministic across frame rates.
+  const POLICIES = {
+    // Hold Up only — the original "floor it forward" case; auto-turn meanders gently.
+    holdUp: () => UP,
+    // Deterministic time-keyed slalom (no RNG) — used for the convergence gate.
+    slalom: (t) => (Math.floor(t / 1.5) % 2 === 0 ? mk({ right: true }) : mk({ left: true })),
+    // Time-keyed random-walk steering from the descent schedule (frame-rate stable).
+    wander: (t, pos, vel, trees, sched) => {
+      const dir = sched[Math.min(sched.length - 1, Math.floor(t / 0.8))];
+      return dir < 0 ? mk({ left: true }) : dir > 0 ? mk({ right: true }) : UP;
+    },
+    // Adversarial: steer toward the nearest tree ahead within range — worst case for
+    // the discrete collision check. Deterministic from the (frame-rate-varying) path,
+    // gated only on no-tunnel / finite / termination (not convergence).
+    adversarial: (t, pos) => {
+      let best = null, bestD = 18;
+      for (const tr of POLICY_TREES) {
+        if (tr.z > pos.z) continue;                 // only trees downhill (ahead)
+        const d = Math.hypot(tr.x - pos.x, tr.z - pos.z);
+        if (d < bestD) { bestD = d; best = tr; }
+      }
+      if (!best) return UP;
+      return best.x > pos.x ? mk({ right: true }) : mk({ left: true });
+    },
+    // Jump spam: hold Up and pulse Jump ~every 0.8 s of in-game time.
+    jumpSpam: (t) => mk({ jump: (Math.floor(t / 0.8) % 2 === 0) }),
+  };
+  let POLICY_TREES = []; // set per descent so the adversarial policy can see the field
+
+  // One descent. `frameSpec` is either a fixed dt (number) or { hitch: true, seed }
+  // for bursty frame hitching (mostly 1/60 with occasional capped 0.1 s spikes — the
+  // GC-pause scenario). `policyName` selects the input policy.
+  function runDescent(layoutSeed, frameSpec, policyName, opts = {}) {
+    const maxTime = opts.maxTime || Infinity; // stop the descent after this many in-game seconds
     Math.random = makeRng(layoutSeed);
     const scene = makeScene();
-    // Silence the unconditional placement logs (Trees.addTrees / addRocks) so the
-    // harness output stays readable; restore immediately after.
     const _log = console.log, _warn = console.warn;
     console.log = () => {}; console.warn = () => {};
     const treePositions = Trees.addTrees(scene);
     const rockPositions = addRocks(scene);
     console.log = _log; console.warn = _warn;
+    POLICY_TREES = treePositions;
+
+    // Per-descent steering schedule for `wander` (in-game-time keyed, so identical
+    // across frame rates); separate stream from placement so layouts stay fixed.
+    const sRng = makeRng(0x5EED ^ layoutSeed);
+    const schedule = Array.from({ length: 200 }, () => (sRng() < 0.5 ? -1 : 1));
 
     Math.random = makeRng(0xC0FFEE ^ layoutSeed); // deterministic auto-turn, independent of dt
     const snowman = fakeSnowman();
@@ -96,83 +148,164 @@ function fakeSnowman() {
     const showGameOver = (r) => { if (!reason) reason = r; };
     let st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, -15),
                airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+    const policy = POLICIES[policyName];
 
-    let maxSpeed = 0, maxStep = 0, tunnelFrames = 0;
-    const MAX_FRAMES = Math.ceil(120 / dt); // 2 min of in-game wall clock cap
-    for (let f = 0; f < MAX_FRAMES; f++) {
+    // Frame-time generator. Fixed dt, or bursty hitching clamped to the 0.1 s loop cap.
+    const fixed = typeof frameSpec === 'number';
+    const hitchRng = fixed ? null : makeRng(0x117C4 ^ layoutSeed ^ (frameSpec.seed || 0));
+    const nextDt = () => fixed ? frameSpec : (hitchRng() < 0.08 ? 0.1 : 1 / 60);
+    // Cap wall-clock frames at ~2 min in-game; smallest dt sets the worst case.
+    const MAX_FRAMES = Math.ceil(120 / (fixed ? frameSpec : 1 / 60));
+
+    let maxSpeed = 0, maxStep = 0, treeTunnel = 0, rockTunnel = 0, nonFinite = false, t = 0, f = 0;
+    for (; f < MAX_FRAMES; f++) {
+      const dt = nextDt();
+      t += dt;
       const prevX = pos.x, prevZ = pos.z;
+      const controls = policy(t, pos, velocity, treePositions, schedule);
       st = Snowman.updateSnowman(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity,
-        st.lastTerrainHeight, st.airTime, st.jumpCooldown, UP, st.turnPhase, st.currentTurnDirection,
+        st.lastTerrainHeight, st.airTime, st.jumpCooldown, controls, st.turnPhase, st.currentTurnDirection,
         st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
         treePositions, true, showGameOver, rockPositions);
       snowman.position.set(pos.x, pos.y, pos.z);
+
+      if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y) || !Number.isFinite(pos.z) ||
+          !Number.isFinite(velocity.x) || !Number.isFinite(velocity.z)) { nonFinite = true; break; }
 
       const speed = Math.hypot(velocity.x, velocity.z);
       if (speed > maxSpeed) maxSpeed = speed;
       const step = Math.hypot(pos.x - prevX, pos.z - prevZ);
       if (step > maxStep) maxStep = step;
 
-      // Tunneling probe: did the prev->cur segment pass THROUGH a tree disk that
+      // Tunneling probe: did the prev->cur segment pass THROUGH an obstacle disk that
       // neither endpoint sampled inside (so the point-based check missed it)?
-      for (const t of treePositions) {
-        if (pointSegmentDistance(t.x, t.z, prevX, prevZ, pos.x, pos.z) < TREE_RADIUS &&
-            Math.hypot(prevX - t.x, prevZ - t.z) >= TREE_RADIUS &&
-            Math.hypot(pos.x - t.x, pos.z - t.z) >= TREE_RADIUS) {
-          tunnelFrames++;
+      for (const tr of treePositions) {
+        if (pointSegmentDistance(tr.x, tr.z, prevX, prevZ, pos.x, pos.z) < TREE_RADIUS &&
+            Math.hypot(prevX - tr.x, prevZ - tr.z) >= TREE_RADIUS &&
+            Math.hypot(pos.x - tr.x, pos.z - tr.z) >= TREE_RADIUS) {
+          treeTunnel++;
+        }
+      }
+      for (const rk of rockPositions) {
+        const rr = rockCollisionRadius(rk.size);
+        if (pointSegmentDistance(rk.x, rk.z, prevX, prevZ, pos.x, pos.z) < rr &&
+            Math.hypot(prevX - rk.x, prevZ - rk.z) >= rr &&
+            Math.hypot(pos.x - rk.x, pos.z - rk.z) >= rr) {
+          rockTunnel++;
         }
       }
 
-      if (reason || pos.z < -195) break;
+      if (reason || pos.z < -195 || t >= maxTime) break;
     }
-    return { maxSpeed, maxStep, tunnelFrames, reason, trees: treePositions.length, rocks: rockPositions.length };
+    const terminated = reason !== null || pos.z < -195;
+    return { maxSpeed, maxStep, treeTunnel, rockTunnel, nonFinite, terminated, reason,
+             finalX: pos.x, finalZ: pos.z, framesUsed: f + 1, maxFrames: MAX_FRAMES,
+             trees: treePositions.length, rocks: rockPositions.length };
   }
 
   let hardFail = false;
 
-  // --- 1) No tunneling at any frame rate / layout [GATING] ---
-  let totalTunnel = 0, worstStep = 0, worstStepDt = 0;
-  // --- 2) Frame-rate-bounded speed [GATING] ---
-  let worstSpeedRatio = 0, worstSpeedSeed = 0;
-  const rows = [];
+  // --- Run the full INPUT x FRAME-RATE matrix (fixed rates + a hitch run) ---
+  const POLICY_NAMES = ['holdUp', 'slalom', 'wander', 'adversarial', 'jumpSpam'];
+  const records = []; // { seed, policy, fps|'hitch', ...metrics }
   for (const seed of SEEDS) {
-    const byDt = {};
-    for (const dt of FRAME_RATES) {
-      const r = runDescent(seed, dt);
-      byDt[dt] = r;
-      totalTunnel += r.tunnelFrames;
-      if (r.maxStep > worstStep) { worstStep = r.maxStep; worstStepDt = dt; }
-      rows.push({ seed, fps: Math.round(1 / dt), ...r });
+    for (const policyName of POLICY_NAMES) {
+      for (const dt of FRAME_RATES) {
+        records.push({ seed, policy: policyName, fps: Math.round(1 / dt), dt, ...runDescent(seed, dt, policyName) });
+      }
+      // One bursty-hitching run per (seed, policy): GC-pause spikes amid 60 FPS frames.
+      records.push({ seed, policy: policyName, fps: 'hitch', dt: null, ...runDescent(seed, { hitch: true, seed: 1 }, policyName) });
     }
-    const ratio = byDt[1 / 10].maxSpeed / byDt[1 / 60].maxSpeed;
-    if (ratio > worstSpeedRatio) { worstSpeedRatio = ratio; worstSpeedSeed = seed; }
   }
 
-  console.log('=== Forward-only stress: real terrain + trees + rocks, holding Up ===');
-  console.log('  seed     FPS  trees rocks  maxSpeed  maxStep  tunnel  outcome');
-  for (const r of rows) {
-    console.log('  %s  %s   %s   %s   %s   %s    %s    %s',
-      String(r.seed).padStart(6), String(r.fps).padStart(3), String(r.trees).padStart(4),
-      String(r.rocks).padStart(4), r.maxSpeed.toFixed(2).padStart(6), r.maxStep.toFixed(3).padStart(6),
-      String(r.tunnelFrames).padStart(4), r.reason || `z<-195 (finish)`);
+  // --- 1) No tunneling (trees AND rocks), any policy / rate [GATING] ---
+  let totalTreeTunnel = 0, totalRockTunnel = 0, worstStep = 0, worstStepCtx = '';
+  for (const r of records) {
+    totalTreeTunnel += r.treeTunnel; totalRockTunnel += r.rockTunnel;
+    if (r.maxStep > worstStep) { worstStep = r.maxStep; worstStepCtx = `${r.policy}@${r.fps}FPS seed ${r.seed}`; }
   }
-
-  const noTunneling = totalTunnel === 0 && worstStep < TREE_RADIUS;
-  console.log('\n--- No collision tunneling at any frame rate [GATING] ---');
-  console.log('  total uncaught pass-throughs:', totalTunnel,
-    '| worst per-frame step:', worstStep.toFixed(3), `(at ${Math.round(1 / worstStepDt)} FPS)`, '| tree radius:', TREE_RADIUS);
-  console.log('  PASS:', noTunneling ? 'every step stays inside the collision radius ✅' : 'a frame stepped past a tree disk ❌');
+  const noTunneling = totalTreeTunnel === 0 && totalRockTunnel === 0 && worstStep < TREE_RADIUS;
+  console.log('=== Forward stress: real terrain + trees + rocks | %d policies x %d rates+hitch x %d seeds ===',
+    POLICY_NAMES.length, FRAME_RATES.length, SEEDS.length);
+  console.log('\n--- No collision tunneling (trees + rocks) at any frame rate / policy [GATING] ---');
+  console.log('  uncaught tree pass-throughs:', totalTreeTunnel, '| uncaught rock pass-throughs:', totalRockTunnel);
+  console.log('  worst per-frame step:', worstStep.toFixed(3), `(${worstStepCtx})`, '| tree radius:', TREE_RADIUS);
+  console.log('  PASS:', noTunneling ? 'every step stays inside the collision radius ✅' : 'a frame stepped past an obstacle disk ❌');
   if (!noTunneling) hardFail = true;
 
-  // Before the fix this ratio was ~4 (8 -> 32 m/s); 1.6 leaves margin for the small
-  // discrete-integration drift while still failing hard on a per-frame-drag regression.
+  // --- 2) Speed does not balloon at low frame rate, EVERY policy [GATING] ---
+  // Generalizes the #209 holdUp speed gate to the whole input matrix: a per-frame-vs-
+  // per-second mistake in ANY force path (steer, accelerate, jump, brake) would inflate
+  // a policy's terminal speed at low FPS. Max-speed is the robust frame-rate observable
+  // (driven by drag, which the fix bounds); lateral PATH is not (see the diagnostic
+  // below), so we gate speed, not position.
   const SPEED_RATIO_CAP = 1.6;
+  let worstSpeedRatio = 0, worstSpeedCtx = '';
+  for (const seed of SEEDS) {
+    for (const policyName of POLICY_NAMES) {
+      const at = (fps) => records.find(r => r.seed === seed && r.policy === policyName && r.fps === fps).maxSpeed;
+      const ratio = at(10) / at(60);
+      if (ratio > worstSpeedRatio) { worstSpeedRatio = ratio; worstSpeedCtx = `${policyName} seed ${seed}`; }
+    }
+  }
   const speedBounded = worstSpeedRatio < SPEED_RATIO_CAP;
-  console.log('\n--- Cruise speed does not balloon at low frame rate [GATING] ---');
-  console.log('  worst 10-FPS / 60-FPS max-speed ratio:', worstSpeedRatio.toFixed(2),
-    `(seed ${worstSpeedSeed})`, '| cap:', SPEED_RATIO_CAP);
+  console.log('\n--- Speed does not balloon at low frame rate (all policies) [GATING] ---');
+  console.log('  worst 10-FPS / 60-FPS max-speed ratio:', worstSpeedRatio.toFixed(2), `(${worstSpeedCtx})`, '| cap:', SPEED_RATIO_CAP);
   console.log('  PASS:', speedBounded ? 'low-FPS speed stays bounded ✅' : 'speed scales with frame rate ❌');
   if (!speedBounded) hardFail = true;
 
-  console.log(`\nFORWARD STRESS HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (no tunneling; speed frame-rate bounded)'}`);
+  // --- Steered-path frame-rate sensitivity [DIAGNOSTIC, not gated] ---
+  // A deterministic time-keyed slalom does NOT trace the same path at every FPS: coarse-
+  // dt Euler integration, amplified by the radial mountain redirecting velocity along a
+  // position-dependent fall line, drifts the lateral path ~tens of units over a descent.
+  // That is honest integration sensitivity, not a bug (the steer force is delta-scaled,
+  // line 391/394 of physics.ts), and it is too chaotic to gate tightly without flaking —
+  // so it is reported, not asserted. The robust frame-rate guarantees are speed (gate 2)
+  // and no-tunneling/finite/termination (gates 1/4/5).
+  const CONV_SECONDS = 8;
+  let worstConv = 0, worstConvSeed = 0;
+  for (const seed of SEEDS) {
+    const ref = runDescent(seed, 1 / 60, 'slalom', { maxTime: CONV_SECONDS });
+    for (const dt of [1 / 30, 1 / 10]) {
+      const r = runDescent(seed, dt, 'slalom', { maxTime: CONV_SECONDS });
+      const gap = Math.hypot(r.finalX - ref.finalX, r.finalZ - ref.finalZ);
+      if (gap > worstConv) { worstConv = gap; worstConvSeed = seed; }
+    }
+  }
+  console.log('\n--- Steered-path frame-rate sensitivity (slalom) [DIAGNOSTIC] ---');
+  console.log(`  worst ${CONV_SECONDS}s-window lateral drift vs 60 FPS:`, worstConv.toFixed(2), `(seed ${worstConvSeed})`,
+    '— coarse-dt Euler on the radial fall line; not gated');
+
+  // --- 4) No NaN/Infinity, any policy / rate [GATING] ---
+  const nonFiniteRuns = records.filter(r => r.nonFinite);
+  const allFinite = nonFiniteRuns.length === 0;
+  console.log('\n--- No NaN/Infinity in pos/velocity at any frame rate / policy [GATING] ---');
+  console.log('  non-finite runs:', nonFiniteRuns.length,
+    nonFiniteRuns.length ? '(' + nonFiniteRuns.slice(0, 3).map(r => `${r.policy}@${r.fps}`).join(', ') + ' ...)' : '');
+  console.log('  PASS:', allFinite ? 'all positions/velocities stayed finite ✅' : 'a run went non-finite ❌');
+  if (!allFinite) hardFail = true;
+
+  // --- 5) Every descent terminates within the frame cap [GATING] (issue 2 proxy) ---
+  const stuckRuns = records.filter(r => !r.terminated || r.framesUsed >= r.maxFrames);
+  const allTerminate = stuckRuns.length === 0;
+  console.log('\n--- Every descent terminates (finish / crash / off-side), no spin [GATING] ---');
+  console.log('  runs that exhausted the frame cap without ending:', stuckRuns.length,
+    stuckRuns.length ? '(' + stuckRuns.slice(0, 3).map(r => `${r.policy}@${r.fps} seed ${r.seed}`).join('; ') + ')' : '');
+  console.log('  PASS:', allTerminate ? 'every descent reached a definite outcome ✅' : 'a descent never ended (possible freeze) ❌');
+  if (!allTerminate) hardFail = true;
+
+  // --- Per-policy summary table (diagnostic) ---
+  console.log('\n  policy        rates        maxSpeed(60/30/10)   treeTun rockTun  finite term');
+  for (const policyName of POLICY_NAMES) {
+    const rs = records.filter(r => r.policy === policyName);
+    const sp = (fps) => (rs.filter(r => r.fps === fps).reduce((a, r) => a + r.maxSpeed, 0) / SEEDS.length).toFixed(1);
+    const tt = rs.reduce((a, r) => a + r.treeTunnel, 0), rt = rs.reduce((a, r) => a + r.rockTunnel, 0);
+    const fin = rs.every(r => !r.nonFinite), term = rs.every(r => r.terminated);
+    console.log('  %s  fixed+hitch  %s / %s / %s        %s     %s     %s   %s',
+      policyName.padEnd(12), sp(60).padStart(5), sp(30).padStart(5), sp(10).padStart(5),
+      String(tt).padStart(3), String(rt).padStart(3), fin ? 'yes' : 'NO', term ? 'yes' : 'NO');
+  }
+
+  console.log(`\nFORWARD STRESS HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (no tunneling; speed bounded; finite; terminates)'}`);
   process.exit(hardFail ? 1 : 0);
 })().catch((e) => { console.error('FATAL', e); process.exit(1); });


### PR DESCRIPTION
## Summary

Follow-up to PR #209 (frame-rate-independent snowman drag). Stress-testing surfaced the **same bug class still live in the avalanche kernel**, so this fixes it and broadens the stress harness into a full input × frame-rate matrix to guard the whole class going forward.

## 1. Bug fix — avalanche ground friction was frame-rate dependent

`src/avalanche.ts` applied the ground `friction = 0.98` **once per frame** while gravity/slide are `* dt` scaled — the exact defect #209 just fixed for the snowman. Consequences on a slow device:

- Boulders decayed ~4× less at the capped 10 FPS delta than at 60 FPS.
- The grounded-slide terminal speed `2·dt / (1 − friction)` scaled **~6×** with frame time.
- → the avalanche reached farther and faster, **skewing burial (game-over) fairness by frame rate**.

**Fix** mirrors the snowman's `dragFactor`: `friction → Math.pow(0.98, dt * 60)`. Byte-identical at the 60 Hz baseline (`dt·60 == 1` when `dt == 1/60`, `x ** 1 === x`), so existing avalanche tests are unchanged — only off-60 Hz frames are corrected. The debris/powder loop already drag-scaled correctly; this brings the boulders in line.

## 2. New gate — `avalanche_framerate_harness.js`

Triggers one deterministic, seeded avalanche on **flat** terrain (so the grounded-slide regime — where the friction term dominates — shows cleanly, the way the invariant harness pins the snowman on a synthetic slope) and asserts the 10/60 FPS front-travel ratio stays near 1 and all boulder state stays finite.

Proven to **fail on the pre-fix kernel (ratio ≈ 2.9) and pass on the fix (≈ 0.95)** — a passing test on the old code would have proven nothing.

## 3. Forward stress harness broadened to an input × frame-rate matrix

`forward_stress_harness.js` (added hold-Up-only in #209) now sweeps **5 input policies** (hold-Up, deterministic slalom, time-keyed wander, adversarial steer-into-the-nearest-tree, jump-spam) × **60/30/10 FPS + a bursty frame-hitching run** (60 FPS with occasional 0.1 s GC-pause spikes) × 4 seeds. New gating checks beyond the original tree-tunneling + speed-ratio:

- **Rock tunneling** — the prev→cur segment probe now replays every rock disk at its `rockCollisionRadius`, not just trees.
- **Speed bounded under every policy** — generalizes the #209 hold-Up speed gate to the whole matrix.
- **No NaN/Infinity** — every pos/velocity, any policy/rate.
- **Termination** — every descent ends (finish/crash/off-side), never spins the frame cap. Closest reproducible proxy for the reported **"game freezes at the end."**

Steered-path convergence is reported as a **diagnostic, not gated**: a deterministic slalom doesn't trace the same path at every FPS, but that's honest coarse-dt Euler integration on the radial fall line (the steer force *is* delta-scaled) — too chaotic to gate without flaking.

The broadened matrix found **no new defects**. Verified to still fail hard on a reverted drag fix (3.16 m per-frame step → tunneling; 10/60 speed ratio 3.83).

## Testing

- `npm test` — green (exit 0), incl. `INVARIANT HARNESS ✅`, `FORWARD STRESS HARNESS ✅`, `AVALANCHE FRAME-RATE HARNESS ✅`, avalanche unit tests 12/12.
- `npm run lint` — 0 errors.
- Each new/changed gate verified to **fail on the pre-fix code** and pass on the fix.

No user-visible visual change (physics/test-only), so no screenshots.

Docs updated: `PHYSICS.md` §7.3, `tests/README.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8pB6CDMifPNTdK4RZqoTH)_