### PR TITLE
chore(ts): tighten compiler/lint config and remove dead code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,8 +34,8 @@ module.exports = [
         // only for snowglider.js's old bare reads. As of PR 2.9 snowglider.js is
         // an ES module that imports them, and the later Phase 2 cleanup removed
         // their window namespace bridges too.
-        Howl: "readonly",
-        Howler: "readonly",
+        // (Howl/Howler were removed alongside the `howler` dependency — audio is
+        // native HTML5 now and nothing references those globals.)
         ScoresModule: "readonly",
         // three.js + Mountains + Trees + the terrain samplers (getTerrainHeight/
         // getTerrainGradient/getDownhillDirection) are single-sourced from npm and
@@ -88,9 +88,16 @@ module.exports = [
       }
     },
     rules: {
-      // Mirror the JS block: surface issues as warnings, don't fail the build,
-      // and don't fight unused vars during the migration.
-      "@typescript-eslint/no-unused-vars": "off",
+      // The TypeScript migration is complete and `tsc --noEmit` now enforces
+      // noUnusedLocals/noUnusedParameters (it FAILS on unused code), so re-enable
+      // the eslint twin as a warning for consistency. The leading-underscore
+      // ignore patterns mirror tsc's default so deliberately-unused
+      // call-site-parity params (e.g. `_scene`) don't warn in either tool.
+      "@typescript-eslint/no-unused-vars": ["warn", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_"
+      }],
       // Deliberate `any` lives only in boot/test seams + untyped Firestore
       // DocumentData.
       "@typescript-eslint/no-explicit-any": "warn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "firebase": "^11.5.0",
-        "howler": "^2.2.4",
         "three": "0.184.0"
       },
       "devDependencies": {
@@ -3600,12 +3599,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/howler": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
-      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
-      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "firebase": "^11.5.0",
-    "howler": "^2.2.4",
     "three": "0.184.0"
   },
   "devDependencies": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -277,7 +277,7 @@ function avatarInitials(name: string): string {
 // Paint #profileAvatar: the real photo if present, otherwise a generated avatar
 // with a random color plus either the user's initials or a random snow glyph.
 function renderAvatar(el: HTMLElement, user: {
-  isAnonymous?: boolean; uid?: string;
+  isAnonymous?: boolean; uid?: string | undefined;
   displayName?: string | null; email?: string | null; photoURL?: string | null;
 }) {
   const seed = user.uid || user.displayName || user.email || 'guest';

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -47,10 +47,11 @@ export class Camera {
   isFirstFrame: boolean;
   mode: CameraMode;
 
-  // `scene` is accepted to match the call site (`new Camera(scene)`) and kept for
+  // `_scene` is accepted to match the call site (`new Camera(scene)`) and kept for
   // parity with the other managers, though the camera reads terrain via the
-  // imported `Mountains` sampler rather than the scene graph.
-  constructor(scene: THREE.Scene) {
+  // imported `Mountains` sampler rather than the scene graph (hence the
+  // underscore: deliberately unused).
+  constructor(_scene: THREE.Scene) {
     // Create the camera
     this.camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
     
@@ -138,8 +139,10 @@ export class Camera {
     return this.mode;
   }
   
-  // Update camera position based on player position, rotation, and velocity
-  update(playerPosition: THREE.Vector3, playerRotation: THREE.Euler, velocity: PlanarVelocity, getTerrainHeight: TerrainHeightFn) {
+  // Update camera position based on player position, rotation, and velocity.
+  // `_getTerrainHeight` is accepted for call-site parity but unused: the camera
+  // samples terrain via the imported `Mountains.getTerrainHeight` directly.
+  update(playerPosition: THREE.Vector3, playerRotation: THREE.Euler, velocity: PlanarVelocity, _getTerrainHeight: TerrainHeightFn) {
     // Track frames for smoothing transitions
     this.frameCount++;
     

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -447,10 +447,6 @@ export const Controls = {
       // Refresh controls
       const existingControls = document.querySelectorAll('.touch-control');
       if (show && existingControls.length === 0) {
-        // Recalculate regions and create controls
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-        
         if (Object.keys(touchState.controlRegions).length === 0) {
           // Initialize control regions if they don't exist
           setupControls();

--- a/src/course.ts
+++ b/src/course.ts
@@ -121,7 +121,6 @@ export const CourseModule = (function () {
   let nextIndex = 0;           // index into the combined checkpoint+finish list
   let runSplits: number[] = [];          // split times recorded this run
   let recordSamples: GhostSample[] = []; // trajectory recorded this run
-  let sampleAccum = 0;
   let runActive = false;
   let airScore = 0;            // accumulated air-score for this run (meaningful jumps #47)
 
@@ -324,7 +323,7 @@ export const CourseModule = (function () {
           ghostTotalTime = data[data.length - 1].t;
         }
       }
-    } catch (e) {
+    } catch {
       ghostSamples = null;
     }
   }
@@ -336,7 +335,7 @@ export const CourseModule = (function () {
     try {
       const raw = localStorage.getItem(LS_SPLITS);
       bestSplits = raw ? JSON.parse(raw) : null;
-    } catch (e) {
+    } catch {
       bestSplits = null;
     }
   }
@@ -424,7 +423,6 @@ export const CourseModule = (function () {
     nextIndex = 0;
     runSplits = [];
     recordSamples = [];
-    sampleAccum = 0;
     runActive = true;
     airScore = 0;
 
@@ -512,7 +510,7 @@ export const CourseModule = (function () {
     }
 
     // --- Record this run's trajectory for a future ghost ---
-    sampleAccum += 1; // accumulate frames; we throttle by wall-clock via elapsed below
+    // Throttled by wall-clock (elapsed - lastSample >= SAMPLE_INTERVAL) below.
     if (recordSamples.length === 0 ||
         elapsed - recordSamples[recordSamples.length - 1].t >= SAMPLE_INTERVAL) {
       recordSamples.push({
@@ -568,7 +566,7 @@ export const CourseModule = (function () {
           rot: lastReal ? lastReal.rot : Math.PI
         });
         localStorage.setItem(LS_GHOST, JSON.stringify(recordSamples));
-      } catch (e) { /* storage may be unavailable; ignore */ }
+      } catch { /* storage may be unavailable; ignore */ }
     }
 
     const medal = medalFor(totalTime, previousBest, isFirst);

--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -63,8 +63,7 @@ export function setupScene() {
   //    by Math.PI at their definitions below to reproduce the legacy brightness.
   // Adopting modern color/lighting is a deliberate later change.
   // (Adopted alongside the three.js r134 -> r160 -> 0.184 upgrade.)
-  const THREECompat = THREE as any;
-  THREECompat.ColorManagement.enabled = false;
+  THREE.ColorManagement.enabled = false;
   const scene = new THREE.Scene();
   // Sky background + distance fog are applied after the lights are set up
   // (see Sky.applyGradientSky below) so the gradient sky / horizon fog replace the
@@ -75,7 +74,7 @@ export function setupScene() {
   // NOT need `preserveDrawingBuffer: true`, which would tax every frame by
   // blocking present-path optimizations just for that occasional capture.
   const renderer = new THREE.WebGLRenderer({ antialias: true });
-  (renderer as any).outputColorSpace = THREECompat.LinearSRGBColorSpace;
+  renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
   // Render at the device pixel ratio (capped at 2) so the scene is crisp on
   // HiDPI/Retina displays instead of soft; the cap keeps the framebuffer — and
   // GPU cost — bounded on 3x phone screens.

--- a/src/mountains/rocks.ts
+++ b/src/mountains/rocks.ts
@@ -266,32 +266,6 @@ export function addRocks(scene: THREE.Scene): RockPosition[] {
     }
   }
 
-  // Create a raycaster to ensure precise placement
-  const raycaster = new THREE.Raycaster();
-  const downDirection = new THREE.Vector3(0, -1, 0);
-
-  // Get terrain mesh for raycasting - try multiple ways to find it
-  let terrainMesh: THREE.Object3D | null = null;
-
-  // Check global reference first (set in snowglider.js)
-  if (window && window.terrainMesh) {
-    terrainMesh = window.terrainMesh;
-  }
-  // Then check userData
-  else if (scene.userData && scene.userData.terrainMesh) {
-    terrainMesh = scene.userData.terrainMesh;
-  }
-  // Last resort - find by name or type
-  else {
-    terrainMesh = scene.children.find(child => {
-      const mesh = child as THREE.Mesh;
-      return child.name === 'terrain' ||
-        (child.type === 'Mesh' &&
-         !!mesh.geometry &&
-         mesh.geometry.type === 'PlaneGeometry');
-    }) ?? null;
-  }
-
   const collisionRockPositions: RockPosition[] = [];
 
   // Create rock instances

--- a/src/mountains/trees.ts
+++ b/src/mountains/trees.ts
@@ -457,12 +457,10 @@ function addTrees(scene: THREE.Scene): TreePosition[] {
     // Position trees in the former ski path area with random placement
     // Each tree has a random position within the ski path width
     const zoneChoice = Math.random();
-    let xRange;
     let sizeVar;
-    
+
     if (zoneChoice < 0.2) {
       // 20% in inner zone (3-8 units from center) - smallest trees
-      xRange = 5;
       const side = Math.random() < 0.5 ? 1 : -1; // Randomly choose side
       const x = (3 + Math.random() * 5) * side; // 3-8 units from center
       sizeVar = 0.6 + Math.random() * 0.2; // 0.6-0.8 scale (very small)

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -26,7 +26,6 @@
  */
 
 import {
-  getFirestore,
   doc,
   setDoc,
   getDoc,
@@ -39,7 +38,7 @@ import {
   serverTimestamp,
   type Firestore
 } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore.js";
-import { getAnalytics, logEvent, type Analytics } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-analytics.js";
+import { logEvent, type Analytics } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-analytics.js";
 import type { User } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-auth.js";
 
 // Module state
@@ -397,9 +396,6 @@ function displayLeaderboard() {
           leaderboardElement.innerHTML = '<h3>No scores recorded yet!</h3>';
           return;
         }
-
-        let html = '<h3>Top 10 Times</h3><table>';
-        html += '<tr><th>Rank</th><th>Player</th><th>Time</th></tr>';
 
         // Fetch user data only if firestore is still available
         const userPromises = scores.map(score => {

--- a/src/snow.ts
+++ b/src/snow.ts
@@ -108,7 +108,7 @@ function resetSnowflakePosition(snowflake: THREE.Sprite, playerPos: Vec3Like) {
   snowflake.position.y = playerPos.y + Math.random() * snowflakeHeight;
 }
 
-function updateSnowflakes(delta: number, playerPos: Vec3Like, scene: THREE.Scene) {
+function updateSnowflakes(delta: number, playerPos: Vec3Like, _scene: THREE.Scene) {
   snowflakes.forEach(snowflake => {
     // Apply falling movement
     snowflake.position.y -= snowflake.userData.speed * delta;
@@ -187,8 +187,7 @@ function createSnowSplash(): SnowSplash {
   
   const texture = new THREE.CanvasTexture(canvas);
   const texture2 = new THREE.CanvasTexture(canvas2);
-  const textures = [texture, texture2];
-  
+
   // Follow the same approach as snowflakes - use individual sprites
   const splashParticles: THREE.Sprite[] = [];
   const particleCount = 250; // Increased for more dramatic effect
@@ -431,9 +430,6 @@ export const Snow = {
   createSnowSplash,
   updateSnowSplash
 };
-
-// For backward compatibility, alias Utils to Snow
-const Utils = Snow;
 
 // Snow is imported directly by snowglider.js, and the browser tests import it as
 // `Snow as Utils` (issue #84). Mountains/Trees are read via the ES-module imports

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
     "checkJs": true,
     "noEmit": true,
     "strict": true,
+    "verbatimModuleSyntax": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -4,6 +4,9 @@
 //
 // Phase 1 strategy: start loose (`any` for not-yet-typed module namespaces),
 // give the well-understood primitives real three.js types, and tighten per module.
+import type * as THREE from 'three';
+import type { TreePosition } from '../src/trees.js';
+
 declare global {
   // three.js r160 is single-sourced from npm. Every src module and every browser
   // test now `import * as THREE from 'three'`, so the ambient `THREE` global and
@@ -37,10 +40,6 @@ declare global {
   const isInAir: boolean;
   const verticalVelocity: number;
 
-  // Howler.js globals (still listed in package.json / eslint; audio is native HTML5 now).
-  const Howl: any;
-  const Howler: any;
-
   // NOTE: as of PR 2.9 snowglider.js is an ES module, so its shared helpers
   // (`showGameOver`, `updateCamera`, `updateSnowman`, …) and ALL the shared mutable
   // game state (`scene`, `snowman`, `velocity`, `pos`, `camera`, `cameraManager`,
@@ -73,8 +72,8 @@ declare global {
     FIREBASE_MANUAL_INIT?: boolean;
     __FIREBASE_DEFAULTS__?: any; // set by auth.js to stop Firebase auto-init 404s
     // Cross-module/test handles published by snowglider.js (docs/ARCHITECTURE.md §3).
-    terrainMesh?: any;
-    treePositions?: any;
+    terrainMesh?: THREE.Mesh;
+    treePositions?: TreePosition[];
     rockPositions?: Array<{ x: number; y: number; z: number; size: number }>;
     isTestMode?: boolean;
     // Lifecycle/input callbacks snowglider.js publishes for controls.js + buttons.


### PR DESCRIPTION
Strengthens TypeScript hygiene with **zero runtime behavior change**. The Three.js performance work from the same analysis already landed in #212; this PR is the TypeScript half.

Verified green: `npm run typecheck`, `npm run lint`, `npm test` (full suite), and `npm run build`.

## `tsconfig.json` — stricter compiler
- **`verbatimModuleSyntax: true`** — the highest-value change. Both build paths (Vite's `ts.transpileModule` and Node's native type-stripping) already *require* type-only imports/exports to be explicitly marked; the codebase complied by convention but nothing enforced it. Now the compiler guarantees what the build assumes. Passed with **zero source changes**.
- **`noImplicitReturns`**, **`noUnusedLocals`**, **`noUnusedParameters`**, **`exactOptionalPropertyTypes`** — enabled after fixing the ~14 issues they surfaced.
- **Deferred:** `noUncheckedIndexedAccess` flagged 279 sites in the math-heavy code — valuable but a large, risky follow-up of its own.

## `eslint.config.js`
- Re-enabled `@typescript-eslint/no-unused-vars` as a **warning** with leading-underscore ignore patterns (mirrors `tsc`'s default), now that the migration is complete. This caught real dead code `tsc` misses (write-only vars, unused catch bindings).
- Dropped the `Howl`/`Howler` globals.

## Dead code removed (surfaced by the flags above)
- `mountains/rocks.ts`: the unused `Raycaster` / `downDirection` / `terrainMesh` lookup block.
- `mountains/trees.ts`: write-only `xRange`.
- `course.ts`: write-only `sampleAccum` frame counter (the throttle actually uses wall-clock `elapsed`).
- `scores.ts`: a shadowed/leftover `html` builder + unused `getFirestore`/`getAnalytics` imports.
- `snow.ts`: unused `textures` array + dead `Utils` alias.
- `controls.ts`: unused `width`/`height`.
- `camera.ts` / `snow.ts`: underscore-prefixed the deliberately-unused call-site-parity params.
- `course.ts`: bindingless `catch` for ignored errors.

## Types & dependencies
- `game/scene-setup.ts`: removed the `THREE as any` / `renderer as any` casts (`ColorManagement`, `LinearSRGBColorSpace`, `outputColorSpace` are all typed in `@types/three@0.184`).
- `types/globals.d.ts`: tightened `terrainMesh?: THREE.Mesh` and `treePositions?: TreePosition[]`. (Left `AuthModule`/`ScoresModule`/`testHooks` as loose seams — full typing there is a genuine migration, not a quick win.)
- Removed the unused **`howler`** runtime dependency (audio is native HTML5 now; only comments referenced it).

Net: ESLint warnings 25 → 21 (all remaining are deliberate `any` boot/test seams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUamPGXTCaDXDhkZr7pQph)_