### PR TITLE
feat(diagnostics): runtime physics/frame-rate telemetry to catch the #209 bug class live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 - `src/controls.ts` - Keyboard and touch controls implementation
 - `src/audio.ts` - Background music and audio controls
 - `src/sfx.ts` - Procedural Web Audio sound effects (wind/carve/jump/land/avalanche/crash/finish)
+- `src/diagnostics.ts` - Read-only runtime physics/frame-rate telemetry (`Diag`): catches the frame-rate-dependence bug class (#209) live — runaway low-FPS speed, per-frame steps past a collision radius (tunnel risk), NaN. Dev overlay (`?debug`), `window.__snowgliderDiag.dump()` JSON export; off under automation. See `docs/DIAGNOSTICS.md`.
 - `src/auth.ts` - Firebase authentication implementation
 - `src/scores.ts` - User scoring and leaderboard functionality
 - `src/boot/` - Classic-script local-auth fallback + Firebase bootstrap (the only remaining `.js`), and `script-loader.ts` (startup driver)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,7 +56,16 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   (`fps_ge50_frames`/`fps_30_50_frames`/`fps_15_30_frames`/`fps_lt15_frames`) so the
   real-world frame-rate spread is chartable and anomalies can be sliced against it. A short
   healthy run is sampled exactly once; an empty reset emits nothing.
-- **The codex P2 was fixed:** `resetSnowman()` teleports the player to spawn, so
+- **Review hardening (codex P2s).** (a) The analytics sink targeted
+  `window.firebaseModules.logEvent`, which **only `auth.html` ever populated** — so on the
+  main game page the sink (and the pre-existing `game_start`/`game_over`/`game_reset`
+  calls) silently no-oped. `auth.ts` now publishes a `logEvent` wrapper bound to the real
+  Analytics instance on the main page, so all of them actually deliver. (b) The fps→speed
+  ratio compared max speed across *any* populated bands, so a device fast at startup (slow
+  snowman) that settled below 30 FPS at cruising speed could read as frame-rate-dependent
+  from acceleration alone; the ratio now counts only **settled** (cruising-speed) frames
+  and requires a minimum per band, with a regression test for the accel artifact.
+- **The first codex P2 was fixed:** `resetSnowman()` teleports the player to spawn, so
   `Diag.reset()` is now called in the lifecycle reset path — otherwise the first frame of a
   restarted run read as a ~135u step (old finish → spawn) and was falsely flagged a tunnel
   risk, permanently marking the run BAD. Regression-tested both ways.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,16 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   `Diag.reset()` is now called in the lifecycle reset path — otherwise the first frame of a
   restarted run read as a ~135u step (old finish → spawn) and was falsely flagged a tunnel
   risk, permanently marking the run BAD. Regression-tested both ways.
+- **Two more codex P2s fixed.** (c) `session_health` was only flushed on `reset()`, so a
+  one-and-done run that ended via game-over/finish and was then abandoned (player never
+  presses Reset) contributed no baseline. `Diag.endRun()` now flushes at run-end (called
+  from `showGameOver`) and a `pagehide` listener flushes if the player just navigates away;
+  all three paths share one de-duped flush so a run is never double-counted. (d) The tunnel
+  check used the tree radius (2.5u) alone, but collidable rocks can be as small as
+  ≈1.69u (`rockCollisionRadius(ROCK_COLLISION_MIN_SIZE)`), so a ~2u step could skip a small
+  rock while diagnostics reported no tunnel risk. `Diag` is now initialised with the
+  **smallest** collidable obstacle radius (`min(treeRadius, smallest-rock-radius)`).
+  Both are regression-tested in `tests/diagnostics-tests.js`.
 - **Analytics are pure + headlessly tested.** `percentile`, `classifyFrame`, `foldFrame`,
   `fpsSpeedRatio`, and `frameRateHealth` are exported pure functions (no DOM), unit-tested
   in `tests/diagnostics-tests.js` (`npm run test:diagnostics`, also in `npm test`). The

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,13 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   harness. The sink is wrapped so telemetry can never throw into the game loop, gated like
   the other `logEvent` call sites (modular SDK present, not `file://`), and swappable for a
   dedicated error monitor (Sentry / GlitchTip) with a one-line change at the `init()` site.
+- **Healthy runs are sampled too** (`session_health`). Reporting only anomalies leaves
+  nothing to compare a BAD verdict against, so a sampled baseline now fires on a periodic
+  heartbeat through a long run (`healthSampleSec`, default 30s) and once at run-end — same
+  shape as `physics_anomaly`, flattening the **FPS-band distribution**
+  (`fps_ge50_frames`/`fps_30_50_frames`/`fps_15_30_frames`/`fps_lt15_frames`) so the
+  real-world frame-rate spread is chartable and anomalies can be sliced against it. A short
+  healthy run is sampled exactly once; an empty reset emits nothing.
 - **The codex P2 was fixed:** `resetSnowman()` teleports the player to spawn, so
   `Diag.reset()` is now called in the lifecycle reset path — otherwise the first frame of a
   restarted run read as a ~135u step (old finish → spawn) and was falsely flagged a tunnel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,11 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   snowman) that settled below 30 FPS at cruising speed could read as frame-rate-dependent
   from acceleration alone; the ratio now counts only **settled** (cruising-speed) frames
   and requires a minimum per band, with a regression test for the accel artifact.
+  A follow-up tightened this further: the cruising floor is now near the expected terminal
+  speed (so a mid-acceleration ~5 m/s frame is not "cruising"), and a BAD `physics_anomaly`
+  requires an egregious, #209-scale gap (≥2×, the bug was ~4×) — a milder gap (≥1.5×) is
+  WARN-only, since it can come from normal run progression / technique. Regression tests
+  cover a 5→8 m/s progression (not flagged) and a modest gap (WARN, not BAD).
 - **The first codex P2 was fixed:** `resetSnowman()` teleports the player to spawn, so
   `Diag.reset()` is now called in the lifecycle reset path — otherwise the first frame of a
   restarted run read as a ~135u step (old finish → spawn) and was falsely flagged a tunnel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,38 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Runtime physics / frame-rate diagnostics (`src/diagnostics.ts`)
+- PR #209 and its avalanche follow-up fixed two instances of the **same bug class** — a
+  per-frame multiplier (`v *= 1 − k`) mixed in with dt-scaled forces, so a steady state
+  scaled with frame rate. Both were invisible to every existing test (none *varied the
+  frame time*) and invisible in play (they only bite on a slow/mobile device the
+  developer never runs on). The offline stress harnesses now sweep dt in CI; this adds
+  the **runtime counterpart** so the *next* bug in this class is diagnosed, not guessed.
+- **`Diag`** is a read-only telemetry observer wired into the main loop beside
+  `Sfx`/`Flex` (`Diag.record(...)` in `game/main-loop.ts`). It reads the per-frame
+  physics result + position **only** — never `pos`/`velocity` — so the physics-invariant
+  harness is byte-identical and it is a no-op under automation (off unless
+  `window.testHooks.diagnosticsEnabled`, mirroring `debris`/`sfx`). It watches the dt the
+  real device produces and the speed/step that ride on it, and surfaces the three
+  frame-rate smells **live**: (1) a per-frame **step ≥ an obstacle's collision radius**
+  (the discrete point-vs-disk check could miss it → tunnel risk — the runtime analog of
+  the harness's offline tunneling probe); (2) terminal **speed that climbs as FPS
+  drops**, computed as the max-speed ratio between low- and high-FPS frame bands (the
+  #209 signature); (3) **NaN/Infinity** in the state.
+- **How you use it.** Throttled `console.warn` breadcrumbs fire on any anomaly during
+  normal play. Add `?debug` (or press `` ` ``) for a live HUD overlay — fps, dt cap hits,
+  max step vs radius, and the speed-by-FPS-band table. `window.__snowgliderDiag.dump()`
+  downloads a JSON trace (config, summary, health verdict, recent frames) to attach to a
+  bug report — turning "the game froze / I drove through a tree" into hard numbers.
+- **Analytics are pure + headlessly tested.** `percentile`, `classifyFrame`, `foldFrame`,
+  `fpsSpeedRatio`, and `frameRateHealth` are exported pure functions (no DOM), unit-tested
+  in `tests/diagnostics-tests.js` (`npm run test:diagnostics`, also in `npm test`). The
+  tests prove the detector **fires on the real #209 numbers** (8 → 32 m/s across a 60→10
+  FPS drop grades BAD; a 3.2 u step past the 2.5 u tree radius flags a tunnel risk) and
+  stays **quiet on a healthy steady-60-FPS run** and on a merely-slow-but-bounded device
+  (no fast band to compare against → no false "frame-rate-dependent" accusation). See
+  [`DIAGNOSTICS.md`](DIAGNOSTICS.md).
+
 ### Avalanche friction made frame-rate independent (follow-up to PR #209)
 - The snowman drag fix in PR #209 corrected a per-frame multiplier mixed in with
   dt-scaled forces. Stress-testing turned up the **same bug class still live in the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,23 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   max step vs radius, and the speed-by-FPS-band table. `window.__snowgliderDiag.dump()`
   downloads a JSON trace (config, summary, health verdict, recent frames) to attach to a
   bug report — turning "the game froze / I drove through a tree" into hard numbers.
+- **Broadened beyond the one bug + aggregated off-device** (review follow-up). The
+  detector gained an **absolute speed-ceiling** invariant (a runaway is caught even at a
+  steady frame rate, where the fps-band ratio sees nothing) and a generic
+  `Diag.note(category, detail)` seam so **other subsystems** (asset loaders, avalanche,
+  camera) can report into the same pipeline. Crucially, findings now leave the device: a
+  `report` sink routes a **once-per-run `physics_anomaly`** verdict — plus **`client_error`
+  / `unhandled_rejection`** from newly-added global handlers (the app had none, so an
+  uncaught throw in the rAF loop previously vanished) — into the **existing Firebase
+  Analytics** pipeline (`window.firebaseModules.logEvent`). Aggregated across real devices,
+  that is how the #209 class would have surfaced in the wild rather than via a stress
+  harness. The sink is wrapped so telemetry can never throw into the game loop, gated like
+  the other `logEvent` call sites (modular SDK present, not `file://`), and swappable for a
+  dedicated error monitor (Sentry / GlitchTip) with a one-line change at the `init()` site.
+- **The codex P2 was fixed:** `resetSnowman()` teleports the player to spawn, so
+  `Diag.reset()` is now called in the lifecycle reset path — otherwise the first frame of a
+  restarted run read as a ~135u step (old finish → spawn) and was falsely flagged a tunnel
+  risk, permanently marking the run BAD. Regression-tested both ways.
 - **Analytics are pure + headlessly tested.** `percentile`, `classifyFrame`, `foldFrame`,
   `fpsSpeedRatio`, and `frameRateHealth` are exported pure functions (no DOM), unit-tested
   in `tests/diagnostics-tests.js` (`npm run test:diagnostics`, also in `npm test`). The

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -61,6 +61,14 @@ pipeline** (`window.firebaseModules.logEvent`, the same seam `game_start`/`game_
   counts, fps→speed ratio). Aggregated across real devices, this is exactly how the #209
   class would have surfaced — low-FPS sessions correlating with runaway speed / tunnel
   events — instead of as an unreproducible "I drove through a tree".
+- **`session_health`** — a **sampled baseline** so HEALTHY runs contribute data too, not
+  just anomalies (an anomaly is only meaningful against a baseline). Same shape as
+  `physics_anomaly` minus `reasons`, and it flattens the **FPS-band distribution**
+  (`fps_ge50_frames`, `fps_30_50_frames`, `fps_15_30_frames`, `fps_lt15_frames`) so you can
+  chart the real-world frame-rate spread and slice anomalies against it. Emitted on a
+  periodic heartbeat through a long run (`healthSampleSec`, default 30s) **and once at
+  run-end** (on reset), so even a short healthy run is sampled exactly once; a trivial/empty
+  reset emits nothing.
 - **`client_error` / `unhandled_rejection`** — the app had **no** `window.onerror` /
   `unhandledrejection` handler, so an uncaught throw in the rAF loop (a real "freezes"
   candidate) vanished silently. `Diag` installs both, attaching the message/stack plus the

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -31,7 +31,7 @@ For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
 
 | Signal | Meaning | Verdict |
 | --- | --- | --- |
-| **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. Runtime analog of the harness's offline tunneling probe. | **BAD** |
+| **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. The radius is the **smallest** collidable obstacle — `min(tree 2.5u, smallest collidable rock ≈1.69u)` — so a step that would tunnel a small rock isn't masked by the larger tree radius. Runtime analog of the harness's offline tunneling probe. | **BAD** |
 | **fps→speed ratio ≥ 2.0** | Max **cruise-speed** speed in low-FPS frames is ≥2× the max in high-FPS frames → a force path scales with frame time (the #209 signature, which was ~4×). Only *genuine cruising* frames (≥85% of the expected terminal speed) count, and each band needs a minimum of them — so a steady frame rate, an accelerating start, or a normal mid-run speed rise (e.g. 5→8 m/s) never reaches BAD. A milder gap (≥1.5×) is **WARN-only**, since it can come from run progression / technique rather than a frame-rate-dependent force. | **BAD** (≥1.5 → WARN) |
 | **speed past the absolute ceiling** | A frame above `speedCeiling` (50 m/s) — impossible for legit play even buggy. Caught independent of frame rate, so a runaway with *no* FPS tell still fires. | **BAD** |
 | **NaN / Infinity** | Non-finite physics state. | **BAD** |
@@ -67,8 +67,11 @@ pipeline** (`window.firebaseModules.logEvent`, the same seam `game_start`/`game_
   (`fps_ge50_frames`, `fps_30_50_frames`, `fps_15_30_frames`, `fps_lt15_frames`) so you can
   chart the real-world frame-rate spread and slice anomalies against it. Emitted on a
   periodic heartbeat through a long run (`healthSampleSec`, default 30s) **and once at
-  run-end** (on reset), so even a short healthy run is sampled exactly once; a trivial/empty
-  reset emits nothing.
+  run-end** — at the game-over/finish (`Diag.endRun()` from `showGameOver`), on the next
+  `reset()`, or on `pagehide` if the player just navigates away — so even a short
+  one-and-done run (finish/crash, then leave without pressing Reset) is sampled exactly once.
+  All three paths share one de-duped flush, so a run is never double-counted; a
+  trivial/empty run emits nothing.
 - **`client_error` / `unhandled_rejection`** — the app had **no** `window.onerror` /
   `unhandledrejection` handler, so an uncaught throw in the rAF loop (a real "freezes"
   candidate) vanished silently. `Diag` installs both, attaching the message/stack plus the

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -1,0 +1,76 @@
+# Physics / Frame-Rate Diagnostics
+
+`src/diagnostics.ts` (`Diag`) is a **runtime telemetry observer** for the physics loop.
+It exists to catch one specific, expensive class of bug — and the next one like it.
+
+## The bug class it targets
+
+PR #209 and its avalanche follow-up fixed two instances of the **same shape of bug**: a
+quantity integrated as a *per-frame* multiplier (`v *= 1 − k`) sitting next to forces that
+are *delta-scaled* (`v += a · dt`). Mix the two and the steady state scales with frame
+rate. The snowman's terminal speed ballooned **~8 → ~32 m/s from 60 to 10 FPS**, fast
+enough to slip between — and, when a per-frame step exceeded an obstacle's collision
+radius, **tunnel straight through** — the trees.
+
+Why it was so hard to find:
+
+- **No existing test varied the frame time.** Every harness ran at a fixed `dt = 1/60`, so
+  the whole dimension the bug lived in was unexercised.
+- **It only bites on slow/mobile devices.** The developer's 60 FPS machine never sees it;
+  the bug report is "the game freezes / I drove through a tree with no warning" — with no
+  way to reproduce.
+
+The offline stress harnesses (`tests/verification/forward_stress_harness.js`,
+`physics_invariant_harness.js`) now **sweep `dt` in CI**. `Diag` is the **runtime
+counterpart**: it watches the `dt` the *real device* produces and the speed/step that ride
+on it, and surfaces the same smells live.
+
+## What it detects
+
+For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
+
+| Signal | Meaning | Verdict |
+| --- | --- | --- |
+| **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. Runtime analog of the harness's offline tunneling probe. | **BAD** |
+| **fps→speed ratio ≥ 1.6** | Max speed in low-FPS frames is ≥1.6× the max in high-FPS frames → a force path scales with frame time (the #209 signature). Needs both a fast (≥30 FPS) and slow (<30 FPS) band populated, so a *steady* frame rate never false-alarms. | **BAD** (≥1.25 → WARN) |
+| **NaN / Infinity** | Non-finite physics state. | **BAD** |
+| **≥10% of frames at the delta cap** | The device is below 1/cap FPS (the regime the bug bites). Informational, not an accusation. | **WARN** |
+
+## How to use it
+
+- **Console breadcrumbs.** During normal play, throttled `console.warn`s fire on any
+  anomaly — so even a tester who never opened a panel leaves a trail in the console.
+- **Live overlay.** Load the game with `?debug` (or press `` ` `` at any time) for a HUD:
+  current/avg FPS, dt-cap hits, max step vs radius, the **speed-by-FPS-band** table, and
+  the health verdict with reasons.
+- **Bug-report export.** `window.__snowgliderDiag.dump()` returns *and downloads* a JSON
+  trace — config, running summary, health verdict, and the most recent ~120 frames —
+  ready to attach to a GitHub issue. `snapshot()` returns it without downloading;
+  `reset()` clears the trace; `overlay(true|false)` toggles the HUD.
+
+## Design constraints (shared with `sfx`/`intro`/`debris`)
+
+- **Read-only.** `record()` takes the per-frame result + `pos`; it never writes
+  `pos`/`velocity` or any kernel state, so the physics-invariant harness stays
+  byte-identical.
+- **Automation-safe.** Off by default under `?test=` suites (`window.isTestMode`) and
+  webdriver runs, unless a test opts in via `window.testHooks.diagnosticsEnabled`.
+- **Cheap.** O(1) per frame — a fixed ring buffer plus an incremental summary fold (no
+  full-history rescan). The overlay repaints at a throttled ~6 Hz; warnings are
+  rate-limited per category.
+- **Headless-testable.** All analytics (`percentile`, `classifyFrame`, `foldFrame`,
+  `fpsSpeedRatio`, `frameRateHealth`) are exported pure functions with no DOM dependency,
+  unit-tested in `tests/diagnostics-tests.js` (`npm run test:diagnostics`).
+
+## Tests
+
+`npm run test:diagnostics` proves the detector both **fires and stays quiet**:
+
+- the real #209 numbers (8 → 32 m/s across a 60→10 FPS drop) grade **BAD** and the verdict
+  cites both the tunnel risk and the frame-rate-dependent force;
+- a steady 60 FPS run grades **OK**;
+- a steady-slow-but-bounded device is **WARN**ed about the delta cap but **not** accused of
+  the speed bug (the guard against crying wolf).
+
+To disable the subsystem entirely, set `DIAG_ENABLED = false` in `src/diagnostics.ts`
+(every method early-exits).

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -32,7 +32,7 @@ For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
 | Signal | Meaning | Verdict |
 | --- | --- | --- |
 | **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. Runtime analog of the harness's offline tunneling probe. | **BAD** |
-| **fps→speed ratio ≥ 1.6** | Max **settled** (cruising-speed) speed in low-FPS frames is ≥1.6× the max in high-FPS frames → a force path scales with frame time (the #209 signature). Only settled frames count and each band needs a minimum of them, so a *steady* frame rate and an *accelerating start* (fast frames while the snowman is still slow) never false-alarm. | **BAD** (≥1.25 → WARN) |
+| **fps→speed ratio ≥ 2.0** | Max **cruise-speed** speed in low-FPS frames is ≥2× the max in high-FPS frames → a force path scales with frame time (the #209 signature, which was ~4×). Only *genuine cruising* frames (≥85% of the expected terminal speed) count, and each band needs a minimum of them — so a steady frame rate, an accelerating start, or a normal mid-run speed rise (e.g. 5→8 m/s) never reaches BAD. A milder gap (≥1.5×) is **WARN-only**, since it can come from run progression / technique rather than a frame-rate-dependent force. | **BAD** (≥1.5 → WARN) |
 | **speed past the absolute ceiling** | A frame above `speedCeiling` (50 m/s) — impossible for legit play even buggy. Caught independent of frame rate, so a runaway with *no* FPS tell still fires. | **BAD** |
 | **NaN / Infinity** | Non-finite physics state. | **BAD** |
 | **≥10% of frames at the delta cap** | The device is below 1/cap FPS (the regime the bug bites). Informational, not an accusation. | **WARN** |

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -33,6 +33,7 @@ For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
 | --- | --- | --- |
 | **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. Runtime analog of the harness's offline tunneling probe. | **BAD** |
 | **fps→speed ratio ≥ 1.6** | Max speed in low-FPS frames is ≥1.6× the max in high-FPS frames → a force path scales with frame time (the #209 signature). Needs both a fast (≥30 FPS) and slow (<30 FPS) band populated, so a *steady* frame rate never false-alarms. | **BAD** (≥1.25 → WARN) |
+| **speed past the absolute ceiling** | A frame above `speedCeiling` (50 m/s) — impossible for legit play even buggy. Caught independent of frame rate, so a runaway with *no* FPS tell still fires. | **BAD** |
 | **NaN / Infinity** | Non-finite physics state. | **BAD** |
 | **≥10% of frames at the delta cap** | The device is below 1/cap FPS (the regime the bug bites). Informational, not an accusation. | **WARN** |
 
@@ -44,9 +45,36 @@ For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
   current/avg FPS, dt-cap hits, max step vs radius, the **speed-by-FPS-band** table, and
   the health verdict with reasons.
 - **Bug-report export.** `window.__snowgliderDiag.dump()` returns *and downloads* a JSON
-  trace — config, running summary, health verdict, and the most recent ~120 frames —
+  trace — config, running summary, health verdict, recent frames, and any `note()`s —
   ready to attach to a GitHub issue. `snapshot()` returns it without downloading;
   `reset()` clears the trace; `overlay(true|false)` toggles the HUD.
+
+## Aggregation: Firebase Analytics + global error capture
+
+A detector whose output dies in the device console can't catch the *next* bug in the
+wild. `Diag` therefore routes its findings into the **existing Firebase Analytics
+pipeline** (`window.firebaseModules.logEvent`, the same seam `game_start`/`game_over`/
+`game_reset` already use) via a `report` sink injected at `init()`:
+
+- **`physics_anomaly`** — emitted **once per run** the moment a run's health first reaches
+  BAD, with the structured summary (fps, dtMax, speedMax, tunnel/runaway/non-finite frame
+  counts, fps→speed ratio). Aggregated across real devices, this is exactly how the #209
+  class would have surfaced — low-FPS sessions correlating with runaway speed / tunnel
+  events — instead of as an unreproducible "I drove through a tree".
+- **`client_error` / `unhandled_rejection`** — the app had **no** `window.onerror` /
+  `unhandledrejection` handler, so an uncaught throw in the rAF loop (a real "freezes"
+  candidate) vanished silently. `Diag` installs both, attaching the message/stack plus the
+  current physics snapshot as context.
+- **`diag_note`** — the generic `Diag.note(category, detail)` seam lets **other
+  subsystems** (asset loaders, avalanche, camera) report anomalies into the same pipeline,
+  so diagnostics is not limited to the physics kernel. e.g.
+  `Diag.note('asset_load_failed', { url })`.
+
+The sink is wrapped so a telemetry failure can never throw into the game loop, is gated
+exactly like the other `logEvent` call sites (modular SDK present, not `file://`), and is
+inert under automation (the recorder is off there). Swapping the sink for a dedicated
+error monitor (Sentry / self-hosted GlitchTip) later is a one-line change at the `init()`
+call site — `Diag` itself stays decoupled from the transport.
 
 ## Design constraints (shared with `sfx`/`intro`/`debris`)
 

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -32,7 +32,7 @@ For every frame the main loop feeds it (`Diag.record(...)`), it classifies:
 | Signal | Meaning | Verdict |
 | --- | --- | --- |
 | **step ≥ collision radius** | The per-frame move jumped farther than an obstacle's radius, so the discrete point-vs-disk collision check could skip the disk entirely. Runtime analog of the harness's offline tunneling probe. | **BAD** |
-| **fps→speed ratio ≥ 1.6** | Max speed in low-FPS frames is ≥1.6× the max in high-FPS frames → a force path scales with frame time (the #209 signature). Needs both a fast (≥30 FPS) and slow (<30 FPS) band populated, so a *steady* frame rate never false-alarms. | **BAD** (≥1.25 → WARN) |
+| **fps→speed ratio ≥ 1.6** | Max **settled** (cruising-speed) speed in low-FPS frames is ≥1.6× the max in high-FPS frames → a force path scales with frame time (the #209 signature). Only settled frames count and each band needs a minimum of them, so a *steady* frame rate and an *accelerating start* (fast frames while the snowman is still slow) never false-alarm. | **BAD** (≥1.25 → WARN) |
 | **speed past the absolute ceiling** | A frame above `speedCeiling` (50 m/s) — impossible for legit play even buggy. Caught independent of frame rate, so a runaway with *no* FPS tell still fires. | **BAD** |
 | **NaN / Infinity** | Non-finite physics state. | **BAD** |
 | **≥10% of frames at the delta cap** | The device is below 1/cap FPS (the regime the bug bites). Informational, not an accusation. | **WARN** |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -26,6 +26,7 @@
     "test:debris": "node tests/debris-tests.js",
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
     "test:sfx": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sfx-tests.js",
+    "test:diagnostics": "node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
     "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:debris": "node tests/debris-tests.js",
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
     "test:sfx": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sfx-tests.js",
-    "test:diagnostics": "node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js",
+    "test:diagnostics": "node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-dom-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
     "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -128,6 +128,24 @@ function initializeAuth(firebaseConfig: FirebaseOptions) {
         analytics = null;
     }
 
+    // Publish a minimal analytics seam on window so the game page (index.html) can log
+    // events without importing Firebase. The game's existing callers
+    // (game_start / game_over / game_reset in snowglider/result-overlay/lifecycle) and the
+    // diagnostics telemetry sink all read `window.firebaseModules.logEvent` — but only
+    // auth.html populated it, so on the main page those calls silently no-oped. Bind a
+    // thin wrapper to the real Analytics instance here so they actually deliver. The
+    // wrapper reads the module-scoped `analytics` at call time, so it self-disables if
+    // Analytics is later cleared, and is guarded so a logging failure never throws into a
+    // caller.
+    if (typeof window !== 'undefined' && analytics) {
+      window.firebaseModules = Object.assign(window.firebaseModules || {}, {
+        logEvent: (name: string, params?: Record<string, unknown>) => {
+          try { if (analytics) logEvent(analytics, name, params); }
+          catch (e) { console.log('logEvent skipped:', (e as Error).message); }
+        }
+      });
+    }
+
     // Initialize ScoresModule with Firestore and Analytics instances
     ScoresModule.initializeScores(firestore, analytics);
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,456 @@
+// diagnostics.ts — runtime physics / frame-rate telemetry for SnowGlider.
+//
+// WHY THIS EXISTS (the bug class it targets)
+// ------------------------------------------
+// PR #209 and its avalanche follow-up both fixed the *same* shape of bug: a quantity
+// integrated as a **per-frame** multiplier (`v *= 1 - k`) while every neighbouring
+// force is **delta-scaled** (`v += a * dt`). Mixing the two makes the steady state
+// scale with frame rate — the snowman's terminal speed ballooned ~8 → ~32 m/s from 60
+// to 10 FPS, fast enough to slip between (and, when a per-frame step exceeded an
+// obstacle's collision radius, tunnel straight through) the trees. It was invisible to
+// every existing test because none of them *varied the frame time*, and invisible in
+// play because it only bites on a slow/mobile device that the developer never runs on.
+//
+// This module is the **runtime** counterpart to the offline stress harnesses
+// (tests/verification/forward_stress_harness.js, physics_invariant_harness.js): instead
+// of sweeping dt in CI, it watches the dt the *real device* actually produces and the
+// physics observables that ride on it, and surfaces the same three smells live —
+//   1. low-FPS frames whose per-frame STEP exceeds an obstacle radius  → tunnel risk;
+//   2. terminal SPEED that climbs as FPS drops                          → fps-dependent force;
+//   3. NaN/Infinity in the state.
+// It turns "the game freezes / I drove through a tree" — an unreproducible field report
+// — into a downloadable JSON trace (`__snowgliderDiag.dump()`) with the exact dt, speed,
+// step, and fps-band breakdown, so the next bug in this class is diagnosed, not guessed.
+//
+// DESIGN CONSTRAINTS (mirroring sfx.ts / intro.ts / debris)
+//   - **Read-only observer.** record() takes the per-frame physics RESULT plus pos —
+//     it never writes pos/velocity or any kernel state, so the physics-invariant
+//     harness stays byte-identical. It is wired in alongside Sfx/Flex, after the step.
+//   - **Automation-safe.** Off by default under ?test= suites (window.isTestMode) and
+//     webdriver runs (Playwright/Puppeteer), unless a test opts in via
+//     window.testHooks.diagnosticsEnabled — so existing tests keep their exact paths.
+//   - **Headless-testable.** All the analytics (percentiles, per-frame classification,
+//     the running summary fold, the health verdict) are exported PURE functions that
+//     need no DOM/AudioContext, so they unit-test in Node (npm run test:diagnostics).
+//   - **Cheap.** O(1) per frame: a fixed ring buffer for the recent trace plus an
+//     incremental summary fold (no full-history scan). The DOM overlay repaints at a
+//     throttled ~6 Hz, and console warnings are rate-limited per category.
+//   - **Inert without a DOM** (jsdom/Node): the overlay/keybind/window-API setup is
+//     skipped, but the pure analytics still run, so the recorder is safe to construct
+//     anywhere.
+//
+// To disable entirely: set DIAG_ENABLED = false (all methods early-exit).
+
+const DIAG_ENABLED = true;
+
+// --- Tunables ------------------------------------------------------------------
+const RING_CAPACITY = 1200;     // ~20 s of 60 FPS trace kept for the overlay + dump
+const OVERLAY_HZ = 6;           // overlay repaint rate (throttled; cheap)
+const WARN_THROTTLE_SEC = 4;    // min seconds between repeats of the same warning
+
+// FPS bands the summary buckets frames into. The whole point of the module: if the
+// max speed in a SLOWER band is materially higher than in a FAST band, a force path is
+// frame-rate dependent (the #209 smell). Ordered fast → slow.
+export interface FpsBand { label: string; minFps: number; maxFps: number; }
+export const FPS_BANDS: FpsBand[] = [
+  { label: '>=50',  minFps: 50, maxFps: Infinity },
+  { label: '30-50', minFps: 30, maxFps: 50 },
+  { label: '15-30', minFps: 15, maxFps: 30 },
+  { label: '<15',   minFps: 0,  maxFps: 15 },
+];
+
+export interface DiagConfig {
+  /** The run-loop's delta clamp (main-loop caps delta at 0.1 s). A frame whose dt sits
+   *  at the cap means the device dropped to/below 1/cap FPS — the regime the bug bit. */
+  frameCapSec: number;
+  /** Smallest obstacle collision radius the discrete point-vs-disk check guards (trees
+   *  use 2.5). A per-frame step >= this could skip the disk entirely → tunnel risk. */
+  collisionRadius: number;
+  /** Rough expected 60 Hz cruising/terminal speed (~8 m/s). Only used to flag a frame
+   *  as "fast" for the overlay; the fps-band correlation is what actually detects the bug. */
+  speedExpected: number;
+}
+
+export const DEFAULT_CONFIG: DiagConfig = {
+  frameCapSec: 0.1,
+  collisionRadius: 2.5,
+  speedExpected: 8,
+};
+
+/** One frame's physics observables, as read from the kernel result + position. */
+export interface FrameSample {
+  dt: number;
+  speed: number;
+  x: number;
+  z: number;
+  technique: string;
+  isInAir: boolean;
+}
+
+/** Per-frame anomaly flags derived from a sample and the previous position. */
+export interface FrameFlags {
+  step: number;        // planar distance moved this frame (world units)
+  fps: number;         // 1/dt
+  clamped: boolean;    // dt pinned at the loop cap → device below 1/cap FPS
+  tunnelRisk: boolean; // step >= collisionRadius → discrete check could miss a disk
+  nonFinite: boolean;  // any of dt/speed/x/z not finite
+  fast: boolean;       // speed well above the expected 60 Hz terminal speed
+}
+
+export interface BandStat {
+  label: string;
+  frames: number;
+  speedMax: number;
+  speedSum: number; // for the mean; kept raw so the fold stays additive
+}
+
+/** The incremental running summary. Folded one frame at a time so the recorder never
+ *  rescans history; also the exact object frameRateHealth() + dump() consume. */
+export interface DiagSummary {
+  frames: number;
+  durationSec: number;
+  dtMaxSec: number;
+  clampedFrames: number;
+  stepMax: number;
+  speedMax: number;
+  tunnelRiskFrames: number;
+  nonFiniteFrames: number;
+  bands: BandStat[];
+}
+
+export interface HealthVerdict {
+  level: 'ok' | 'warn' | 'bad';
+  reasons: string[];
+}
+
+// --- Pure analytics (no DOM; unit-tested headlessly) ---------------------------
+
+/** Linear-interpolated percentile of an ascending-sorted array. p in [0,1]. */
+export function percentile(sortedAsc: number[], p: number): number {
+  const n = sortedAsc.length;
+  if (n === 0) return NaN;
+  if (n === 1) return sortedAsc[0];
+  const idx = Math.min(n - 1, Math.max(0, p * (n - 1)));
+  const lo = Math.floor(idx), hi = Math.ceil(idx);
+  if (lo === hi) return sortedAsc[lo];
+  return sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (idx - lo);
+}
+
+/** Classify one frame relative to the previous position + the config thresholds. */
+export function classifyFrame(prev: { x: number; z: number } | null, s: FrameSample, cfg: DiagConfig): FrameFlags {
+  const finite = Number.isFinite(s.dt) && Number.isFinite(s.speed) &&
+    Number.isFinite(s.x) && Number.isFinite(s.z);
+  const step = prev && finite ? Math.hypot(s.x - prev.x, s.z - prev.z) : 0;
+  const fps = s.dt > 0 ? 1 / s.dt : Infinity;
+  return {
+    step,
+    fps,
+    clamped: finite && s.dt >= cfg.frameCapSec - 1e-9,
+    tunnelRisk: step >= cfg.collisionRadius,
+    nonFinite: !finite,
+    fast: finite && s.speed > cfg.speedExpected * 1.5,
+  };
+}
+
+/** Empty summary seed for the fold. */
+export function emptySummary(): DiagSummary {
+  return {
+    frames: 0, durationSec: 0, dtMaxSec: 0, clampedFrames: 0,
+    stepMax: 0, speedMax: 0, tunnelRiskFrames: 0, nonFiniteFrames: 0,
+    bands: FPS_BANDS.map((b) => ({ label: b.label, frames: 0, speedMax: 0, speedSum: 0 })),
+  };
+}
+
+/** Fold one frame into the running summary (mutates + returns `agg` for chaining).
+ *  Additive/idempotent per frame, so the recorder calls it once per frame and the
+ *  tests can fold an array to get the same result. */
+export function foldFrame(agg: DiagSummary, s: FrameSample, flags: FrameFlags): DiagSummary {
+  agg.frames += 1;
+  if (Number.isFinite(s.dt)) {
+    agg.durationSec += s.dt;
+    if (s.dt > agg.dtMaxSec) agg.dtMaxSec = s.dt;
+  }
+  if (flags.clamped) agg.clampedFrames += 1;
+  if (flags.tunnelRisk) agg.tunnelRiskFrames += 1;
+  if (flags.nonFinite) { agg.nonFiniteFrames += 1; return agg; } // don't pollute speed stats
+  if (flags.step > agg.stepMax) agg.stepMax = flags.step;
+  if (s.speed > agg.speedMax) agg.speedMax = s.speed;
+  // Bucket by fps so we can correlate speed against frame rate.
+  for (let i = 0; i < FPS_BANDS.length; i++) {
+    const b = FPS_BANDS[i];
+    if (flags.fps >= b.minFps && flags.fps < b.maxFps) {
+      const bs = agg.bands[i];
+      bs.frames += 1;
+      bs.speedSum += s.speed;
+      if (s.speed > bs.speedMax) bs.speedMax = s.speed;
+      break;
+    }
+  }
+  return agg;
+}
+
+/** Mean speed in a band (0 if the band saw no frames). */
+export function bandMeanSpeed(b: BandStat): number {
+  return b.frames > 0 ? b.speedSum / b.frames : 0;
+}
+
+/** The fps-dependence signal at the heart of this module: the ratio of the max speed
+ *  seen in the SLOWEST populated band to the FASTEST populated band. ~1 means speed is
+ *  frame-rate independent (good); >> 1 means a force path scales with frame time (the
+ *  #209 bug). Needs both a fast (>=30 FPS) and a slow (<30 FPS) band populated to mean
+ *  anything; returns 1 (no signal) otherwise so it never false-alarms on a steady FPS. */
+export function fpsSpeedRatio(summary: DiagSummary): number {
+  const fast = summary.bands.filter((b, i) => FPS_BANDS[i].minFps >= 30 && b.frames > 0);
+  const slow = summary.bands.filter((b, i) => FPS_BANDS[i].maxFps <= 30 && b.frames > 0);
+  if (fast.length === 0 || slow.length === 0) return 1;
+  const fastMax = Math.max(...fast.map((b) => b.speedMax));
+  const slowMax = Math.max(...slow.map((b) => b.speedMax));
+  if (fastMax <= 1e-6) return 1;
+  return slowMax / fastMax;
+}
+
+/** Turn a summary into an actionable verdict. Thresholds chosen to be quiet on a
+ *  healthy run and loud on the #209 signature. */
+export function frameRateHealth(summary: DiagSummary, cfg: DiagConfig): HealthVerdict {
+  const reasons: string[] = [];
+  let level: HealthVerdict['level'] = 'ok';
+  const bump = (l: HealthVerdict['level']) => {
+    if (l === 'bad') level = 'bad';
+    else if (l === 'warn' && level === 'ok') level = 'warn';
+  };
+
+  if (summary.nonFiniteFrames > 0) {
+    reasons.push(`${summary.nonFiniteFrames} non-finite frame(s) — NaN/Infinity in physics state`);
+    bump('bad');
+  }
+  if (summary.tunnelRiskFrames > 0) {
+    reasons.push(`${summary.tunnelRiskFrames} frame(s) stepped >= ${cfg.collisionRadius}u (an obstacle radius) — collision tunnel risk`);
+    bump('bad');
+  }
+  const ratio = fpsSpeedRatio(summary);
+  if (ratio >= 1.6) {
+    reasons.push(`speed ${ratio.toFixed(1)}x higher in low-FPS frames than high-FPS — frame-rate-dependent force (the #209 class)`);
+    bump('bad');
+  } else if (ratio >= 1.25) {
+    reasons.push(`speed ${ratio.toFixed(1)}x higher at low FPS — possible frame-rate dependence`);
+    bump('warn');
+  }
+  const clampedPct = summary.frames > 0 ? summary.clampedFrames / summary.frames : 0;
+  if (clampedPct >= 0.1) {
+    reasons.push(`${(clampedPct * 100).toFixed(0)}% of frames hit the ${cfg.frameCapSec * 1000}ms delta cap — device below ${Math.round(1 / cfg.frameCapSec)} FPS`);
+    bump('warn');
+  }
+  if (reasons.length === 0) reasons.push('no frame-rate anomalies detected');
+  return { level, reasons };
+}
+
+// --- Stateful recorder + DOM overlay (the live device side) --------------------
+
+class Diagnostics {
+  private cfg: DiagConfig = DEFAULT_CONFIG;
+  private active = false;
+  private ring: Array<FrameSample & FrameFlags> = [];
+  private head = 0;
+  private summary: DiagSummary = emptySummary();
+  private prev: { x: number; z: number } | null = null;
+  private lastWarn: Record<string, number> = {};
+  private overlay: HTMLElement | null = null;
+  private lastOverlayPaint = 0;
+  private clockSec = 0; // accumulated in-game seconds (dt sum); avoids Date.now in tests
+
+  /** Wire up the recorder. Safe to call once at startup. Honors the automation gate and
+   *  the ?debug overlay flag; without a DOM it just enables the headless recorder. */
+  init(cfg?: Partial<DiagConfig>): void {
+    if (!DIAG_ENABLED) return;
+    this.cfg = { ...DEFAULT_CONFIG, ...(cfg || {}) };
+    if (typeof window === 'undefined') { this.active = true; return; }
+
+    const automated = !!window.isTestMode ||
+      (typeof navigator !== 'undefined' && !!navigator.webdriver);
+    const optedIn = !!(window.testHooks && window.testHooks.diagnosticsEnabled);
+    // The recorder is cheap and read-only, so leave it on in normal play; only the
+    // automated suites stay byte-identical unless a test opts in (matches debris/sfx).
+    this.active = !automated || optedIn;
+    if (!this.active) return;
+
+    const search = (window.location && window.location.search) || '';
+    const wantOverlay = /[?&]debug(=|&|$)/.test(search) || /[?&]debug=(physics|all)/.test(search);
+
+    if (typeof document !== 'undefined') {
+      if (wantOverlay) this.ensureOverlay();
+      // Hotkey: backtick toggles the overlay during normal play (off under automation).
+      window.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === '`') this.toggleOverlay();
+      });
+      // Bug-report API: __snowgliderDiag.dump() returns the trace + verdict and, in a
+      // browser, also downloads it as JSON so a tester can attach it to an issue.
+      (window as unknown as { __snowgliderDiag?: unknown }).__snowgliderDiag = {
+        snapshot: () => this.snapshot(),
+        dump: () => this.dump(),
+        reset: () => this.reset(),
+        overlay: (on?: boolean) => (on === undefined ? this.toggleOverlay() : on ? this.ensureOverlay() : this.hideOverlay()),
+      };
+    }
+  }
+
+  /** Record one frame. READ-ONLY: never mutates pos/velocity/kernel state. Called from
+   *  the main loop right after the physics step, beside Sfx/Flex. */
+  record(s: FrameSample): void {
+    if (!DIAG_ENABLED || !this.active) return;
+    const flags = classifyFrame(this.prev, s, this.cfg);
+    foldFrame(this.summary, s, flags);
+    this.clockSec += Number.isFinite(s.dt) ? s.dt : 0;
+
+    // Ring buffer of the recent trace (for the overlay + dump).
+    const entry = { ...s, ...flags };
+    if (this.ring.length < RING_CAPACITY) this.ring.push(entry);
+    else { this.ring[this.head] = entry; this.head = (this.head + 1) % RING_CAPACITY; }
+
+    if (!flags.nonFinite) this.prev = { x: s.x, z: s.z };
+    this.maybeWarn(flags);
+    this.maybePaint();
+  }
+
+  /** Throttled console warnings on the anomaly categories, so a live slow-device run
+   *  leaves a breadcrumb in the console even if nobody opened the overlay. */
+  private maybeWarn(flags: FrameFlags): void {
+    if (flags.nonFinite) this.warn('nonFinite', '[diag] non-finite physics state (NaN/Infinity) this frame');
+    if (flags.tunnelRisk) {
+      this.warn('tunnel', `[diag] per-frame step ${flags.step.toFixed(2)}u >= collision radius ${this.cfg.collisionRadius}u at ${flags.fps.toFixed(0)} FPS — possible tunnel-through`);
+    }
+    const ratio = fpsSpeedRatio(this.summary);
+    if (ratio >= 1.6) {
+      this.warn('fpsSpeed', `[diag] terminal speed ${ratio.toFixed(1)}x higher at low FPS than high FPS — frame-rate-dependent force (see __snowgliderDiag.dump())`);
+    }
+  }
+
+  private warn(key: string, msg: string): void {
+    const now = this.clockSec;
+    if (this.lastWarn[key] !== undefined && now - this.lastWarn[key] < WARN_THROTTLE_SEC) return;
+    this.lastWarn[key] = now;
+    if (typeof console !== 'undefined' && console.warn) console.warn(msg);
+  }
+
+  /** The trace in chronological order (oldest first). */
+  private orderedRing(): Array<FrameSample & FrameFlags> {
+    if (this.ring.length < RING_CAPACITY) return this.ring.slice();
+    return this.ring.slice(this.head).concat(this.ring.slice(0, this.head));
+  }
+
+  /** A structured, JSON-serialisable snapshot: config, summary, verdict, recent trace. */
+  snapshot() {
+    const health = frameRateHealth(this.summary, this.cfg);
+    const bands = this.summary.bands.map((b) => ({
+      label: b.label, frames: b.frames,
+      speedMax: +b.speedMax.toFixed(2), speedMean: +bandMeanSpeed(b).toFixed(2),
+    }));
+    return {
+      config: this.cfg,
+      summary: {
+        frames: this.summary.frames,
+        durationSec: +this.summary.durationSec.toFixed(2),
+        fps: this.summary.durationSec > 0 ? +(this.summary.frames / this.summary.durationSec).toFixed(1) : 0,
+        dtMaxMs: +(this.summary.dtMaxSec * 1000).toFixed(1),
+        clampedFrames: this.summary.clampedFrames,
+        stepMax: +this.summary.stepMax.toFixed(2),
+        speedMax: +this.summary.speedMax.toFixed(2),
+        tunnelRiskFrames: this.summary.tunnelRiskFrames,
+        nonFiniteFrames: this.summary.nonFiniteFrames,
+        fpsSpeedRatio: +fpsSpeedRatio(this.summary).toFixed(2),
+        bands,
+      },
+      health,
+      recent: this.orderedRing().slice(-120).map((e) => ({
+        dt: +e.dt.toFixed(4), fps: +e.fps.toFixed(0), speed: +e.speed.toFixed(2),
+        step: +e.step.toFixed(2), x: +e.x.toFixed(1), z: +e.z.toFixed(1),
+        technique: e.technique, air: e.isInAir,
+        flags: [e.clamped && 'clamped', e.tunnelRisk && 'tunnel', e.nonFinite && 'NaN'].filter(Boolean),
+      })),
+    };
+  }
+
+  /** Return the snapshot and, in a browser, download it as JSON for a bug report. */
+  dump() {
+    const snap = this.snapshot();
+    try {
+      if (typeof document !== 'undefined' && typeof Blob !== 'undefined' && typeof URL !== 'undefined' && URL.createObjectURL) {
+        const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `snowglider-diag-${Math.round(this.clockSec)}s.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+    } catch { /* download is best-effort; the returned object is the source of truth */ }
+    return snap;
+  }
+
+  reset(): void {
+    this.ring = [];
+    this.head = 0;
+    this.summary = emptySummary();
+    this.prev = null;
+    this.lastWarn = {};
+    this.clockSec = 0;
+  }
+
+  // --- DOM overlay (live HUD) ---
+  private ensureOverlay(): void {
+    if (typeof document === 'undefined' || this.overlay) return;
+    const el = document.createElement('div');
+    el.id = 'diagOverlay';
+    el.style.cssText = [
+      'position:fixed', 'top:8px', 'left:8px', 'z-index:9999',
+      'font:11px/1.4 monospace', 'color:#cfe', 'background:rgba(0,0,0,0.62)',
+      'padding:7px 9px', 'border-radius:6px', 'white-space:pre', 'pointer-events:none',
+      'max-width:46ch',
+    ].join(';');
+    (document.body || document.documentElement).appendChild(el);
+    this.overlay = el;
+    this.paint(true);
+  }
+
+  private hideOverlay(): void {
+    if (this.overlay && this.overlay.parentNode) this.overlay.parentNode.removeChild(this.overlay);
+    this.overlay = null;
+  }
+
+  private toggleOverlay(): void {
+    if (this.overlay) this.hideOverlay(); else this.ensureOverlay();
+  }
+
+  private maybePaint(): void {
+    if (!this.overlay) return;
+    if (this.clockSec - this.lastOverlayPaint < 1 / OVERLAY_HZ) return;
+    this.paint(false);
+  }
+
+  private paint(force: boolean): void {
+    if (!this.overlay) return;
+    this.lastOverlayPaint = this.clockSec;
+    const sm = this.summary;
+    const health = frameRateHealth(sm, this.cfg);
+    const fpsAvg = sm.durationSec > 0 ? sm.frames / sm.durationSec : 0;
+    const recent = this.orderedRing();
+    const last = recent[recent.length - 1];
+    const icon = health.level === 'bad' ? '🔴' : health.level === 'warn' ? '🟡' : '🟢';
+    const bandLines = sm.bands
+      .filter((b) => b.frames > 0)
+      .map((b) => `   ${b.label.padEnd(6)} f=${String(b.frames).padStart(5)} vmax=${b.speedMax.toFixed(1).padStart(5)} vavg=${bandMeanSpeed(b).toFixed(1).padStart(5)}`)
+      .join('\n');
+    const lines = [
+      `${icon} SnowGlider physics diag  (\` toggles)`,
+      `fps  now=${last ? last.fps.toFixed(0) : '–'}  avg=${fpsAvg.toFixed(0)}  dtMax=${(sm.dtMaxSec * 1000).toFixed(0)}ms  clamp=${sm.clampedFrames}`,
+      `spd  now=${last ? last.speed.toFixed(1) : '–'}  max=${sm.speedMax.toFixed(1)}  stepMax=${sm.stepMax.toFixed(2)}/${this.cfg.collisionRadius}`,
+      `risk tunnel=${sm.tunnelRiskFrames}  NaN=${sm.nonFiniteFrames}  fps→spd=${fpsSpeedRatio(sm).toFixed(2)}x`,
+      `speed by fps band:`,
+      bandLines || '   (single band)',
+      health.level === 'ok' ? '' : health.reasons.map((r) => ` ! ${r}`).join('\n'),
+    ];
+    this.overlay.textContent = lines.filter((l) => l !== '').join('\n');
+    void force;
+  }
+}
+
+export const Diag = new Diagnostics();

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -348,6 +348,11 @@ class Diagnostics {
       window.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === '`') this.toggleOverlay();
       });
+      // Last-chance baseline flush: if the player navigates away mid-run or after a
+      // game-over without pressing Reset, reset() never runs — so emit the owed
+      // session_health here. pagehide is the reliable teardown hook on mobile (Safari
+      // fires it where unload/beforeunload are unreliable); de-duped via flushHealthBaseline.
+      window.addEventListener('pagehide', () => this.flushHealthBaseline());
       // Bug-report API: __snowgliderDiag.dump() returns the trace + verdict and, in a
       // browser, also downloads it as JSON so a tester can attach it to an issue.
       (window as unknown as { __snowgliderDiag?: unknown }).__snowgliderDiag = {
@@ -563,15 +568,33 @@ class Diagnostics {
     return snap;
   }
 
-  reset(): void {
-    // Run-end baseline sample: capture the just-completed run before clearing, so even a
-    // short healthy run (too brief for a heartbeat) contributes one session_health. Skipped
-    // for a trivial/empty reset (e.g. the reset at init) and de-duped against a heartbeat
-    // that just fired this run.
+  /** Flush the just-completed run's `session_health` baseline if one is still owed —
+   *  the run reached MIN_SAMPLE_FRAMES and no heartbeat/run-end sample already fired for
+   *  it (de-duped on the clock, which doesn't advance after the run stops). Idempotent, so
+   *  the run-end (showGameOver), pagehide, and reset paths can all call it without
+   *  double-emitting. A no-op for a trivial/empty run (e.g. the reset at init). */
+  private flushHealthBaseline(): void {
     if (this.active && this.summary.frames >= MIN_SAMPLE_FRAMES &&
         this.clockSec - this.lastHealthEmitSec >= 1) {
       this.emitHealthSample();
     }
+  }
+
+  /** Mark the end of a run (finish / crash / avalanche burial) without clearing state, so a
+   *  one-and-done session that ends and is then abandoned — the player never presses
+   *  Reset/Restart, so reset() never runs — still contributes its `session_health` baseline.
+   *  Called from showGameOver; de-duped against the eventual reset() emit. */
+  endRun(): void {
+    if (!DIAG_ENABLED || !this.active) return;
+    this.flushHealthBaseline();
+  }
+
+  reset(): void {
+    // Run-end baseline sample: capture the just-completed run before clearing, so even a
+    // short healthy run (too brief for a heartbeat) contributes one session_health. Skipped
+    // for a trivial/empty reset (e.g. the reset at init) and de-duped against a heartbeat or
+    // an endRun()/pagehide flush that already fired for this run.
+    this.flushHealthBaseline();
     this.ring = [];
     this.head = 0;
     this.summary = emptySummary();

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -47,16 +47,19 @@ const DIAG_ENABLED = true;
 const RING_CAPACITY = 1200;     // ~20 s of 60 FPS trace kept for the overlay + dump
 const OVERLAY_HZ = 6;           // overlay repaint rate (throttled; cheap)
 const WARN_THROTTLE_SEC = 4;    // min seconds between repeats of the same warning
+const MIN_SAMPLE_FRAMES = 30;   // a run must reach this many frames (~0.5s) to be sampled
 
 // FPS bands the summary buckets frames into. The whole point of the module: if the
 // max speed in a SLOWER band is materially higher than in a FAST band, a force path is
 // frame-rate dependent (the #209 smell). Ordered fast → slow.
-export interface FpsBand { label: string; minFps: number; maxFps: number; }
+// `key` is the analytics-safe form of `label` (Firebase event-param names must be
+// alphanumeric + underscore), used to flatten the FPS distribution into session_health.
+export interface FpsBand { label: string; key: string; minFps: number; maxFps: number; }
 export const FPS_BANDS: FpsBand[] = [
-  { label: '>=50',  minFps: 50, maxFps: Infinity },
-  { label: '30-50', minFps: 30, maxFps: 50 },
-  { label: '15-30', minFps: 15, maxFps: 30 },
-  { label: '<15',   minFps: 0,  maxFps: 15 },
+  { label: '>=50',  key: 'fps_ge50',  minFps: 50, maxFps: Infinity },
+  { label: '30-50', key: 'fps_30_50', minFps: 30, maxFps: 50 },
+  { label: '15-30', key: 'fps_15_30', minFps: 15, maxFps: 30 },
+  { label: '<15',   key: 'fps_lt15',  minFps: 0,  maxFps: 15 },
 ];
 
 export interface DiagConfig {
@@ -73,6 +76,10 @@ export interface DiagConfig {
    *  (#209 topped out ~32 at 10 FPS). A frame above this is a runaway regardless of frame
    *  rate, so it is caught even at a steady FPS where the fps-band ratio sees nothing. */
   speedCeiling: number;
+  /** Interval (in-game seconds) between `session_health` baseline heartbeats during a long
+   *  run. A run shorter than this still gets exactly one sample at run-end (reset), so even
+   *  short healthy runs contribute a baseline — the comparison set for `physics_anomaly`. */
+  healthSampleSec: number;
 }
 
 export const DEFAULT_CONFIG: DiagConfig = {
@@ -80,6 +87,7 @@ export const DEFAULT_CONFIG: DiagConfig = {
   collisionRadius: 2.5,
   speedExpected: 8,
   speedCeiling: 50,
+  healthSampleSec: 30,
 };
 
 /** A structured event sink (e.g. Firebase Analytics logEvent). Injected via init() so
@@ -277,6 +285,7 @@ class Diagnostics {
   private clockSec = 0; // accumulated in-game seconds (dt sum); avoids Date.now in tests
   private sink: DiagSink = () => {}; // structured-event transport (Firebase Analytics)
   private reportedAnomaly = false;   // physics anomaly reported once per run (debounce)
+  private lastHealthEmitSec = 0;     // clock of the last session_health emit (heartbeat dedup)
   private errorHandlersInstalled = false;
   private notes: Array<{ atSec: number; category: string; detail: Record<string, unknown> }> = [];
 
@@ -338,7 +347,31 @@ class Diagnostics {
     if (!flags.nonFinite) this.prev = { x: s.x, z: s.z };
     this.maybeWarn(flags);
     this.maybeReport();
+    this.maybeHeartbeat();
     this.maybePaint();
+  }
+
+  /** Structured run summary shared by `physics_anomaly` and `session_health`. Flattens the
+   *  FPS-band distribution (frames per band) so a healthy baseline and an anomaly are the
+   *  SAME shape and directly comparable in analytics. */
+  private healthPayload(): Record<string, unknown> {
+    const sm = this.summary;
+    const payload: Record<string, unknown> = {
+      level: frameRateHealth(sm, this.cfg).level,
+      frames: sm.frames,
+      durationSec: +sm.durationSec.toFixed(1),
+      fps: sm.durationSec > 0 ? Math.round(sm.frames / sm.durationSec) : 0,
+      dtMaxMs: Math.round(sm.dtMaxSec * 1000),
+      clampedFrames: sm.clampedFrames,
+      speedMax: +sm.speedMax.toFixed(1),
+      stepMax: +sm.stepMax.toFixed(2),
+      tunnelFrames: sm.tunnelRiskFrames,
+      runawayFrames: sm.runawayFrames,
+      nonFiniteFrames: sm.nonFiniteFrames,
+      fpsSpeedRatio: +fpsSpeedRatio(sm).toFixed(2),
+    };
+    sm.bands.forEach((b, i) => { payload[`${FPS_BANDS[i].key}_frames`] = b.frames; });
+    return payload;
   }
 
   /** Report a physics anomaly to the sink at most ONCE per run (debounced) — the moment
@@ -350,19 +383,23 @@ class Diagnostics {
     const health = frameRateHealth(this.summary, this.cfg);
     if (health.level !== 'bad') return;
     this.reportedAnomaly = true;
-    const sm = this.summary;
-    this.emit('physics_anomaly', {
-      reasons: health.reasons.join(' | '),
-      frames: sm.frames,
-      fps: sm.durationSec > 0 ? Math.round(sm.frames / sm.durationSec) : 0,
-      dtMaxMs: Math.round(sm.dtMaxSec * 1000),
-      speedMax: +sm.speedMax.toFixed(1),
-      stepMax: +sm.stepMax.toFixed(2),
-      tunnelFrames: sm.tunnelRiskFrames,
-      runawayFrames: sm.runawayFrames,
-      nonFiniteFrames: sm.nonFiniteFrames,
-      fpsSpeedRatio: +fpsSpeedRatio(sm).toFixed(2),
-    });
+    this.emit('physics_anomaly', { reasons: health.reasons.join(' | '), ...this.healthPayload() });
+  }
+
+  /** Emit a `session_health` baseline sample and stamp the heartbeat clock. Fired
+   *  periodically through a long run and once at run-end (reset), so HEALTHY runs — not
+   *  just anomalies — contribute the FPS-distribution baseline that gives a BAD verdict
+   *  context. Carries the same shape as `physics_anomaly` (minus `reasons`). */
+  private emitHealthSample(): void {
+    this.lastHealthEmitSec = this.clockSec;
+    this.emit('session_health', this.healthPayload());
+  }
+
+  /** Periodic heartbeat during a long run (run-end sampling is handled in reset()). */
+  private maybeHeartbeat(): void {
+    if (this.summary.frames < MIN_SAMPLE_FRAMES) return;
+    if (this.clockSec - this.lastHealthEmitSec < this.cfg.healthSampleSec) return;
+    this.emitHealthSample();
   }
 
   /** Generic anomaly seam for OTHER subsystems (asset loaders, avalanche, camera, …) to
@@ -499,6 +536,14 @@ class Diagnostics {
   }
 
   reset(): void {
+    // Run-end baseline sample: capture the just-completed run before clearing, so even a
+    // short healthy run (too brief for a heartbeat) contributes one session_health. Skipped
+    // for a trivial/empty reset (e.g. the reset at init) and de-duped against a heartbeat
+    // that just fired this run.
+    if (this.active && this.summary.frames >= MIN_SAMPLE_FRAMES &&
+        this.clockSec - this.lastHealthEmitSec >= 1) {
+      this.emitHealthSample();
+    }
     this.ring = [];
     this.head = 0;
     this.summary = emptySummary();
@@ -506,6 +551,7 @@ class Diagnostics {
     this.lastWarn = {};
     this.clockSec = 0;
     this.reportedAnomaly = false; // a fresh run can report its own anomaly
+    this.lastHealthEmitSec = 0;
     this.notes = [];
   }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -69,13 +69,23 @@ export interface DiagConfig {
   /** Rough expected 60 Hz cruising/terminal speed (~8 m/s). Only used to flag a frame
    *  as "fast" for the overlay; the fps-band correlation is what actually detects the bug. */
   speedExpected: number;
+  /** Absolute speed ceiling (m/s) no legitimate descent should ever exceed, even buggy
+   *  (#209 topped out ~32 at 10 FPS). A frame above this is a runaway regardless of frame
+   *  rate, so it is caught even at a steady FPS where the fps-band ratio sees nothing. */
+  speedCeiling: number;
 }
 
 export const DEFAULT_CONFIG: DiagConfig = {
   frameCapSec: 0.1,
   collisionRadius: 2.5,
   speedExpected: 8,
+  speedCeiling: 50,
 };
+
+/** A structured event sink (e.g. Firebase Analytics logEvent). Injected via init() so
+ *  diagnostics.ts stays decoupled from Firebase and unit-tests with a stub. Called at
+ *  most once per run for a physics anomaly, and per uncaught error/rejection. */
+export type DiagSink = (event: string, data: Record<string, unknown>) => void;
 
 /** One frame's physics observables, as read from the kernel result + position. */
 export interface FrameSample {
@@ -94,6 +104,7 @@ export interface FrameFlags {
   clamped: boolean;    // dt pinned at the loop cap → device below 1/cap FPS
   tunnelRisk: boolean; // step >= collisionRadius → discrete check could miss a disk
   nonFinite: boolean;  // any of dt/speed/x/z not finite
+  runaway: boolean;    // speed past the absolute ceiling — impossible-for-legit-play fast
   fast: boolean;       // speed well above the expected 60 Hz terminal speed
 }
 
@@ -115,6 +126,7 @@ export interface DiagSummary {
   speedMax: number;
   tunnelRiskFrames: number;
   nonFiniteFrames: number;
+  runawayFrames: number;
   bands: BandStat[];
 }
 
@@ -148,6 +160,7 @@ export function classifyFrame(prev: { x: number; z: number } | null, s: FrameSam
     clamped: finite && s.dt >= cfg.frameCapSec - 1e-9,
     tunnelRisk: step >= cfg.collisionRadius,
     nonFinite: !finite,
+    runaway: finite && s.speed > cfg.speedCeiling,
     fast: finite && s.speed > cfg.speedExpected * 1.5,
   };
 }
@@ -156,7 +169,7 @@ export function classifyFrame(prev: { x: number; z: number } | null, s: FrameSam
 export function emptySummary(): DiagSummary {
   return {
     frames: 0, durationSec: 0, dtMaxSec: 0, clampedFrames: 0,
-    stepMax: 0, speedMax: 0, tunnelRiskFrames: 0, nonFiniteFrames: 0,
+    stepMax: 0, speedMax: 0, tunnelRiskFrames: 0, nonFiniteFrames: 0, runawayFrames: 0,
     bands: FPS_BANDS.map((b) => ({ label: b.label, frames: 0, speedMax: 0, speedSum: 0 })),
   };
 }
@@ -172,6 +185,7 @@ export function foldFrame(agg: DiagSummary, s: FrameSample, flags: FrameFlags): 
   }
   if (flags.clamped) agg.clampedFrames += 1;
   if (flags.tunnelRisk) agg.tunnelRiskFrames += 1;
+  if (flags.runaway) agg.runawayFrames += 1;
   if (flags.nonFinite) { agg.nonFiniteFrames += 1; return agg; } // don't pollute speed stats
   if (flags.step > agg.stepMax) agg.stepMax = flags.step;
   if (s.speed > agg.speedMax) agg.speedMax = s.speed;
@@ -227,6 +241,10 @@ export function frameRateHealth(summary: DiagSummary, cfg: DiagConfig): HealthVe
     reasons.push(`${summary.tunnelRiskFrames} frame(s) stepped >= ${cfg.collisionRadius}u (an obstacle radius) — collision tunnel risk`);
     bump('bad');
   }
+  if (summary.runawayFrames > 0) {
+    reasons.push(`${summary.runawayFrames} frame(s) above the ${cfg.speedCeiling} m/s speed ceiling — runaway speed (frame-rate independent)`);
+    bump('bad');
+  }
   const ratio = fpsSpeedRatio(summary);
   if (ratio >= 1.6) {
     reasons.push(`speed ${ratio.toFixed(1)}x higher in low-FPS frames than high-FPS — frame-rate-dependent force (the #209 class)`);
@@ -257,12 +275,18 @@ class Diagnostics {
   private overlay: HTMLElement | null = null;
   private lastOverlayPaint = 0;
   private clockSec = 0; // accumulated in-game seconds (dt sum); avoids Date.now in tests
+  private sink: DiagSink = () => {}; // structured-event transport (Firebase Analytics)
+  private reportedAnomaly = false;   // physics anomaly reported once per run (debounce)
+  private errorHandlersInstalled = false;
+  private notes: Array<{ atSec: number; category: string; detail: Record<string, unknown> }> = [];
 
   /** Wire up the recorder. Safe to call once at startup. Honors the automation gate and
-   *  the ?debug overlay flag; without a DOM it just enables the headless recorder. */
-  init(cfg?: Partial<DiagConfig>): void {
+   *  the ?debug overlay flag; without a DOM it just enables the headless recorder.
+   *  `opts.report` injects the structured-event transport (e.g. Firebase Analytics). */
+  init(cfg?: Partial<DiagConfig>, opts?: { report?: DiagSink }): void {
     if (!DIAG_ENABLED) return;
     this.cfg = { ...DEFAULT_CONFIG, ...(cfg || {}) };
+    if (opts && opts.report) this.sink = opts.report;
     if (typeof window === 'undefined') { this.active = true; return; }
 
     const automated = !!window.isTestMode ||
@@ -272,6 +296,11 @@ class Diagnostics {
     // automated suites stay byte-identical unless a test opts in (matches debris/sfx).
     this.active = !automated || optedIn;
     if (!this.active) return;
+
+    // Global error capture: there is no other window.onerror / unhandledrejection in the
+    // app, so an uncaught throw in the rAF loop (a real "freezes" candidate) otherwise
+    // vanishes. Route it through the same sink with the recent physics trace as context.
+    this.installErrorHandlers();
 
     const search = (window.location && window.location.search) || '';
     const wantOverlay = /[?&]debug(=|&|$)/.test(search) || /[?&]debug=(physics|all)/.test(search);
@@ -308,13 +337,94 @@ class Diagnostics {
 
     if (!flags.nonFinite) this.prev = { x: s.x, z: s.z };
     this.maybeWarn(flags);
+    this.maybeReport();
     this.maybePaint();
+  }
+
+  /** Report a physics anomaly to the sink at most ONCE per run (debounced) — the moment
+   *  the run's health verdict first reaches BAD. Aggregated across real devices this is
+   *  how the #209 class would surface in the wild: low-FPS sessions correlating with
+   *  runaway speed / tunnel events, instead of an unreproducible "I drove through a tree". */
+  private maybeReport(): void {
+    if (this.reportedAnomaly) return;
+    const health = frameRateHealth(this.summary, this.cfg);
+    if (health.level !== 'bad') return;
+    this.reportedAnomaly = true;
+    const sm = this.summary;
+    this.emit('physics_anomaly', {
+      reasons: health.reasons.join(' | '),
+      frames: sm.frames,
+      fps: sm.durationSec > 0 ? Math.round(sm.frames / sm.durationSec) : 0,
+      dtMaxMs: Math.round(sm.dtMaxSec * 1000),
+      speedMax: +sm.speedMax.toFixed(1),
+      stepMax: +sm.stepMax.toFixed(2),
+      tunnelFrames: sm.tunnelRiskFrames,
+      runawayFrames: sm.runawayFrames,
+      nonFiniteFrames: sm.nonFiniteFrames,
+      fpsSpeedRatio: +fpsSpeedRatio(sm).toFixed(2),
+    });
+  }
+
+  /** Generic anomaly seam for OTHER subsystems (asset loaders, avalanche, camera, …) to
+   *  report into the same pipeline — so diagnostics is not limited to the physics kernel.
+   *  e.g. Diag.note('asset_load_failed', { url }). Routed to the sink + console + the dump,
+   *  and a no-op when the recorder is inactive (automation). */
+  note(category: string, detail: Record<string, unknown> = {}): void {
+    if (!DIAG_ENABLED || !this.active) return;
+    this.notes.push({ atSec: +this.clockSec.toFixed(2), category, detail });
+    if (this.notes.length > 50) this.notes.shift();
+    this.warn(`note:${category}`, `[diag] ${category} ${JSON.stringify(detail)}`);
+    this.emit('diag_note', { category, ...detail });
+  }
+
+  /** Forward to the injected sink, swallowing any sink error (telemetry must never throw
+   *  into the game loop). */
+  private emit(event: string, data: Record<string, unknown>): void {
+    try { this.sink(event, data); } catch { /* a broken sink must not break the game */ }
+  }
+
+  /** Install window.onerror + unhandledrejection once. Captures the message/stack plus the
+   *  current physics snapshot summary as context, routes it to the sink + console.error.
+   *  Re-throws nothing; never swallows the browser's own default logging. */
+  private installErrorHandlers(): void {
+    if (this.errorHandlersInstalled || typeof window === 'undefined') return;
+    this.errorHandlersInstalled = true;
+    const context = () => {
+      const sm = this.summary;
+      return {
+        frames: sm.frames,
+        fps: sm.durationSec > 0 ? Math.round(sm.frames / sm.durationSec) : 0,
+        speedMax: +sm.speedMax.toFixed(1),
+        health: frameRateHealth(sm, this.cfg).level,
+      };
+    };
+    window.addEventListener('error', (e: ErrorEvent) => {
+      this.emit('client_error', {
+        message: String(e.message || 'error'),
+        source: e.filename || '',
+        line: e.lineno || 0,
+        stack: (e.error && e.error.stack ? String(e.error.stack) : '').slice(0, 600),
+        ...context(),
+      });
+    });
+    window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
+      const reason = e.reason;
+      const msg = reason && reason.message ? reason.message : String(reason);
+      this.emit('unhandled_rejection', {
+        message: String(msg).slice(0, 300),
+        stack: (reason && reason.stack ? String(reason.stack) : '').slice(0, 600),
+        ...context(),
+      });
+    });
   }
 
   /** Throttled console warnings on the anomaly categories, so a live slow-device run
    *  leaves a breadcrumb in the console even if nobody opened the overlay. */
   private maybeWarn(flags: FrameFlags): void {
     if (flags.nonFinite) this.warn('nonFinite', '[diag] non-finite physics state (NaN/Infinity) this frame');
+    if (flags.runaway) {
+      this.warn('runaway', `[diag] speed ${this.summary.speedMax.toFixed(1)} m/s past the ${this.cfg.speedCeiling} m/s ceiling — runaway`);
+    }
     if (flags.tunnelRisk) {
       this.warn('tunnel', `[diag] per-frame step ${flags.step.toFixed(2)}u >= collision radius ${this.cfg.collisionRadius}u at ${flags.fps.toFixed(0)} FPS — possible tunnel-through`);
     }
@@ -356,10 +466,12 @@ class Diagnostics {
         speedMax: +this.summary.speedMax.toFixed(2),
         tunnelRiskFrames: this.summary.tunnelRiskFrames,
         nonFiniteFrames: this.summary.nonFiniteFrames,
+        runawayFrames: this.summary.runawayFrames,
         fpsSpeedRatio: +fpsSpeedRatio(this.summary).toFixed(2),
         bands,
       },
       health,
+      notes: this.notes.slice(),
       recent: this.orderedRing().slice(-120).map((e) => ({
         dt: +e.dt.toFixed(4), fps: +e.fps.toFixed(0), speed: +e.speed.toFixed(2),
         step: +e.step.toFixed(2), x: +e.x.toFixed(1), z: +e.z.toFixed(1),
@@ -393,6 +505,8 @@ class Diagnostics {
     this.prev = null;
     this.lastWarn = {};
     this.clockSec = 0;
+    this.reportedAnomaly = false; // a fresh run can report its own anomaly
+    this.notes = [];
   }
 
   // --- DOM overlay (live HUD) ---
@@ -443,7 +557,7 @@ class Diagnostics {
       `${icon} SnowGlider physics diag  (\` toggles)`,
       `fps  now=${last ? last.fps.toFixed(0) : '–'}  avg=${fpsAvg.toFixed(0)}  dtMax=${(sm.dtMaxSec * 1000).toFixed(0)}ms  clamp=${sm.clampedFrames}`,
       `spd  now=${last ? last.speed.toFixed(1) : '–'}  max=${sm.speedMax.toFixed(1)}  stepMax=${sm.stepMax.toFixed(2)}/${this.cfg.collisionRadius}`,
-      `risk tunnel=${sm.tunnelRiskFrames}  NaN=${sm.nonFiniteFrames}  fps→spd=${fpsSpeedRatio(sm).toFixed(2)}x`,
+      `risk tunnel=${sm.tunnelRiskFrames}  runaway=${sm.runawayFrames}  NaN=${sm.nonFiniteFrames}  fps→spd=${fpsSpeedRatio(sm).toFixed(2)}x`,
       `speed by fps band:`,
       bandLines || '   (single band)',
       health.level === 'ok' ? '' : health.reasons.map((r) => ` ! ${r}`).join('\n'),

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -48,6 +48,12 @@ const RING_CAPACITY = 1200;     // ~20 s of 60 FPS trace kept for the overlay + 
 const OVERLAY_HZ = 6;           // overlay repaint rate (throttled; cheap)
 const WARN_THROTTLE_SEC = 4;    // min seconds between repeats of the same warning
 const MIN_SAMPLE_FRAMES = 30;   // a run must reach this many frames (~0.5s) to be sampled
+// The fps→speed comparison only counts "settled" frames — at or above cruising speed — so a
+// snowman still accelerating from the spawn (vz0 = -3 m/s) doesn't pollute the band maxima.
+// Without this, a device fast at startup (slow snowman) then slow at cruise reads as
+// frame-rate-dependent purely because speed rose with run progress (codex #211).
+const SETTLE_FRACTION = 0.6;        // settled := speed >= speedExpected * this (~4.8 m/s)
+const MIN_BAND_FRAMES_FOR_RATIO = 10; // a band needs this many settled frames to be comparable
 
 // FPS bands the summary buckets frames into. The whole point of the module: if the
 // max speed in a SLOWER band is materially higher than in a FAST band, a force path is
@@ -113,6 +119,7 @@ export interface FrameFlags {
   tunnelRisk: boolean; // step >= collisionRadius → discrete check could miss a disk
   nonFinite: boolean;  // any of dt/speed/x/z not finite
   runaway: boolean;    // speed past the absolute ceiling — impossible-for-legit-play fast
+  settled: boolean;    // speed >= cruising floor — eligible for the fps-band speed compare
   fast: boolean;       // speed well above the expected 60 Hz terminal speed
 }
 
@@ -120,7 +127,9 @@ export interface BandStat {
   label: string;
   frames: number;
   speedMax: number;
-  speedSum: number; // for the mean; kept raw so the fold stays additive
+  speedSum: number;        // for the mean; kept raw so the fold stays additive
+  settledFrames: number;   // frames at/above the cruising floor (used by the ratio)
+  settledSpeedMax: number; // max speed among settled frames only
 }
 
 /** The incremental running summary. Folded one frame at a time so the recorder never
@@ -169,6 +178,7 @@ export function classifyFrame(prev: { x: number; z: number } | null, s: FrameSam
     tunnelRisk: step >= cfg.collisionRadius,
     nonFinite: !finite,
     runaway: finite && s.speed > cfg.speedCeiling,
+    settled: finite && s.speed >= cfg.speedExpected * SETTLE_FRACTION,
     fast: finite && s.speed > cfg.speedExpected * 1.5,
   };
 }
@@ -178,7 +188,7 @@ export function emptySummary(): DiagSummary {
   return {
     frames: 0, durationSec: 0, dtMaxSec: 0, clampedFrames: 0,
     stepMax: 0, speedMax: 0, tunnelRiskFrames: 0, nonFiniteFrames: 0, runawayFrames: 0,
-    bands: FPS_BANDS.map((b) => ({ label: b.label, frames: 0, speedMax: 0, speedSum: 0 })),
+    bands: FPS_BANDS.map((b) => ({ label: b.label, frames: 0, speedMax: 0, speedSum: 0, settledFrames: 0, settledSpeedMax: 0 })),
   };
 }
 
@@ -205,6 +215,12 @@ export function foldFrame(agg: DiagSummary, s: FrameSample, flags: FrameFlags): 
       bs.frames += 1;
       bs.speedSum += s.speed;
       if (s.speed > bs.speedMax) bs.speedMax = s.speed;
+      // Only settled (cruising-speed) frames feed the fps→speed ratio, so an accelerating
+      // snowman at the start of a run can't masquerade as frame-rate dependence.
+      if (flags.settled) {
+        bs.settledFrames += 1;
+        if (s.speed > bs.settledSpeedMax) bs.settledSpeedMax = s.speed;
+      }
       break;
     }
   }
@@ -216,17 +232,21 @@ export function bandMeanSpeed(b: BandStat): number {
   return b.frames > 0 ? b.speedSum / b.frames : 0;
 }
 
-/** The fps-dependence signal at the heart of this module: the ratio of the max speed
- *  seen in the SLOWEST populated band to the FASTEST populated band. ~1 means speed is
+/** The fps-dependence signal at the heart of this module: the ratio of the max SETTLED
+ *  speed seen in the SLOWEST eligible band to the FASTEST eligible band. ~1 means speed is
  *  frame-rate independent (good); >> 1 means a force path scales with frame time (the
- *  #209 bug). Needs both a fast (>=30 FPS) and a slow (<30 FPS) band populated to mean
- *  anything; returns 1 (no signal) otherwise so it never false-alarms on a steady FPS. */
+ *  #209 bug). Only "settled" (cruising-speed) frames count, and each band needs
+ *  MIN_BAND_FRAMES_FOR_RATIO of them to be eligible, so neither an accelerating start nor a
+ *  handful of fluke frames forms the ratio. Needs both a fast (>=30 FPS) and a slow
+ *  (<30 FPS) band eligible to mean anything; returns 1 (no signal) otherwise so it never
+ *  false-alarms on a steady FPS or an unsettled run. */
 export function fpsSpeedRatio(summary: DiagSummary): number {
-  const fast = summary.bands.filter((b, i) => FPS_BANDS[i].minFps >= 30 && b.frames > 0);
-  const slow = summary.bands.filter((b, i) => FPS_BANDS[i].maxFps <= 30 && b.frames > 0);
+  const eligible = (b: BandStat) => b.settledFrames >= MIN_BAND_FRAMES_FOR_RATIO;
+  const fast = summary.bands.filter((b, i) => FPS_BANDS[i].minFps >= 30 && eligible(b));
+  const slow = summary.bands.filter((b, i) => FPS_BANDS[i].maxFps <= 30 && eligible(b));
   if (fast.length === 0 || slow.length === 0) return 1;
-  const fastMax = Math.max(...fast.map((b) => b.speedMax));
-  const slowMax = Math.max(...slow.map((b) => b.speedMax));
+  const fastMax = Math.max(...fast.map((b) => b.settledSpeedMax));
+  const slowMax = Math.max(...slow.map((b) => b.settledSpeedMax));
   if (fastMax <= 1e-6) return 1;
   return slowMax / fastMax;
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -48,12 +48,18 @@ const RING_CAPACITY = 1200;     // ~20 s of 60 FPS trace kept for the overlay + 
 const OVERLAY_HZ = 6;           // overlay repaint rate (throttled; cheap)
 const WARN_THROTTLE_SEC = 4;    // min seconds between repeats of the same warning
 const MIN_SAMPLE_FRAMES = 30;   // a run must reach this many frames (~0.5s) to be sampled
-// The fps→speed comparison only counts "settled" frames — at or above cruising speed — so a
+// The fps→speed comparison only counts "settled" frames — at genuine cruising speed — so a
 // snowman still accelerating from the spawn (vz0 = -3 m/s) doesn't pollute the band maxima.
-// Without this, a device fast at startup (slow snowman) then slow at cruise reads as
-// frame-rate-dependent purely because speed rose with run progress (codex #211).
-const SETTLE_FRACTION = 0.6;        // settled := speed >= speedExpected * this (~4.8 m/s)
-const MIN_BAND_FRAMES_FOR_RATIO = 10; // a band needs this many settled frames to be comparable
+// The floor is set near the expected terminal speed (not just above the spawn speed): a
+// mid-acceleration ~5 m/s frame is NOT cruising, and comparing its band max against true
+// 8 m/s cruising in another band would read normal run progression as frame-rate
+// dependence (codex). Pair that with a strong BAD threshold so only an egregious,
+// #209-scale low-vs-high-FPS gap emits an anomaly; a modest gap is WARN-only, since it can
+// come from progression/technique rather than a frame-rate-dependent force.
+const SETTLE_FRACTION = 0.85;          // settled := speed >= speedExpected * this (~6.8 m/s)
+const MIN_BAND_FRAMES_FOR_RATIO = 10;  // a band needs this many settled frames to be comparable
+const FPS_RATIO_BAD = 2.0;             // low/high-FPS cruise-speed gap this large => BAD (#209 was ~4x)
+const FPS_RATIO_WARN = 1.5;            // a milder gap => WARN (may be progression/technique, not a bug)
 
 // FPS bands the summary buckets frames into. The whole point of the module: if the
 // max speed in a SLOWER band is materially higher than in a FAST band, a force path is
@@ -235,11 +241,13 @@ export function bandMeanSpeed(b: BandStat): number {
 /** The fps-dependence signal at the heart of this module: the ratio of the max SETTLED
  *  speed seen in the SLOWEST eligible band to the FASTEST eligible band. ~1 means speed is
  *  frame-rate independent (good); >> 1 means a force path scales with frame time (the
- *  #209 bug). Only "settled" (cruising-speed) frames count, and each band needs
- *  MIN_BAND_FRAMES_FOR_RATIO of them to be eligible, so neither an accelerating start nor a
- *  handful of fluke frames forms the ratio. Needs both a fast (>=30 FPS) and a slow
+ *  #209 bug). Only "settled" frames at genuine cruising speed (>= SETTLE_FRACTION of the
+ *  expected terminal speed) count, and each band needs MIN_BAND_FRAMES_FOR_RATIO of them to
+ *  be eligible — so neither an accelerating start, a mid-acceleration sub-cruise frame, nor
+ *  a handful of fluke frames forms the ratio. Needs both a fast (>=30 FPS) and a slow
  *  (<30 FPS) band eligible to mean anything; returns 1 (no signal) otherwise so it never
- *  false-alarms on a steady FPS or an unsettled run. */
+ *  false-alarms on a steady FPS or an unsettled run. A modest ratio is only WARN; BAD
+ *  requires the egregious, #209-scale gap (see FPS_RATIO_BAD in frameRateHealth). */
 export function fpsSpeedRatio(summary: DiagSummary): number {
   const eligible = (b: BandStat) => b.settledFrames >= MIN_BAND_FRAMES_FOR_RATIO;
   const fast = summary.bands.filter((b, i) => FPS_BANDS[i].minFps >= 30 && eligible(b));
@@ -274,11 +282,11 @@ export function frameRateHealth(summary: DiagSummary, cfg: DiagConfig): HealthVe
     bump('bad');
   }
   const ratio = fpsSpeedRatio(summary);
-  if (ratio >= 1.6) {
-    reasons.push(`speed ${ratio.toFixed(1)}x higher in low-FPS frames than high-FPS — frame-rate-dependent force (the #209 class)`);
+  if (ratio >= FPS_RATIO_BAD) {
+    reasons.push(`cruise speed ${ratio.toFixed(1)}x higher in low-FPS frames than high-FPS — frame-rate-dependent force (the #209 class)`);
     bump('bad');
-  } else if (ratio >= 1.25) {
-    reasons.push(`speed ${ratio.toFixed(1)}x higher at low FPS — possible frame-rate dependence`);
+  } else if (ratio >= FPS_RATIO_WARN) {
+    reasons.push(`cruise speed ${ratio.toFixed(1)}x higher at low FPS — possible frame-rate dependence (or normal run progression)`);
     bump('warn');
   }
   const clampedPct = summary.frames > 0 ? summary.clampedFrames / summary.frames : 0;
@@ -486,8 +494,8 @@ class Diagnostics {
       this.warn('tunnel', `[diag] per-frame step ${flags.step.toFixed(2)}u >= collision radius ${this.cfg.collisionRadius}u at ${flags.fps.toFixed(0)} FPS — possible tunnel-through`);
     }
     const ratio = fpsSpeedRatio(this.summary);
-    if (ratio >= 1.6) {
-      this.warn('fpsSpeed', `[diag] terminal speed ${ratio.toFixed(1)}x higher at low FPS than high FPS — frame-rate-dependent force (see __snowgliderDiag.dump())`);
+    if (ratio >= FPS_RATIO_BAD) {
+      this.warn('fpsSpeed', `[diag] cruise speed ${ratio.toFixed(1)}x higher at low FPS than high FPS — frame-rate-dependent force (see __snowgliderDiag.dump())`);
     }
   }
 

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -9,6 +9,7 @@ import { Snow } from '../snow.js';
 import { Flex } from '../snowman-flex.js';
 import { AudioModule } from '../audio.js';
 import { Sfx } from '../sfx.js';
+import { Diag } from '../diagnostics.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
@@ -51,6 +52,12 @@ export function createLifecycle(deps: LifecycleDeps) {
 
     // Reset keyboard controls
     Controls.resetControls();
+
+    // Reset the physics/frame-rate telemetry: resetPlayer() above teleported the player
+    // back to spawn (z=-15), so without this the first frame of the new run would read as
+    // a huge prev->cur step (old finish position -> spawn) and be falsely flagged as a
+    // collision tunnel-through, permanently marking the run BAD. A no-op under automation.
+    Diag.reset();
 
     state.startTime = performance.now(); // Reset the timer when starting a new run
     updateTimerDisplay(state.gameActive, state.startTime);

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -12,6 +12,7 @@ import { Snowman } from '../snowman.js';
 import { Flex } from '../snowman-flex.js';
 import { CourseModule } from '../course.js';
 import { Sfx } from '../sfx.js';
+import { Diag } from '../diagnostics.js';
 import { EffectsModule, type ShakeOffset } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
 import { updateStatsHud, updateTimerDisplay } from '../ui/hud.js';
@@ -107,6 +108,20 @@ export function createMainLoop(deps: MainLoopDeps) {
     if (result.justLanded) Sfx.land(result.landingForce);
     prevInAir = result.isInAir;
     Sfx.updateSkiing(result.currentSpeed, result.technique, result.isInAir);
+
+    // Frame-rate / physics telemetry (diagnostics.ts). READ-ONLY observer, wired in
+    // beside Sfx/Flex: it reads the per-frame result + pos only and never touches
+    // pos/velocity, so the physics-invariant harness is unaffected and it is a no-op
+    // under automation. It watches the dt the real device produces and the speed/step
+    // that ride on it, surfacing the frame-rate-dependence bug class (#209) live.
+    Diag.record({
+      dt: delta,
+      speed: result.currentSpeed,
+      x: pos.x,
+      z: pos.z,
+      technique: result.technique,
+      isInAir: player.isInAir,
+    });
 
     // Update timer in the updateTimerDisplay function which is called separately
   }

--- a/src/mountains/index.ts
+++ b/src/mountains/index.ts
@@ -45,7 +45,7 @@ import {
 // directly, and scene-setup.ts imports the RockPosition type from '../mountains.js'.
 // rockCollisionRadius was a named export of the pre-split mountains.ts too — keep it
 // on the facade so `import { rockCollisionRadius } from './mountains.js'` still works.
-export { terrainRidgeField, forestDensityField, rockCollisionRadius };
+export { terrainRidgeField, forestDensityField, rockCollisionRadius, ROCK_COLLISION_MIN_SIZE };
 export type { TerrainVec2, RockPosition };
 
 // Export all mountain-related functions and classes

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -165,7 +165,29 @@ window.addEventListener('resize', handleResize);
 // suites stay byte-identical); add ?debug to play with the live overlay, or call
 // window.__snowgliderDiag.dump() to export a JSON trace for a bug report. The collision
 // radius mirrors collision.ts's tree default and the cap mirrors the loop's delta clamp.
-Diag.init({ frameCapSec: 0.1, collisionRadius: window.treeCollisionRadius || 2.5 });
+//
+// The `report` sink routes Diag's once-per-run BAD verdict + any uncaught error/rejection
+// into the EXISTING Firebase Analytics pipeline (window.firebaseModules.logEvent, the same
+// seam game_start/game_over/game_reset already use). Aggregated across real devices this is
+// how the #209 class would surface in the wild — low-FPS sessions correlating with runaway
+// speed / tunnel events — rather than as an unreproducible field report. Guarded exactly
+// like the other logEvent call sites (modular SDK present, not file://) and wrapped so a
+// telemetry failure can never throw into the game loop.
+Diag.init(
+  { frameCapSec: 0.1, collisionRadius: window.treeCollisionRadius || 2.5 },
+  {
+    report: (event, data) => {
+      try {
+        if (window.firebaseModules && typeof window.firebaseModules.logEvent === 'function' &&
+            window.location.protocol !== 'file:') {
+          window.firebaseModules.logEvent(event, data);
+        }
+      } catch (e) {
+        console.log('Diag analytics skipped:', (e as Error).message);
+      }
+    },
+  }
+);
 
 // --- Run lifecycle (see game/lifecycle.ts): reset / restart / camera toggle ---
 // Built after the loop (restartGame uses startLoop). Re-publish the three hooks the

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -30,6 +30,7 @@ import * as THREE from 'three';
 import { Controls } from './controls.js';
 import { Snow } from './snow.js';
 import { Snowman } from './snowman.js';
+import { rockCollisionRadius, ROCK_COLLISION_MIN_SIZE } from './mountains.js';
 import { AudioModule } from './audio.js';
 import { Sfx } from './sfx.js';
 import { Diag } from './diagnostics.js';
@@ -164,7 +165,11 @@ window.addEventListener('resize', handleResize);
 // of only in the offline stress harnesses. Off under automation by default (so the test
 // suites stay byte-identical); add ?debug to play with the live overlay, or call
 // window.__snowgliderDiag.dump() to export a JSON trace for a bug report. The collision
-// radius mirrors collision.ts's tree default and the cap mirrors the loop's delta clamp.
+// radius is the SMALLEST collidable obstacle radius the discrete point-vs-disk check
+// guards — the min of the tree radius (collision.ts default 2.5u) and the smallest
+// collidable rock radius (rockCollisionRadius(ROCK_COLLISION_MIN_SIZE) ≈ 1.69u). Using the
+// tree radius alone would under-detect: a ~2u per-frame step can skip a small rock's disk
+// while still reading as "no tunnel risk". The cap mirrors the loop's delta clamp.
 //
 // The `report` sink routes Diag's once-per-run BAD verdict + any uncaught error/rejection
 // into the EXISTING Firebase Analytics pipeline (window.firebaseModules.logEvent, the same
@@ -174,7 +179,13 @@ window.addEventListener('resize', handleResize);
 // like the other logEvent call sites (modular SDK present, not file://) and wrapped so a
 // telemetry failure can never throw into the game loop.
 Diag.init(
-  { frameCapSec: 0.1, collisionRadius: window.treeCollisionRadius || 2.5 },
+  {
+    frameCapSec: 0.1,
+    collisionRadius: Math.min(
+      window.treeCollisionRadius || 2.5,
+      rockCollisionRadius(ROCK_COLLISION_MIN_SIZE),
+    ),
+  },
   {
     report: (event, data) => {
       try {

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -32,6 +32,7 @@ import { Snow } from './snow.js';
 import { Snowman } from './snowman.js';
 import { AudioModule } from './audio.js';
 import { Sfx } from './sfx.js';
+import { Diag } from './diagnostics.js';
 import { Physics } from './player-state.js';
 import { IntroModule, prefersReducedMotion } from './intro.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
@@ -154,6 +155,17 @@ const { updateSnowman, updateCamera, startLoop, handleResize } = createMainLoop(
   showGameOver,
 });
 window.addEventListener('resize', handleResize);
+
+// --- Physics / frame-rate diagnostics (see src/diagnostics.ts) ---
+// A read-only telemetry observer the main loop feeds each frame (beside Sfx/Flex). It
+// watches the dt the real device produces and the speed/step that ride on it, surfacing
+// the frame-rate-dependence bug class fixed in PR #209 — runaway low-FPS speed, per-frame
+// steps that exceed an obstacle's collision radius (tunnel risk), and NaN — live instead
+// of only in the offline stress harnesses. Off under automation by default (so the test
+// suites stay byte-identical); add ?debug to play with the live overlay, or call
+// window.__snowgliderDiag.dump() to export a JSON trace for a bug report. The collision
+// radius mirrors collision.ts's tree default and the cap mirrors the loop's delta clamp.
+Diag.init({ frameCapSec: 0.1, collisionRadius: window.treeCollisionRadius || 2.5 });
 
 // --- Run lifecycle (see game/lifecycle.ts): reset / restart / camera toggle ---
 // Built after the loop (restartGame uses startLoop). Re-publish the three hooks the

--- a/src/ui/result-overlay.ts
+++ b/src/ui/result-overlay.ts
@@ -6,6 +6,7 @@
 
 import { AudioModule } from '../audio.js';
 import { Sfx } from '../sfx.js';
+import { Diag } from '../diagnostics.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
 
@@ -96,6 +97,13 @@ export function createShowGameOver(deps: ResultOverlayDeps): (reason: string) =>
       return;
     }
     state.gameActive = false;
+
+    // Flush the run's diagnostics baseline now that the run has ended. The main loop stops
+    // recording once gameActive is false, and a player who finishes/crashes and then leaves
+    // never presses Reset/Restart (which is the other path that flushes), so without this a
+    // one-and-done session would contribute no session_health sample. De-duped against the
+    // eventual reset()/pagehide flush; a no-op under automation.
+    try { Diag.endRun(); } catch { /* telemetry must never block the overlay */ }
 
     // Fire the crash-shatter wipeout on a crash (any non-finish reason): tree/rock
     // hit, off-mountain, fell-off, or avalanche burial. The finish is never a crash.

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -95,6 +95,18 @@ async function main() {
   check('storageBucket is left untouched (dead rewrite removed)',
     config.storageBucket === 'sn0wglider.firebasestorage.app');
 
+  // PR #211: with Analytics up, initializeAuth publishes window.firebaseModules.logEvent on
+  // the main page (previously only auth.html did), so the game's logEvent callers AND the
+  // diagnostics telemetry sink actually deliver instead of silently no-oping. Verify the
+  // seam exists and routes to the real Analytics logEvent.
+  check('window.firebaseModules.logEvent is published once Analytics is up',
+    !!global.window.firebaseModules && typeof global.window.firebaseModules.logEvent === 'function');
+  const logsBefore = calls.logEvent.length;
+  global.window.firebaseModules.logEvent('physics_anomaly', { runawayFrames: 1 });
+  check('window.firebaseModules.logEvent routes to the real Analytics instance',
+    calls.logEvent.length === logsBefore + 1 &&
+    calls.logEvent[calls.logEvent.length - 1].name === 'physics_anomaly');
+
   // PR #111: auth.ts broadcasts snowglider:auth-changed on login/logout so the
   // start-screen onboarding UI can refresh without hooking the internal listener.
   let authChangedEvents = 0;

--- a/tests/diagnostics-dom-tests.js
+++ b/tests/diagnostics-dom-tests.js
@@ -1,0 +1,110 @@
+// diagnostics-dom-tests.js — jsdom coverage for the BROWSER-only paths of diagnostics.ts
+// that the headless diagnostics-tests.js cannot reach: the init() browser branch, the dev
+// overlay (create / paint / toggle / hide), the window.__snowgliderDiag bug-report API,
+// dump()'s Blob download, and the global error / unhandledrejection capture.
+//
+//   node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-dom-tests.js
+//
+// Mirrors tests/verification/dom_smoke_test.js: stand up a jsdom window/document, then
+// import the REAL module and drive its DOM code directly (no browser, no WebGL).
+const { JSDOM } = require('jsdom');
+
+// ?debug in the URL so init() opens the overlay; jsdom's navigator.webdriver is false and
+// isTestMode is unset, so the recorder treats this as normal play and stays active.
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/?debug', pretendToBeVisual: true,
+});
+const { window } = dom;
+global.window = window;
+global.document = window.document;
+global.navigator = window.navigator;
+// Blob download seam: jsdom has no URL.createObjectURL; stub it so dump()'s browser branch
+// executes end-to-end, and silence the anchor's real navigation on click().
+global.Blob = global.Blob || window.Blob;
+window.URL.createObjectURL = () => 'blob:diag';
+window.URL.revokeObjectURL = () => {};
+global.URL = window.URL;
+const origCreate = window.document.createElement.bind(window.document);
+window.document.createElement = function (tag) {
+  const el = origCreate(tag);
+  if (tag === 'a') el.click = () => {}; // avoid jsdom "navigation not implemented"
+  return el;
+};
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+
+async function main() {
+  const D = await import('../src/diagnostics.js');
+  const events = [];
+  D.Diag.init({ ...D.DEFAULT_CONFIG, healthSampleSec: 1 }, { report: (event, data) => events.push({ event, data }) });
+
+  // --- init() browser branch + overlay creation (?debug) ----------------------
+  check('init: ?debug creates the dev overlay', !!document.getElementById('diagOverlay'));
+  check('init: exposes window.__snowgliderDiag bug-report API',
+    !!window.__snowgliderDiag && typeof window.__snowgliderDiag.dump === 'function');
+
+  // --- drive frames so the overlay paints, across MULTIPLE fps bands ----------
+  // Mixed dt populates several FPS bands (>=50, 15-30, <15) so the band table + the
+  // paint loop's branches are exercised; a late runaway flips health so paint renders
+  // the reasons block too.
+  let z = -15;
+  const rec = (dt, speed) => { z -= speed * dt; D.Diag.record({ dt, speed, x: 0, z, technique: 'tuck', isInAir: false }); };
+  for (let i = 0; i < 40; i++) rec(1 / 60, 8);   // >=50 band, healthy
+  for (let i = 0; i < 20; i++) rec(1 / 20, 9);   // 15-30 band
+  for (let i = 0; i < 20; i++) rec(0.1, 12);     // <15 band (clamped)
+  check('overlay: repaints while recording (overlay still present)', !!document.getElementById('diagOverlay'));
+  const painted = document.getElementById('diagOverlay').textContent;
+  check('overlay: shows the fps / speed HUD text', /fps/.test(painted) && /spd/.test(painted));
+  check('overlay: renders the speed-by-fps-band table', /by fps band/.test(painted));
+
+  // Push it BAD so the paint reasons block + warn paths run.
+  for (let i = 0; i < 10; i++) rec(1 / 60, 80); // runaway -> BAD
+  check('overlay: a healthy heartbeat was emitted while playing',
+    events.some((e) => e.event === 'session_health'));
+  check('report: a runaway run emitted physics_anomaly', events.some((e) => e.event === 'physics_anomaly'));
+
+  // --- window API: snapshot / dump (Blob branch) / overlay toggle / reset -----
+  const snap = window.__snowgliderDiag.snapshot();
+  check('api: snapshot() returns a health verdict', !!snap && !!snap.health);
+  const dumped = window.__snowgliderDiag.dump(); // exercises the Blob/createObjectURL/anchor path
+  check('api: dump() returns the same structured snapshot', !!dumped && !!dumped.summary);
+
+  window.__snowgliderDiag.overlay(false);
+  check('api: overlay(false) hides the overlay', !document.getElementById('diagOverlay'));
+  window.__snowgliderDiag.overlay(true);
+  check('api: overlay(true) re-creates the overlay', !!document.getElementById('diagOverlay'));
+
+  // --- backtick hotkey toggles the overlay ------------------------------------
+  window.dispatchEvent(new window.KeyboardEvent('keydown', { key: '`' }));
+  check('hotkey: backtick hides the overlay', !document.getElementById('diagOverlay'));
+  window.dispatchEvent(new window.KeyboardEvent('keydown', { key: '`' }));
+  check('hotkey: backtick shows it again', !!document.getElementById('diagOverlay'));
+
+  // --- global error + unhandledrejection capture ------------------------------
+  events.length = 0;
+  const errEvt = new window.Event('error');
+  Object.assign(errEvt, { message: 'kaboom', filename: 'snowglider.ts', lineno: 42, error: new Error('kaboom') });
+  window.dispatchEvent(errEvt);
+  const clientErr = events.find((e) => e.event === 'client_error');
+  check('error: window.onerror is captured and reported', !!clientErr && clientErr.data.message === 'kaboom');
+  check('error: capture attaches physics context (health level)', !!clientErr && typeof clientErr.data.health === 'string');
+
+  const rejEvt = new window.Event('unhandledrejection');
+  Object.assign(rejEvt, { reason: new Error('promise blew up') });
+  window.dispatchEvent(rejEvt);
+  check('error: unhandledrejection is captured and reported',
+    events.some((e) => e.event === 'unhandled_rejection' && /promise blew up/.test(String(e.data.message))));
+
+  // --- init() is idempotent: a second call must not double-install handlers ----
+  D.Diag.init({ ...D.DEFAULT_CONFIG }, { report: (event, data) => events.push({ event, data }) });
+  events.length = 0;
+  window.dispatchEvent(Object.assign(new window.Event('error'), { message: 'once', error: new Error('once') }));
+  check('init: error handlers are installed once (one report per error, not duplicated)',
+    events.filter((e) => e.event === 'client_error').length === 1);
+
+  console.log(`\nDIAGNOSTICS DOM TESTS: ${fail === 0 ? 'OK ✅' : 'FAIL ❌'} (${pass} passed, ${fail} failed)`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/tests/diagnostics-dom-tests.js
+++ b/tests/diagnostics-dom-tests.js
@@ -96,6 +96,18 @@ async function main() {
   check('error: unhandledrejection is captured and reported',
     events.some((e) => e.event === 'unhandled_rejection' && /promise blew up/.test(String(e.data.message))));
 
+  // a rejection whose reason is a bare string (no .message / .stack) is still captured.
+  events.length = 0;
+  window.dispatchEvent(Object.assign(new window.Event('unhandledrejection'), { reason: 'plain string reason' }));
+  check('error: a non-Error rejection reason is still captured',
+    events.some((e) => e.event === 'unhandled_rejection' && /plain string reason/.test(String(e.data.message))));
+
+  // a bare error event (no message / filename / lineno / error) still reports via fallbacks.
+  events.length = 0;
+  window.dispatchEvent(new window.Event('error'));
+  check('error: a bare error event reports with fallbacks (message "error", empty stack)',
+    events.some((e) => e.event === 'client_error' && e.data.message === 'error' && e.data.stack === ''));
+
   // --- init() is idempotent: a second call must not double-install handlers ----
   D.Diag.init({ ...D.DEFAULT_CONFIG }, { report: (event, data) => events.push({ event, data }) });
   events.length = 0;

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -231,6 +231,10 @@ async function main() {
     noteEvents[0].data.category === 'asset_load_failed' && noteEvents[0].data.url === 'music.mp3');
   check('note: appears in the snapshot for the dump',
     D.Diag.snapshot().notes.some((n) => n.category === 'asset_load_failed'));
+  // the note ring is capped (oldest evicted past 50) so a noisy subsystem can't grow it.
+  D.Diag.reset();
+  for (let i = 0; i < 60; i++) D.Diag.note('spam', { i });
+  check('note: ring caps at 50 entries (oldest evicted)', D.Diag.snapshot().notes.length === 50);
 
   // --- sink failures must never throw into the game loop ----------------------
   D.Diag.reset();
@@ -243,6 +247,41 @@ async function main() {
   check('sink: a throwing sink is swallowed (telemetry never breaks the game)', threw === false);
 
   // restore a quiet sink for the remaining recorder checks
+  D.Diag.init(cfg, { report: () => {} });
+
+  // --- live recorder: ring-buffer wraparound (trace longer than the ring) ------
+  // RING_CAPACITY is 1200; record past it so the wraparound WRITE and the ordered-read
+  // (newest-last) both run, and the recent trace stays bounded without losing the summary.
+  D.Diag.reset();
+  for (let i = 0; i < 1300; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i * 0.1, technique: 'tuck', isInAir: false });
+  const bigSnap = D.Diag.snapshot();
+  check('ring buffer wraps: full session counted, recent trace bounded',
+    bigSnap.summary.frames === 1300 && bigSnap.recent.length === 120 &&
+    bigSnap.recent[bigSnap.recent.length - 1].z < bigSnap.recent[0].z); // newest is further downhill
+
+  // --- live recorder: the fps-dependence console breadcrumb fires --------------
+  // A mixed fast/slow run at genuine cruising speed (8 vs 24, both above the floor; 24*0.1 =
+  // 2.4u step stays under the 2.5u radius so this isolates the fps signal from tunneling)
+  // drives fpsSpeedRatio past the BAD threshold during live record().
+  D.Diag.reset();
+  for (let i = 0; i < 30; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+  for (let i = 0; i < 30; i++) D.Diag.record({ dt: 0.1, speed: 24, x: 0, z: -50 - i, technique: 'tuck', isInAir: false });
+  check('live recorder reports fps-dependence (ratio past the BAD threshold)',
+    D.Diag.snapshot().summary.fpsSpeedRatio >= 2 && D.frameRateHealth(
+      // rebuild the summary shape frameRateHealth expects via a fresh fold for the assertion
+      summarize(D, [...descent({ dt: 1 / 60, speed: 8, frames: 30 }), ...descent({ dt: 0.1, speed: 24, frames: 30 })], cfg), cfg
+    ).level === 'bad');
+
+  // --- live recorder: a non-finite frame trips the NaN breadcrumb + trace flag ----
+  D.Diag.reset();
+  for (let i = 0; i < 5; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+  D.Diag.record({ dt: 1 / 60, speed: NaN, x: NaN, z: NaN, technique: 'tuck', isInAir: false });
+  const nanSnap = D.Diag.snapshot();
+  check('live recorder records a non-finite frame and flags it in the trace',
+    nanSnap.summary.nonFiniteFrames === 1 && nanSnap.recent.some((e) => e.flags.includes('NaN')));
+
+  // restore a quiet, freshly-reset recorder for the remaining checks
+  D.Diag.reset();
   D.Diag.init(cfg, { report: () => {} });
 
   // --- the live recorder is inert + safe in Node (no DOM) ---------------------

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -60,6 +60,23 @@ async function main() {
   const bad = D.classifyFrame({ x: 0, z: 0 }, { dt: 1 / 60, speed: NaN, x: 0, z: 0, technique: 'tuck', isInAir: false }, cfg);
   check('classify: non-finite speed flagged', bad.nonFinite === true);
 
+  // regression (codex #211): the tunnel check must honor the SMALLEST collidable obstacle
+  // radius. collision.ts guards trees (2.5u) AND rocks (rockCollisionRadius(size)); the
+  // smallest collidable rock is ~1.69u (rockCollisionRadius(ROCK_COLLISION_MIN_SIZE)), so the
+  // orchestrator wires Diag with min(treeRadius, smallest-rock-radius). A ~2u per-frame step
+  // sits between those: it can skip a small rock's disk yet reads as "no tunnel risk" against
+  // the tree-only 2.5u radius. Prove classifyFrame uses the configured radius so the smaller
+  // one catches it. (rockCollisionRadius's value is unit-tested in terrain-tests.js.)
+  const { rockCollisionRadius, ROCK_COLLISION_MIN_SIZE } = await import('../src/mountains.js');
+  const minObstacleRadius = Math.min(2.5, rockCollisionRadius(ROCK_COLLISION_MIN_SIZE));
+  check('tunnel radius: the smallest collidable rock radius is below the 2.5u tree radius',
+    minObstacleRadius < 2.5 && approx(minObstacleRadius, 1.6875));
+  const midStep = { dt: 0.1, speed: 20, x: 0, z: -2.0, technique: 'tuck', isInAir: false }; // 2.0u step
+  check('tunnel radius: a 2.0u step is NOT a tunnel risk at the 2.5u tree radius',
+    D.classifyFrame({ x: 0, z: 0 }, midStep, cfg).tunnelRisk === false);
+  check('tunnel radius: the same 2.0u step IS a tunnel risk at the ~1.69u smallest-rock radius',
+    D.classifyFrame({ x: 0, z: 0 }, midStep, { ...cfg, collisionRadius: minObstacleRadius }).tunnelRisk === true);
+
   // --- fpsSpeedRatio: the core frame-rate-dependence detector ------------------
   // No signal without both a fast and a slow band populated (a steady-FPS run).
   const steady60 = summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 200 }), cfg);
@@ -221,6 +238,29 @@ async function main() {
   events.length = 0;
   D.Diag.reset();
   check('session_health: an empty reset emits nothing', events.length === 0);
+
+  // (d) regression (codex #211): a run that ENDS via game-over/finish (showGameOver) but is
+  // then abandoned — the player never presses Reset/Restart, so reset() never runs — still
+  // contributes its baseline via endRun(), and a later reset()/pagehide must NOT double-emit
+  // (de-duped on the clock, which doesn't advance after the run stops).
+  events.length = 0;
+  D.Diag.reset();
+  D.Diag.init({ ...cfg, healthSampleSec: 1000 }, { report: (event, data) => events.push({ event, data }) });
+  for (let i = 0; i < 90; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false }); // ~1.5s
+  D.Diag.endRun(); // run ended (showGameOver) before any heartbeat — flush the owed baseline now
+  check('session_health: endRun() flushes a baseline for an ended-then-abandoned run',
+    events.filter((e) => e.event === 'session_health').length === 1);
+  D.Diag.reset(); // a later restart/abandon must not re-emit the same run's baseline
+  check('session_health: a reset after endRun() does not double-emit',
+    events.filter((e) => e.event === 'session_health').length === 1);
+
+  // (e) endRun() on a too-short run (below MIN_SAMPLE_FRAMES) emits nothing.
+  events.length = 0;
+  D.Diag.reset();
+  D.Diag.init({ ...cfg, healthSampleSec: 1000 }, { report: (event, data) => events.push({ event, data }) });
+  for (let i = 0; i < 5; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+  D.Diag.endRun();
+  check('session_health: endRun() on a too-short run emits nothing', events.length === 0);
 
   // --- generic note() seam: other subsystems report into the same pipeline ----
   events.length = 0;

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -121,6 +121,26 @@ async function main() {
   D.Diag.reset();
   check('recorder: reset clears the trace', D.Diag.snapshot().summary.frames === 0);
 
+  // --- regression (codex #211): reset() suppresses the teleport-to-spawn false flag ---
+  // resetSnowman() teleports the player from wherever the last run ended back to spawn
+  // (z=-15). Without a Diag.reset() in that lifecycle path, the first frame of the new run
+  // reads as a giant prev->cur step (old finish -> spawn) and is falsely flagged a tunnel
+  // risk, permanently marking the fresh run BAD. Prove reset() clears `prev` so the first
+  // post-reset frame steps 0, and that WITHOUT it the teleport WOULD be flagged.
+  D.Diag.reset();
+  D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -150, technique: 'tuck', isInAir: false }); // deep in a run
+  D.Diag.reset();                                                                              // lifecycle restart
+  D.Diag.record({ dt: 1 / 60, speed: 3, x: 0, z: -15, technique: 'glide', isInAir: false });   // first frame of new run @ spawn
+  check('reset: first frame after a restart is not a false tunnel risk',
+    D.Diag.snapshot().summary.tunnelRiskFrames === 0);
+  // Control: the SAME teleport without a reset in between IS caught (so the guard matters).
+  D.Diag.reset();
+  D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -150, technique: 'tuck', isInAir: false });
+  D.Diag.record({ dt: 1 / 60, speed: 3, x: 0, z: -15, technique: 'glide', isInAir: false });   // no reset: 135u jump
+  check('reset: control — the teleport without reset is flagged (guard is load-bearing)',
+    D.Diag.snapshot().summary.tunnelRiskFrames === 1);
+  D.Diag.reset();
+
   console.log(`\nDIAGNOSTICS TESTS: ${fail === 0 ? 'OK ✅' : 'FAIL ❌'} (${pass} passed, ${fail} failed)`);
   process.exit(fail === 0 ? 0 : 1);
 }

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -146,6 +146,40 @@ async function main() {
   check('sink: a fresh run can report its own anomaly after reset',
     events.filter((e) => e.event === 'physics_anomaly').length === 2);
 
+  // --- session_health: HEALTHY runs contribute a baseline too -----------------
+  // The anomaly report only fires on BAD runs; without a healthy baseline there is
+  // nothing to compare a BAD verdict against. A periodic heartbeat (long runs) plus a
+  // run-end sample (short runs) gives every run an FPS-distribution sample.
+  // (a) periodic heartbeat on a long, healthy run — small interval to keep the test fast.
+  events.length = 0;
+  D.Diag.reset();
+  D.Diag.init({ ...cfg, healthSampleSec: 1 }, { report: (event, data) => events.push({ event, data }) });
+  for (let i = 0; i < 200; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false }); // ~3.3s
+  const beats = events.filter((e) => e.event === 'session_health');
+  check('session_health: a long healthy run emits baseline heartbeats', beats.length >= 1);
+  check('session_health: healthy heartbeat is graded ok (the comparison baseline)', beats[0].data.level === 'ok');
+  check('session_health: heartbeat carries the FPS-band distribution', 'fps_ge50_frames' in beats[0].data &&
+    typeof beats[0].data.fps === 'number');
+  check('session_health: never fires on the very first frame (needs >= MIN_SAMPLE_FRAMES)',
+    beats.length < 200);
+
+  // (b) a SHORT healthy run (no heartbeat) is still sampled once at run-end (reset).
+  events.length = 0;
+  D.Diag.reset(); // this reset may itself emit for the long run above; clear after
+  events.length = 0;
+  D.Diag.init({ ...cfg, healthSampleSec: 1000 }, { report: (event, data) => events.push({ event, data }) });
+  for (let i = 0; i < 90; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false }); // ~1.5s
+  check('session_health: no heartbeat for a run shorter than the interval',
+    events.filter((e) => e.event === 'session_health').length === 0);
+  D.Diag.reset();
+  check('session_health: a completed short run is sampled once at run-end',
+    events.filter((e) => e.event === 'session_health').length === 1);
+
+  // (c) a trivial/empty reset (e.g. the reset at init) does NOT emit a sample.
+  events.length = 0;
+  D.Diag.reset();
+  check('session_health: an empty reset emits nothing', events.length === 0);
+
   // --- generic note() seam: other subsystems report into the same pipeline ----
   events.length = 0;
   D.Diag.reset();

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -92,6 +92,29 @@ async function main() {
   ], cfg);
   check('fps→speed: a real low-FPS speed inflation at cruising still flags', D.fpsSpeedRatio(realBug) >= 3);
 
+  // regression (codex follow-up): a healthy 5 -> 8 m/s rise (high-FPS frames at a
+  // mid-acceleration ~5 m/s, then low-FPS frames at normal 8 m/s cruising) must NOT emit a
+  // BAD anomaly — the speed rose from run progression, not frame rate. 5 m/s is below the
+  // cruising floor, so the fast band is ineligible and there is no signal. (Before the
+  // tightened floor this gave ratio 1.6 -> BAD.)
+  const progression = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 5, frames: 30 }), // high FPS, sub-cruise (mid-acceleration)
+    ...descent({ dt: 0.1, speed: 8, frames: 30 }),    // low FPS at normal cruising speed
+  ], cfg);
+  check('fps→speed: a 5->8 m/s progression across an FPS drop is not flagged', D.fpsSpeedRatio(progression) === 1);
+  check('health: the 5->8 progression run is not graded BAD for fps-dependence',
+    !D.frameRateHealth(progression, cfg).reasons.some((r) => /frame-rate-dependent/i.test(r)));
+
+  // a MODEST cruise-speed gap (both bands at genuine cruising, ~8 vs ~13) is WARN-only, not
+  // a BAD anomaly — only the egregious #209-scale gap (>= 2x) emits physics_anomaly.
+  const modestGap = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 8, frames: 30 }),
+    ...descent({ dt: 0.1, speed: 13, frames: 30 }),   // ratio ~1.6: above WARN, below BAD
+  ], cfg);
+  check('fps→speed: a modest cruise gap is WARN, not a BAD anomaly',
+    D.fpsSpeedRatio(modestGap) >= 1.5 && D.fpsSpeedRatio(modestGap) < 2.0 &&
+    !D.frameRateHealth(modestGap, cfg).reasons.some((r) => /frame-rate-dependent/i.test(r)));
+
   // --- frameRateHealth verdicts ----------------------------------------------
   const healthySummary = summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 300 }), cfg);
   const healthy = D.frameRateHealth(healthySummary, cfg);

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -73,6 +73,25 @@ async function main() {
   const ratio = D.fpsSpeedRatio(buggy);
   check('fps→speed: 8→32 m/s across the FPS drop flags ~4x dependence', ratio >= 3.5 && ratio <= 4.5);
 
+  // regression (codex #211): a device fast at STARTUP (snowman still accelerating, ~3 m/s)
+  // that then settles below 30 FPS at normal cruising speed (~8 m/s) must NOT be flagged
+  // frame-rate-dependent — the speed rose from run progress, not frame rate. The fast band
+  // here holds only pre-cruise (unsettled) frames, so it is ineligible and the ratio is no
+  // signal.
+  const accelArtifact = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 3, frames: 60 }),  // >=50 FPS but below the cruising floor
+    ...descent({ dt: 0.1, speed: 8, frames: 60 }),     // <15 FPS at settled cruising speed
+  ], cfg);
+  check('fps→speed: an accelerating high-FPS start is not a false dependence', D.fpsSpeedRatio(accelArtifact) === 1);
+  check('health: the accel-artifact run is not graded BAD for fps-dependence',
+    !D.frameRateHealth(accelArtifact, cfg).reasons.some((r) => /frame-rate-dependent/i.test(r)));
+  // ...but a genuine bug where the SLOW frames are faster AT CRUISING SPEED still fires.
+  const realBug = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 8, frames: 60 }),   // >=50 FPS, cruising (settled)
+    ...descent({ dt: 0.1, speed: 26, frames: 60 }),     // <15 FPS, faster at cruising (the bug)
+  ], cfg);
+  check('fps→speed: a real low-FPS speed inflation at cruising still flags', D.fpsSpeedRatio(realBug) >= 3);
+
   // --- frameRateHealth verdicts ----------------------------------------------
   const healthySummary = summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 300 }), cfg);
   const healthy = D.frameRateHealth(healthySummary, cfg);

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -1,0 +1,128 @@
+// diagnostics-tests.js — headless unit tests for the physics/frame-rate telemetry
+// (src/diagnostics.ts, the runtime counterpart to the offline stress harnesses).
+//
+// Diag's analytics are exported PURE functions (percentile / classifyFrame / foldFrame /
+// fpsSpeedRatio / frameRateHealth), so the whole detector chain unit-tests in plain Node
+// with no DOM. The point of these tests: prove the detector actually FIRES on the real
+// PR #209 signature (terminal speed ballooning ~8 → ~32 m/s from 60 to 10 FPS, and a
+// per-frame step of 3.17 u jumping the 2.5 u tree collision radius) and stays QUIET on a
+// healthy steady-60-FPS run — otherwise a green diagnostics test would prove nothing.
+//   node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+const approx = (a, b, eps = 1e-9) => Math.abs(a - b) <= eps;
+
+// Fold a list of {dt, speed, x, z} samples through the real classify+fold chain and
+// return the running summary, exactly as Diag.record() does frame by frame.
+function summarize(D, samples, cfg) {
+  const agg = D.emptySummary();
+  let prev = null;
+  for (const s0 of samples) {
+    const s = { technique: 'tuck', isInAir: false, ...s0 };
+    const flags = D.classifyFrame(prev, s, cfg);
+    D.foldFrame(agg, s, flags);
+    if (!flags.nonFinite) prev = { x: s.x, z: s.z };
+  }
+  return agg;
+}
+
+// Build a straight-down-the-fall-line descent at a fixed dt and constant terminal speed,
+// stepping z by speed*dt each frame (x held at 0). Mirrors "hold Up" cruising.
+function descent({ dt, speed, frames, x = 0 }) {
+  const out = [];
+  let z = -15;
+  for (let i = 0; i < frames; i++) { z -= speed * dt; out.push({ dt, speed, x, z }); }
+  return out;
+}
+
+async function main() {
+  const D = await import('../src/diagnostics.js');
+  const cfg = D.DEFAULT_CONFIG; // frameCap 0.1s, collisionRadius 2.5, speedExpected 8
+
+  // --- percentile -------------------------------------------------------------
+  check('percentile: empty is NaN', Number.isNaN(D.percentile([], 0.5)));
+  check('percentile: median of 1..5 is 3', approx(D.percentile([1, 2, 3, 4, 5], 0.5), 3));
+  check('percentile: p0 / p100 are the ends', D.percentile([1, 2, 3, 4, 5], 0) === 1 && D.percentile([1, 2, 3, 4, 5], 1) === 5);
+  check('percentile: interpolates between samples', approx(D.percentile([0, 10], 0.25), 2.5));
+
+  // --- classifyFrame: per-frame anomaly flags ---------------------------------
+  // A 10-FPS (capped 0.1s) frame at 32 m/s steps 3.2 u — past the 2.5 u tree radius.
+  const slowStep = D.classifyFrame({ x: 0, z: 0 }, { dt: 0.1, speed: 32, x: 0, z: -3.2, technique: 'tuck', isInAir: false }, cfg);
+  check('classify: capped 0.1s frame flagged clamped', slowStep.clamped === true);
+  check('classify: 3.2u step past 2.5u radius is a tunnel risk', slowStep.tunnelRisk === true && approx(slowStep.step, 3.2, 1e-9));
+  check('classify: 10 FPS reported', approx(slowStep.fps, 10));
+  // A healthy 60-FPS frame at 8 m/s steps ~0.13 u — well under the radius, not clamped.
+  const fastStep = D.classifyFrame({ x: 0, z: 0 }, { dt: 1 / 60, speed: 8, x: 0, z: -8 / 60, technique: 'tuck', isInAir: false }, cfg);
+  check('classify: 60 FPS frame not clamped', fastStep.clamped === false);
+  check('classify: small step is no tunnel risk', fastStep.tunnelRisk === false);
+  // NaN guard.
+  const bad = D.classifyFrame({ x: 0, z: 0 }, { dt: 1 / 60, speed: NaN, x: 0, z: 0, technique: 'tuck', isInAir: false }, cfg);
+  check('classify: non-finite speed flagged', bad.nonFinite === true);
+
+  // --- fpsSpeedRatio: the core frame-rate-dependence detector ------------------
+  // No signal without both a fast and a slow band populated (a steady-FPS run).
+  const steady60 = summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 200 }), cfg);
+  check('fps→speed: steady 60 FPS gives ratio ~1 (no signal)', approx(D.fpsSpeedRatio(steady60), 1, 1e-9));
+
+  // THE #209 SIGNATURE: mix a 60-FPS leg at ~8 m/s with a 10-FPS leg at ~32 m/s.
+  const buggy = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 8, frames: 200 }),
+    ...descent({ dt: 0.1, speed: 32, frames: 40 }),
+  ], cfg);
+  const ratio = D.fpsSpeedRatio(buggy);
+  check('fps→speed: 8→32 m/s across the FPS drop flags ~4x dependence', ratio >= 3.5 && ratio <= 4.5);
+
+  // --- frameRateHealth verdicts ----------------------------------------------
+  const healthySummary = summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 300 }), cfg);
+  const healthy = D.frameRateHealth(healthySummary, cfg);
+  check('health: steady 60 FPS run is OK', healthy.level === 'ok');
+
+  const buggyHealth = D.frameRateHealth(buggy, cfg);
+  check('health: the #209 run is graded BAD', buggyHealth.level === 'bad');
+  check('health: BAD verdict cites tunnel risk', buggyHealth.reasons.some((r) => /tunnel/i.test(r)));
+  check('health: BAD verdict cites frame-rate-dependent force', buggyHealth.reasons.some((r) => /frame-rate-dependent/i.test(r)));
+
+  // A device that is merely slow but consistent (steady 10 FPS, bounded speed) must be
+  // WARNED about the low frame rate but NOT accused of the speed bug (no fast band to
+  // compare against → no false positive). This is the guard against crying wolf.
+  const slowButOk = summarize(D, descent({ dt: 0.1, speed: 8, frames: 120 }), cfg);
+  const slowHealth = D.frameRateHealth(slowButOk, cfg);
+  check('health: steady-slow-but-bounded device is not falsely accused of the speed bug',
+    !slowHealth.reasons.some((r) => /frame-rate-dependent/i.test(r)));
+  check('health: steady-slow device is warned about the delta cap',
+    slowHealth.reasons.some((r) => /delta cap|below/i.test(r)));
+
+  // --- non-finite frames surface in the summary + verdict ---------------------
+  const withNaN = summarize(D, [
+    ...descent({ dt: 1 / 60, speed: 8, frames: 30 }),
+    { dt: 1 / 60, speed: Infinity, x: NaN, z: NaN },
+  ], cfg);
+  check('summary: counts the non-finite frame', withNaN.nonFiniteFrames === 1);
+  check('health: any non-finite frame is BAD', D.frameRateHealth(withNaN, cfg).level === 'bad');
+
+  // --- foldFrame is additive (record() folds one frame at a time) -------------
+  const all = descent({ dt: 1 / 60, speed: 8, frames: 50 });
+  const once = summarize(D, all, cfg);
+  const split = (() => {
+    const agg = D.emptySummary(); let prev = null;
+    for (const s of all) { const f = D.classifyFrame(prev, { technique: 'tuck', isInAir: false, ...s }, cfg); D.foldFrame(agg, { technique: 'tuck', isInAir: false, ...s }, f); prev = { x: s.x, z: s.z }; }
+    return agg;
+  })();
+  check('fold: incremental == batch (frames + speedMax)',
+    once.frames === split.frames && approx(once.speedMax, split.speedMax));
+
+  // --- the live recorder is inert + safe in Node (no DOM) ---------------------
+  D.Diag.init(cfg);            // no window/document in Node → headless recorder path
+  D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -1, technique: 'tuck', isInAir: false });
+  const snap = D.Diag.snapshot();
+  check('recorder: snapshot is JSON-serialisable with a health verdict',
+    !!snap && !!snap.health && typeof JSON.stringify(snap) === 'string');
+  D.Diag.reset();
+  check('recorder: reset clears the trace', D.Diag.snapshot().summary.frames === 0);
+
+  console.log(`\nDIAGNOSTICS TESTS: ${fail === 0 ? 'OK ✅' : 'FAIL ❌'} (${pass} passed, ${fail} failed)`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/tests/diagnostics-tests.js
+++ b/tests/diagnostics-tests.js
@@ -112,6 +112,63 @@ async function main() {
   check('fold: incremental == batch (frames + speedMax)',
     once.frames === split.frames && approx(once.speedMax, split.speedMax));
 
+  // --- broadened invariant: absolute speed-ceiling runaway --------------------
+  // Independent of the fps-band ratio: a frame past the ceiling is a runaway even at a
+  // STEADY frame rate (where the band comparison sees nothing). Guards bugs that inflate
+  // speed without a frame-rate tell.
+  const runaway = summarize(D, descent({ dt: 1 / 60, speed: cfg.speedCeiling + 20, frames: 30 }), cfg);
+  check('runaway: frames past the speed ceiling are counted', runaway.runawayFrames === 30);
+  const runawayHealth = D.frameRateHealth(runaway, cfg);
+  check('runaway: graded BAD even at steady FPS', runawayHealth.level === 'bad' &&
+    runawayHealth.reasons.some((r) => /runaway/i.test(r)));
+  check('runaway: a normal-speed steady run has zero runaway frames',
+    summarize(D, descent({ dt: 1 / 60, speed: 8, frames: 60 }), cfg).runawayFrames === 0);
+
+  // --- analytics sink: reports a physics anomaly ONCE per run -----------------
+  // The injected sink (Firebase Analytics in the app) must fire exactly once when a run's
+  // health first reaches BAD — not every frame (that would flood analytics) and not on a
+  // healthy run.
+  const events = [];
+  D.Diag.reset();
+  D.Diag.init(cfg, { report: (event, data) => events.push({ event, data }) });
+  // Healthy frames first: no report.
+  for (let i = 0; i < 20; i++) D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+  check('sink: silent while a run stays healthy', events.filter((e) => e.event === 'physics_anomaly').length === 0);
+  // Now drive a runaway → exactly one physics_anomaly, with structured fields.
+  for (let i = 0; i < 30; i++) D.Diag.record({ dt: 1 / 60, speed: 80, x: 0, z: -40 - i, technique: 'tuck', isInAir: false });
+  const anomalies = events.filter((e) => e.event === 'physics_anomaly');
+  check('sink: fires exactly once when health flips BAD', anomalies.length === 1);
+  check('sink: anomaly payload carries structured fields', anomalies.length === 1 &&
+    anomalies[0].data.runawayFrames > 0 && typeof anomalies[0].data.reasons === 'string');
+  // After a reset (new run) the sink can report again.
+  D.Diag.reset();
+  for (let i = 0; i < 30; i++) D.Diag.record({ dt: 1 / 60, speed: 80, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+  check('sink: a fresh run can report its own anomaly after reset',
+    events.filter((e) => e.event === 'physics_anomaly').length === 2);
+
+  // --- generic note() seam: other subsystems report into the same pipeline ----
+  events.length = 0;
+  D.Diag.reset();
+  D.Diag.note('asset_load_failed', { url: 'music.mp3' });
+  const noteEvents = events.filter((e) => e.event === 'diag_note');
+  check('note: routes a generic anomaly to the sink', noteEvents.length === 1 &&
+    noteEvents[0].data.category === 'asset_load_failed' && noteEvents[0].data.url === 'music.mp3');
+  check('note: appears in the snapshot for the dump',
+    D.Diag.snapshot().notes.some((n) => n.category === 'asset_load_failed'));
+
+  // --- sink failures must never throw into the game loop ----------------------
+  D.Diag.reset();
+  D.Diag.init(cfg, { report: () => { throw new Error('analytics is down'); } });
+  let threw = false;
+  try {
+    for (let i = 0; i < 30; i++) D.Diag.record({ dt: 1 / 60, speed: 80, x: 0, z: -15 - i, technique: 'tuck', isInAir: false });
+    D.Diag.note('x', {});
+  } catch { threw = true; }
+  check('sink: a throwing sink is swallowed (telemetry never breaks the game)', threw === false);
+
+  // restore a quiet sink for the remaining recorder checks
+  D.Diag.init(cfg, { report: () => {} });
+
   // --- the live recorder is inert + safe in Node (no DOM) ---------------------
   D.Diag.init(cfg);            // no window/document in Node → headless recorder path
   D.Diag.record({ dt: 1 / 60, speed: 8, x: 0, z: -1, technique: 'tuck', isInAir: false });

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -92,6 +92,14 @@ declare global {
     _testShowGameOverOverride?: (...args: any[]) => unknown;
     // Firebase modular SDK handle wired up in index.html (analytics, etc.).
     firebaseModules?: any;
+    // Physics/frame-rate diagnostics bug-report API (src/diagnostics.ts): snapshot /
+    // dump (downloads a JSON trace) / reset / overlay toggle. Present only in live play.
+    __snowgliderDiag?: {
+      snapshot: () => unknown;
+      dump: () => unknown;
+      reset: () => void;
+      overlay: (on?: boolean) => void;
+    };
   }
 }
 


### PR DESCRIPTION
## Why

PR #209 and its avalanche follow-up fixed two instances of the **same bug class** — a quantity integrated as a *per-frame* multiplier (`v *= 1 − k`) sitting next to *delta-scaled* forces (`v += a · dt`), so the steady state scaled with frame rate (terminal speed ballooned **~8 → ~32 m/s from 60 to 10 FPS**, fast enough to slip between and even tunnel through the trees). Both were invisible because:

- **no existing test varied the frame time** (everything ran fixed at `dt = 1/60`), and
- **they only bite on slow/mobile devices** the developer never runs on — the report is just "the game froze / I drove through a tree," with no repro.

The offline stress harnesses now sweep `dt` in CI. This PR adds the **runtime counterpart**: a read-only observer that watches the `dt` the *real device* produces and the speed/step that ride on it, so the next bug in this class is diagnosed from data, not guessed.

## What

`src/diagnostics.ts` (`Diag`) — wired into `game/main-loop.ts` beside `Sfx`/`Flex` via a single `Diag.record(...)`. It detects, **live**:

| Signal | Meaning |
| --- | --- |
| step ≥ collision radius | per-frame move jumped past an obstacle's radius → the discrete point-vs-disk check could miss it (**tunnel risk** — runtime analog of the harness's offline probe) |
| fps→speed ratio ≥ 1.6 | max speed in low-FPS frames ≥1.6× the high-FPS max → a force path scales with frame time (**the #209 signature**); needs both a fast and slow band so steady FPS never false-alarms |
| NaN / Infinity | non-finite physics state |
| ≥10% frames at the delta cap | device below 1/cap FPS (WARN, not an accusation) |

**Surfacing:** throttled `console.warn` breadcrumbs during play; a `?debug` (or `` ` ``) HUD overlay with the speed-by-FPS-band table; `window.__snowgliderDiag.dump()` downloads a JSON trace (config, summary, health verdict, recent frames) to attach to a bug report.

## Safety (mirrors `sfx`/`intro`/`debris`)

- **Read-only** — reads the per-frame result + `pos` only, never `pos`/`velocity` or kernel state, so the **physics-invariant harness stays byte-identical**.
- **Automation-safe** — off under `window.isTestMode` / `navigator.webdriver` unless `window.testHooks.diagnosticsEnabled` opts in.
- **Cheap** — O(1)/frame (ring buffer + incremental summary fold), inert without a DOM.

## Tests

Analytics (`percentile`, `classifyFrame`, `foldFrame`, `fpsSpeedRatio`, `frameRateHealth`) are exported **pure functions**, unit-tested headlessly in `tests/diagnostics-tests.js` (`npm run test:diagnostics`, chained into `npm test`). They prove the detector both **fires and stays quiet**:

- the real #209 numbers (8 → 32 m/s across a 60→10 FPS drop) grade **BAD**, citing both the tunnel risk and the frame-rate-dependent force;
- a 3.2 u step past the 2.5 u tree radius flags a **tunnel risk**;
- a steady 60 FPS run grades **OK**;
- a steady-slow-but-bounded device is **WARN**ed about the cap but **not** accused of the speed bug (guard against crying wolf).

Verified locally: `npm run typecheck`, `npm run lint` (0 errors), `npm test` (full suite incl. `test:verify`/`test:stress`/`test:diagnostics`), and `npm run build` all green.

## Files

- `src/diagnostics.ts` — the module (pure analytics + stateful recorder + dev overlay + `window.__snowgliderDiag` API)
- `src/game/main-loop.ts`, `src/snowglider.ts` — read-only wiring + init seam
- `tests/diagnostics-tests.js`, `package.json` — `test:diagnostics`
- `types/globals.d.ts` — `window.__snowgliderDiag` typing
- `docs/DIAGNOSTICS.md`, `docs/CHANGELOG.md`, `CLAUDE.md` — docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGqmjsswqa8YACkzVF7JFX)_