### PR TITLE
Instance the forest: collapse ~thousands of tree draws to ~10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
     "test:tree-collision": "node tests/tree-collision-tests.js",
+    "test:trees": "node --import ./tests/loaders/register-ts-resolve.mjs tests/trees-tests.js",
     "test:avalanche": "node tests/avalanche-tests.js",
     "test:snowtrails": "node tests/snowtrails-tests.js",
     "test:auth": "node --import ./tests/loaders/register-firebase-mock.mjs tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",

--- a/src/mountains/trees.ts
+++ b/src/mountains/trees.ts
@@ -494,11 +494,6 @@ function addSnowCaps(tree: THREE.Object3D, treeHeight: number, widthScale: numbe
   for (const desc of buckets.snowPatch) tree.add(meshFromDesc('snowPatch', desc));
 }
 
-// Tracked so a re-init can dispose the previous forest's per-instance buffers before
-// rebuilding (the pooled geometries/materials are app-lifetime; only the InstancedMesh
-// instanceMatrix/instanceColor buffers are per-forest and must be freed on rebuild).
-let forestMeshes: THREE.InstancedMesh[] = [];
-
 // Allocate the 5 InstancedMeshes from the collected buckets and add them to the scene.
 function buildForest(scene: THREE.Scene, buckets: Buckets): THREE.InstancedMesh[] {
   const defs: Array<[GeomKey, THREE.Material, THREE.Color[] | null]> = [
@@ -530,17 +525,23 @@ function buildForest(scene: THREE.Scene, buckets: Buckets): THREE.InstancedMesh[
 
 // Add trees to make the scene more interesting
 function addTrees(scene: THREE.Scene): TreePosition[] {
-  // Remove + dispose any previously-built instanced forest to prevent duplicates on
-  // re-init (the trees are InstancedMeshes named 'forestInstanced' now, not Groups).
-  // The shared geometries/materials are pooled and app-lifetime, so InstancedMesh
-  // .dispose() — which frees only the per-forest instanceMatrix/instanceColor buffers —
-  // is the right teardown. forestMeshes holds the exact handles we added last time.
-  for (const mesh of forestMeshes) {
-    scene.remove(mesh);
-    mesh.dispose();
+  // Remove + dispose any previously-built instanced forest in THIS scene, to prevent
+  // duplicates on re-init (the trees are InstancedMeshes named 'forestInstanced' now,
+  // not Groups). The teardown is deliberately scene-LOCAL — scanning the passed scene's
+  // own children rather than a module-global handle list — so that calling addTrees on
+  // a second THREE.Scene never removes or disposes the forest still live in another
+  // scene (each scene owns and clears its own forest, matching the old behaviour). The
+  // shared geometries/materials are pooled and app-lifetime, so InstancedMesh.dispose()
+  // — which frees only the per-forest instanceMatrix/instanceColor buffers — is the
+  // right teardown.
+  for (let i = scene.children.length - 1; i >= 0; i--) {
+    const child = scene.children[i]!;
+    if (child.name === 'forestInstanced') {
+      scene.remove(child);
+      (child as THREE.InstancedMesh).dispose();
+    }
   }
-  forestMeshes = [];
-  
+
   const treePositions: TreePosition[] = [];
 
   // IMPORTANT: Log the ranges we're using to create trees for debugging
@@ -697,7 +698,7 @@ function addTrees(scene: THREE.Scene): TreePosition[] {
     const treeScale = pos.scale || 1.0;
     collectTree(treeScale, new THREE.Matrix4().makeTranslation(pos.x, terrainHeight - 0.5, pos.z), buckets);
   });
-  forestMeshes = buildForest(scene, buckets);
+  buildForest(scene, buckets);
 
   return treePositions;
 }

--- a/src/mountains/trees.ts
+++ b/src/mountains/trees.ts
@@ -127,9 +127,13 @@ let coneGeometry: THREE.ConeGeometry | null = null;
 let branchGeometry: THREE.CylinderGeometry | null = null;
 let snowCapGeometry: THREE.SphereGeometry | null = null;
 let snowPatchGeometry: THREE.SphereGeometry | null = null;
+let trunkColors: THREE.Color[] | null = null;
+let foliageColors: THREE.Color[] | null = null;
 let trunkMaterials: THREE.MeshStandardMaterial[] | null = null;
 let foliageMaterials: THREE.MeshStandardMaterial[] | null = null;
 let snowMaterial: THREE.MeshStandardMaterial | null = null;
+let barkInstancedMaterial: THREE.MeshStandardMaterial | null = null;
+let foliageInstancedMaterial: THREE.MeshStandardMaterial | null = null;
 
 /** Canonical trunk: top/bottom radius + height match the old defaults at scale 1. */
 function getTrunkGeometry(): THREE.CylinderGeometry {
@@ -165,48 +169,72 @@ function getSnowPatchGeometry(): THREE.SphereGeometry {
   return snowPatchGeometry;
 }
 
+// --- Colour palettes (the source of truth for both the Group shim and instances) ---
+// The forest is rendered with InstancedMesh (one draw per geometry/material), and
+// within a material family the *only* per-tree variation is the base colour. So the
+// palettes live here as bare `THREE.Color[]` and feed BOTH the legacy palette
+// materials (`getTrunkMaterials`/`getFoliageMaterials`, kept for the Group-returning
+// `createTree` shim + API compatibility) and the per-instance `setColorAt` calls in
+// `buildForest`. Same HSL values as before → identical look, now via `instanceColor`.
+
 /** Small palette of brown bark shades (the old per-trunk HSL range, quantised). */
-function getTrunkMaterials(): THREE.MeshStandardMaterial[] {
-  if (!trunkMaterials) {
-    const normalMap = getBarkNormal();
+function getTrunkColors(): THREE.Color[] {
+  if (!trunkColors) {
     const count = 6;
-    trunkMaterials = [];
+    trunkColors = [];
     for (let i = 0; i < count; i++) {
       const hue = 0.08 + (i / (count - 1)) * 0.04; // 0.08-0.12, as before
-      trunkMaterials.push(new THREE.MeshStandardMaterial({
-        color: new THREE.Color().setHSL(hue, 0.5, 0.3),
-        roughness: 0.9,
-        normalMap,
-        normalScale: new THREE.Vector2(0.7, 0.7)
-      }));
+      trunkColors.push(new THREE.Color().setHSL(hue, 0.5, 0.3));
     }
   }
-  return trunkMaterials;
+  return trunkColors;
 }
 
 /** Small palette of green foliage shades spanning the old per-cone HSL ranges. */
-function getFoliageMaterials(): THREE.MeshStandardMaterial[] {
-  if (!foliageMaterials) {
-    const normalMap = getFoliageNormal();
+function getFoliageColors(): THREE.Color[] {
+  if (!foliageColors) {
     const count = 12;
-    foliageMaterials = [];
+    foliageColors = [];
     for (let i = 0; i < count; i++) {
       const t = i / (count - 1);
       const hue = 0.35 + t * 0.07;                 // 0.35-0.42, as before
       const saturation = 0.6 + ((i * 7) % count) / count * 0.3; // spread across 0.6-0.9
       const lightness = 0.2 + ((i * 5) % count) / count * 0.1;  // spread across 0.2-0.3
-      foliageMaterials.push(new THREE.MeshStandardMaterial({
-        color: new THREE.Color().setHSL(hue, saturation, lightness),
-        roughness: 0.8,
-        normalMap,
-        normalScale: new THREE.Vector2(0.5, 0.5)
-      }));
+      foliageColors.push(new THREE.Color().setHSL(hue, saturation, lightness));
     }
+  }
+  return foliageColors;
+}
+
+/** Legacy per-shade bark materials (Group shim / API compat); built from the palette. */
+function getTrunkMaterials(): THREE.MeshStandardMaterial[] {
+  if (!trunkMaterials) {
+    const normalMap = getBarkNormal();
+    trunkMaterials = getTrunkColors().map(color => new THREE.MeshStandardMaterial({
+      color: color.clone(),
+      roughness: 0.9,
+      normalMap,
+      normalScale: new THREE.Vector2(0.7, 0.7)
+    }));
+  }
+  return trunkMaterials;
+}
+
+/** Legacy per-shade foliage materials (Group shim / API compat); built from the palette. */
+function getFoliageMaterials(): THREE.MeshStandardMaterial[] {
+  if (!foliageMaterials) {
+    const normalMap = getFoliageNormal();
+    foliageMaterials = getFoliageColors().map(color => new THREE.MeshStandardMaterial({
+      color: color.clone(),
+      roughness: 0.8,
+      normalMap,
+      normalScale: new THREE.Vector2(0.5, 0.5)
+    }));
   }
   return foliageMaterials;
 }
 
-/** The single shared white snow material (every cap/patch was identical anyway). */
+/** The single shared white snow material (every cap/patch is identical, no instanceColor). */
 function getSnowMaterial(): THREE.MeshStandardMaterial {
   if (!snowMaterial) {
     snowMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.8 });
@@ -214,31 +242,114 @@ function getSnowMaterial(): THREE.MeshStandardMaterial {
   return snowMaterial;
 }
 
-/** Pick a random material from a palette (forest colour variety, shared GPU state). */
-function pickMaterial(pool: THREE.MeshStandardMaterial[]): THREE.MeshStandardMaterial {
-  return pool[Math.floor(Math.random() * pool.length)]!;
+// --- Instanced materials (one per family; white base, tinted per-instance) ---
+// Collapsing the 6 bark + 12 foliage palette materials down to ONE material each:
+// the base colour is white and the chosen palette colour is supplied per instance via
+// `setColorAt` (`instanceColor` multiplies the white base, reproducing the palette
+// exactly — ColorManagement is off + output is LinearSRGB, so setHSL maps through
+// unchanged). Snow needs no tint, so the instanced snow caps/patches reuse the shared
+// white `getSnowMaterial()` directly. Headless-safe: the normal maps are null without
+// `document` and three treats a null `normalMap` as no map.
+
+/** White bark material for the instanced trunks (tinted per-instance). */
+function getBarkInstancedMaterial(): THREE.MeshStandardMaterial {
+  if (!barkInstancedMaterial) {
+    barkInstancedMaterial = new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.9,
+      normalMap: getBarkNormal(),
+      normalScale: new THREE.Vector2(0.7, 0.7)
+    });
+  }
+  return barkInstancedMaterial;
 }
 
-// Create a more realistic tree with visible branches and variability.
-// Each part draws from the shared geometry/material pools above and is sized via
-// `mesh.scale`, so the forest reuses a handful of GPU buffers/materials instead of
-// minting thousands. The mesh layout (one Group of individual meshes) is unchanged.
-function createTree(scale = 1.0): THREE.Group {
-  const group = new THREE.Group();
+/** White foliage material for the instanced cones + branches (tinted per-instance). */
+function getFoliageInstancedMaterial(): THREE.MeshStandardMaterial {
+  if (!foliageInstancedMaterial) {
+    foliageInstancedMaterial = new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.8,
+      normalMap: getFoliageNormal(),
+      normalScale: new THREE.Vector2(0.5, 0.5)
+    });
+  }
+  return foliageInstancedMaterial;
+}
 
+/** Pick a random palette index (forest colour variety); one RNG draw, as before. */
+function pickColorIndex(paletteLength: number): number {
+  return Math.floor(Math.random() * paletteLength);
+}
+
+// --- Instanced forest: collectors + builder (the draw-call win, issue #...) ---
+// Sharing a geometry/material does NOT merge draws — the old code still assembled
+// every tree as a Group of ~14-35 individual Meshes, so a few-hundred-tree forest
+// issued thousands of draw calls per frame (doubled by the shadow pass). The parts
+// only span 5 geometries and 3 material families (bark/foliage/snow, varying just by
+// base colour), so the whole forest collapses to 5 InstancedMeshes — ~5 colour + ~5
+// shadow draws total — with per-instance colour reproducing the palette. The avalanche
+// boulders and ski tracks already use this pattern; the forest was the last holdout.
+//
+// `createTree` is now a *collector*: it runs the SAME randomisation in the SAME order
+// (byte-identical RNG draws) but records a transform (+ palette index) per part into
+// per-geometry buckets instead of minting a Mesh. `addTrees` collects every tree into
+// one shared set of buckets, then `buildForest` allocates the 5 InstancedMeshes. A thin
+// Group-returning `createTree` shim (below) feeds one tree through the collector and
+// rebuilds real Meshes from its bucket, preserving the public API for headless callers.
+
+type GeomKey = 'trunk' | 'cone' | 'branch' | 'snowCap' | 'snowPatch';
+const GEOM_KEYS: GeomKey[] = ['trunk', 'cone', 'branch', 'snowCap', 'snowPatch'];
+
+/** One placed part: its world matrix and (for tinted families) a palette colour index. */
+interface InstanceDesc {
+  matrix: THREE.Matrix4;
+  colorIndex?: number;
+}
+type Buckets = Record<GeomKey, InstanceDesc[]>;
+
+function createBuckets(): Buckets {
+  return { trunk: [], cone: [], branch: [], snowCap: [], snowPatch: [] };
+}
+
+// Scratch objects reused across pushPart calls (no per-part allocation churn).
+const _identity = new THREE.Matrix4();
+const _local = new THREE.Matrix4();
+const _world = new THREE.Matrix4();
+const _q = new THREE.Quaternion();
+const _e = new THREE.Euler();
+const _p = new THREE.Vector3();
+const _s = new THREE.Vector3();
+
+/** Compose a part's local TRS, premultiply by the tree's world matrix, record it. */
+function pushPart(
+  buckets: Buckets, key: GeomKey, treeMatrix: THREE.Matrix4,
+  pos: { x: number; y: number; z: number },
+  rot: { x: number; y: number; z: number },
+  scl: { x: number; y: number; z: number },
+  colorIndex?: number
+): void {
+  _q.setFromEuler(_e.set(rot.x, rot.y, rot.z));
+  _local.compose(_p.set(pos.x, pos.y, pos.z), _q, _s.set(scl.x, scl.y, scl.z));
+  _world.multiplyMatrices(treeMatrix, _local);
+  buckets[key].push(colorIndex === undefined ? { matrix: _world.clone() } : { matrix: _world.clone(), colorIndex });
+}
+
+// Collect one tree's parts into the buckets, translated by `treeMatrix`. This is the
+// original createTree body verbatim — same heightScale/widthScale/branchDensity draws,
+// same per-cone tilt — with each `new THREE.Mesh(...)` replaced by a pushPart(...).
+function collectTree(scale: number, treeMatrix: THREE.Matrix4, buckets: Buckets): void {
   // Add randomization factors for variety
   const heightScale = (0.8 + Math.random() * 0.4) * scale; // 0.8-1.2 height variation with scaling
   const widthScale = (0.85 + Math.random() * 0.3) * scale; // 0.85-1.15 width variation with scaling
   const branchDensity = 3 + Math.floor(Math.random() * 3); // 3-5 branch layers
 
-  // Tree trunk — shared canonical cylinder, sized via scale, palette material.
+  // Tree trunk — base at y=0 (so its centre is at trunkHeight/2), sized via scale.
   const trunkHeight = 4 * heightScale;
-  const trunk = new THREE.Mesh(getTrunkGeometry(), pickMaterial(getTrunkMaterials()));
-  trunk.scale.set(widthScale, heightScale, widthScale);
-  // Position the trunk so its base is at y=0 instead of its center
-  trunk.position.y = trunkHeight / 2;
-  trunk.castShadow = true;
-  group.add(trunk);
+  const trunkColorIndex = pickColorIndex(getTrunkColors().length);
+  pushPart(buckets, 'trunk', treeMatrix,
+    { x: 0, y: trunkHeight / 2, z: 0 }, { x: 0, y: 0, z: 0 },
+    { x: widthScale, y: heightScale, z: widthScale }, trunkColorIndex);
 
   // Create multiple branch layers
   const baseHeight = trunkHeight;
@@ -250,115 +361,185 @@ function createTree(scale = 1.0): THREE.Group {
     const coneHeight = 2.5 * heightScale * layerScale;
     const coneRadius = 2.2 * widthScale * layerScale;
 
-    // Shared cone geometry resized to this layer; one foliage shade from the palette.
-    const coneMaterial = pickMaterial(getFoliageMaterials());
-    const cone = new THREE.Mesh(getConeGeometry(), coneMaterial);
-    cone.scale.set(widthScale * layerScale, heightScale * layerScale, widthScale * layerScale);
+    // One foliage shade from the palette (branches inherit the same index).
+    const coneColorIndex = pickColorIndex(getFoliageColors().length);
 
-    // Position with slight random offset for natural look
-    const xTilt = (Math.random() - 0.5) * 0.1; // Slight random tilt
+    // Slight random tilt for natural look
+    const xTilt = (Math.random() - 0.5) * 0.1;
     const zTilt = (Math.random() - 0.5) * 0.1;
-    cone.rotation.x = xTilt;
-    cone.rotation.z = zTilt;
 
     // Position branches with overlap
     layerHeight += coneHeight * 0.6;
-    cone.position.y = layerHeight;
-    cone.castShadow = true;
-    group.add(cone);
+    pushPart(buckets, 'cone', treeMatrix,
+      { x: 0, y: layerHeight, z: 0 }, { x: xTilt, y: 0, z: zTilt },
+      { x: widthScale * layerScale, y: heightScale * layerScale, z: widthScale * layerScale },
+      coneColorIndex);
 
     // Add visible branches coming out of each cone layer
-    addBranchesAtLayer(group, cone.position, coneRadius, coneMaterial);
+    collectBranchesAtLayer(buckets, treeMatrix, layerHeight, coneRadius, coneColorIndex);
   }
 
   // Add some snow on the branches for winter effect
-  addSnowCaps(group, layerHeight, widthScale);
-
-  return group;
+  collectSnowCaps(buckets, treeMatrix, layerHeight, widthScale);
 }
 
-// Add visible branches sticking out of the main cone shape. They are added to the
-// tree group (not the cone) so the shared unit branch geometry can be sized in
-// world units via scale without inheriting the cone's own size — the cone's tiny
-// tilt is the only thing the branches no longer inherit (visually imperceptible).
-function addBranchesAtLayer(parent: THREE.Object3D, conePosition: THREE.Vector3, radius: number, material: THREE.Material) {
+// Collect the branches sticking out of one cone layer. The cone sits at (0, coneY, 0)
+// in tree space, so this matches the old addBranchesAtLayer math with conePosition.x/z
+// fixed at 0 (the cone only ever had its y set).
+function collectBranchesAtLayer(
+  buckets: Buckets, treeMatrix: THREE.Matrix4, coneY: number, radius: number, colorIndex: number
+): void {
   // Number of branches depends on radius
   const branchCount = Math.floor(3 + Math.random() * 3); // 3-5 visible branches
 
   for (let i = 0; i < branchCount; i++) {
-    // Create branch — shared unit cylinder (pre-rotated along +X) sized via scale.
+    // Shared unit cylinder (pre-rotated along +X) sized via scale.
     const branchLength = radius * (0.7 + Math.random() * 0.5);
     const branchThickness = 0.1 + Math.random() * 0.1;
-
-    const branch = new THREE.Mesh(getBranchGeometry(), material);
-    branch.scale.set(branchLength, branchThickness, branchThickness);
 
     // Position branch at random angle around cone
     const angle = (i / branchCount) * Math.PI * 2 + Math.random() * 0.5;
     const height = Math.random() * 0.5; // Vertical position variation
 
-    branch.position.set(
-      conePosition.x + Math.cos(angle) * (radius * 0.5),
-      conePosition.y + height,
-      conePosition.z + Math.sin(angle) * (radius * 0.5)
-    );
+    const rotX = (Math.random() - 0.5) * 0.3;
+    const rotZ = (Math.random() - 0.5) * 0.1;
 
-    // Random rotation for natural variation
-    branch.rotation.y = angle;
-    branch.rotation.x = (Math.random() - 0.5) * 0.3;
-    branch.rotation.z = (Math.random() - 0.5) * 0.1;
-
-    branch.castShadow = true;
-    parent.add(branch);
+    pushPart(buckets, 'branch', treeMatrix, {
+      x: Math.cos(angle) * (radius * 0.5),
+      y: coneY + height,
+      z: Math.sin(angle) * (radius * 0.5)
+    }, { x: rotX, y: angle, z: rotZ },
+      { x: branchLength, y: branchThickness, z: branchThickness }, colorIndex);
   }
 }
 
-// Add snow caps on top of tree (shared snow geometry/material, sized via scale).
-function addSnowCaps(tree: THREE.Object3D, treeHeight: number, widthScale: number) {
-  const snowMat = getSnowMaterial();
-
+// Collect snow caps on top of the tree (shared snow geometry, no tint).
+function collectSnowCaps(buckets: Buckets, treeMatrix: THREE.Matrix4, treeHeight: number, widthScale: number): void {
   // Add some snow on top
   const capRadius = widthScale * 0.8;
-  const snowCap = new THREE.Mesh(getSnowCapGeometry(), snowMat);
-  snowCap.scale.set(capRadius, capRadius * 0.5, capRadius); // flattened dome, as before
-  snowCap.position.y = treeHeight + 0.2;
-  tree.add(snowCap);
+  pushPart(buckets, 'snowCap', treeMatrix,
+    { x: 0, y: treeHeight + 0.2, z: 0 }, { x: 0, y: 0, z: 0 },
+    { x: capRadius, y: capRadius * 0.5, z: capRadius }); // flattened dome, as before
 
   // Maybe add snow on some branches
   if (Math.random() > 0.4) {
     const patchRadius = widthScale * 0.4;
     for (let i = 0; i < 2 + Math.random() * 3; i++) {
-      const snowPatch = new THREE.Mesh(getSnowPatchGeometry(), snowMat);
       // Random position on the tree
       const angle = Math.random() * Math.PI * 2;
       const radius = widthScale * (0.8 + Math.random() * 0.8);
       const height = 2 + Math.random() * (treeHeight - 3);
 
-      snowPatch.position.set(
-        Math.cos(angle) * radius,
-        height,
-        Math.sin(angle) * radius
-      );
-
-      snowPatch.scale.set(patchRadius, patchRadius * 0.3, patchRadius);
-      snowPatch.rotation.x = Math.random() * Math.PI / 4;
-      snowPatch.rotation.z = Math.random() * Math.PI / 4;
-
-      tree.add(snowPatch);
+      pushPart(buckets, 'snowPatch', treeMatrix, {
+        x: Math.cos(angle) * radius,
+        y: height,
+        z: Math.sin(angle) * radius
+      }, { x: Math.random() * Math.PI / 4, y: 0, z: Math.random() * Math.PI / 4 },
+        { x: patchRadius, y: patchRadius * 0.3, z: patchRadius });
     }
   }
 }
 
+/** The shared base geometry for a bucket key. */
+function geometryForKey(key: GeomKey): THREE.BufferGeometry {
+  switch (key) {
+    case 'trunk': return getTrunkGeometry();
+    case 'cone': return getConeGeometry();
+    case 'branch': return getBranchGeometry();
+    case 'snowCap': return getSnowCapGeometry();
+    case 'snowPatch': return getSnowPatchGeometry();
+  }
+}
+
+/** Rebuild a real Mesh from one collected part (for the Group-returning createTree shim). */
+function meshFromDesc(key: GeomKey, desc: InstanceDesc): THREE.Mesh {
+  let material: THREE.Material;
+  if (key === 'trunk') material = getTrunkMaterials()[desc.colorIndex!]!;
+  else if (key === 'cone' || key === 'branch') material = getFoliageMaterials()[desc.colorIndex!]!;
+  else material = getSnowMaterial();
+  const mesh = new THREE.Mesh(geometryForKey(key), material);
+  mesh.applyMatrix4(desc.matrix); // decomposes the world TRS into position/quaternion/scale
+  mesh.castShadow = true;
+  return mesh;
+}
+
+// Group-returning shim — kept for API compatibility (contract-surface tests, any
+// headless caller) and not used by the instanced `addTrees` path. Runs one tree
+// through the collector at identity and rebuilds individual Meshes from its bucket,
+// so the visible result matches the old per-mesh tree exactly.
+function createTree(scale = 1.0): THREE.Group {
+  const buckets = createBuckets();
+  collectTree(scale, _identity, buckets);
+  const group = new THREE.Group();
+  for (const key of GEOM_KEYS) {
+    for (const desc of buckets[key]) group.add(meshFromDesc(key, desc));
+  }
+  return group;
+}
+
+// Thin Object3D-emitting shims preserved on the Trees API (contract-surface tests).
+// They delegate to the collectors and append the rebuilt Meshes to `parent`, matching
+// the old addBranchesAtLayer/addSnowCaps signatures for any external caller.
+function addBranchesAtLayer(parent: THREE.Object3D, conePosition: THREE.Vector3, radius: number, _material?: THREE.Material): void {
+  const buckets = createBuckets();
+  // Reproduce the old world placement: branches sat at conePosition (x/z preserved).
+  collectBranchesAtLayer(buckets, new THREE.Matrix4().makeTranslation(conePosition.x, 0, conePosition.z), conePosition.y, radius, 0);
+  for (const desc of buckets.branch) parent.add(meshFromDesc('branch', desc));
+}
+
+function addSnowCaps(tree: THREE.Object3D, treeHeight: number, widthScale: number): void {
+  const buckets = createBuckets();
+  collectSnowCaps(buckets, _identity, treeHeight, widthScale);
+  for (const desc of buckets.snowCap) tree.add(meshFromDesc('snowCap', desc));
+  for (const desc of buckets.snowPatch) tree.add(meshFromDesc('snowPatch', desc));
+}
+
+// Tracked so a re-init can dispose the previous forest's per-instance buffers before
+// rebuilding (the pooled geometries/materials are app-lifetime; only the InstancedMesh
+// instanceMatrix/instanceColor buffers are per-forest and must be freed on rebuild).
+let forestMeshes: THREE.InstancedMesh[] = [];
+
+// Allocate the 5 InstancedMeshes from the collected buckets and add them to the scene.
+function buildForest(scene: THREE.Scene, buckets: Buckets): THREE.InstancedMesh[] {
+  const defs: Array<[GeomKey, THREE.Material, THREE.Color[] | null]> = [
+    ['trunk', getBarkInstancedMaterial(), getTrunkColors()],
+    ['cone', getFoliageInstancedMaterial(), getFoliageColors()],
+    ['branch', getFoliageInstancedMaterial(), getFoliageColors()],
+    ['snowCap', getSnowMaterial(), null],
+    ['snowPatch', getSnowMaterial(), null]
+  ];
+  const built: THREE.InstancedMesh[] = [];
+  for (const [key, material, palette] of defs) {
+    const list = buckets[key];
+    if (list.length === 0) continue; // skip empty families (no zero-count draw)
+    const im = new THREE.InstancedMesh(geometryForKey(key), material, list.length);
+    im.castShadow = true;
+    im.name = 'forestInstanced';        // scene-cleanup + test handle
+    im.userData.forestPart = key;       // lets tests identify the trunk mesh (1 per tree)
+    for (let i = 0; i < list.length; i++) {
+      im.setMatrixAt(i, list[i]!.matrix);
+      if (palette && list[i]!.colorIndex !== undefined) im.setColorAt(i, palette[list[i]!.colorIndex!]!);
+    }
+    im.instanceMatrix.needsUpdate = true;
+    if (im.instanceColor) im.instanceColor.needsUpdate = true;
+    scene.add(im);
+    built.push(im);
+  }
+  return built;
+}
+
 // Add trees to make the scene more interesting
 function addTrees(scene: THREE.Scene): TreePosition[] {
-  // Remove any existing trees from the scene to prevent duplicates
-  for (let i = scene.children.length - 1; i >= 0; i--) {
-    const child = scene.children[i]!;
-    // Trees are typically groups with many child elements
-    if (child.type === 'Group' && child.children.length > 3) {
-      scene.remove(child);
-    }
+  // Remove + dispose any previously-built instanced forest to prevent duplicates on
+  // re-init (the trees are InstancedMeshes named 'forestInstanced' now, not Groups).
+  // The shared geometries/materials are pooled and app-lifetime, so InstancedMesh
+  // .dispose() — which frees only the per-forest instanceMatrix/instanceColor buffers —
+  // is the right teardown. forestMeshes holds the exact handles we added last time.
+  for (const mesh of forestMeshes) {
+    scene.remove(mesh);
+    mesh.dispose();
   }
+  forestMeshes = [];
   
   const treePositions: TreePosition[] = [];
 
@@ -504,23 +685,20 @@ function addTrees(scene: THREE.Scene): TreePosition[] {
   const extendedTrees = treePositions.filter(tree => tree.z < -80).length;
   console.log(`Trees.addTrees: ${extendedTrees} trees in extended terrain area (z < -80)`);
   
-  // Create tree instances - ensure trees are properly anchored to terrain.
+  // Collect every tree's parts into shared per-geometry buckets, then allocate the
+  // InstancedMeshes once — the whole forest becomes ~5 colour + ~5 shadow draws.
   // (Tree height comes from the analytic terrain sampler below; the old
-  // Raycaster/terrain-mesh lookup here was dead code and has been removed.)
+  // Raycaster/terrain-mesh lookup here was dead code and has been removed.) Each tree's
+  // world matrix is a pure translation: the group only ever got .position.set(...), and
+  // trees are sunk 0.5 units into the terrain to anchor them.
+  const buckets = createBuckets();
   treePositions.forEach(pos => {
-    // Get the exact terrain height from our height map or via calculation
     const terrainHeight = getTerrainHeight(pos.x, pos.z);
-    
-    // Create tree with optional scale and position it precisely on the terrain
-    // Use the scale from the position data or default to 1.0
     const treeScale = pos.scale || 1.0;
-    const tree = createTree(treeScale);
-    
-    // Make sure trees are properly anchored by sinking them 0.5 units into the terrain
-    tree.position.set(pos.x, terrainHeight - 0.5, pos.z);
-    scene.add(tree);
+    collectTree(treeScale, new THREE.Matrix4().makeTranslation(pos.x, terrainHeight - 0.5, pos.z), buckets);
   });
-  
+  forestMeshes = buildForest(scene, buckets);
+
   return treePositions;
 }
 

--- a/tests/browser-tree-tests.js
+++ b/tests/browser-tree-tests.js
@@ -87,31 +87,40 @@ import { Snow as Utils } from '../src/snow.js';
     }
     
     // Test 1: Tree Position Array Verification
-    // This test verifies that treePositions array accurately represents all trees in the scene
+    // The forest is now rendered with InstancedMesh (one draw per geometry/material)
+    // instead of a Group-of-Meshes per tree, so there is no per-tree scene object to
+    // count. Each tree contributes EXACTLY one trunk instance, so the trunk
+    // InstancedMesh's `.count` must equal the collision array length — a stronger,
+    // exact check than the old ±10% Group tally.
     function testTreePositionArray() {
-      // Count visual trees in the scene
-      let visualTrees = 0;
+      // Find the instanced forest meshes; identify the trunk mesh by its userData tag.
+      let forestMeshCount = 0;
+      let trunkMesh = null;
       for (let i = 0; i < scene.children.length; i++) {
         const object = scene.children[i];
-        if (object.type === 'Group' && object.children.length > 3) {
-          visualTrees++;
+        if (object.name === 'forestInstanced' && object.isInstancedMesh) {
+          forestMeshCount++;
+          if (object.userData && object.userData.forestPart === 'trunk') trunkMesh = object;
         }
       }
-      
-      // Count trees in collision array
+
       const collisionTrees = treePositions.length;
-      
-      console.log(`Visual trees in scene: ${visualTrees}`);
+      const trunkInstances = trunkMesh ? trunkMesh.count : 0;
+
+      console.log(`Instanced forest meshes in scene: ${forestMeshCount}`);
+      console.log(`Trunk instances: ${trunkInstances}`);
       console.log(`Trees in collision array: ${collisionTrees}`);
-      
-      // Check if counts are reasonably close
-      const maxDifference = Math.max(visualTrees, collisionTrees) * 0.1; // Allow 10% difference
-      const difference = Math.abs(visualTrees - collisionTrees);
-      
-      assert(difference <= maxDifference, 'Tree Count Consistency', 
-        difference <= maxDifference ? 
-        `Tree counts match within tolerance: ${visualTrees} visual, ${collisionTrees} collision` : 
-        `Tree counts differ too much: ${visualTrees} visual, ${collisionTrees} collision`);
+
+      assert(forestMeshCount >= 1, 'Instanced Forest Present',
+        forestMeshCount >= 1 ?
+        `Forest rendered as ${forestMeshCount} InstancedMesh(es)` :
+        'No forestInstanced meshes found in the scene');
+
+      // One trunk instance per placed tree → exact match with the collision array.
+      assert(trunkInstances === collisionTrees, 'Tree Count Consistency',
+        trunkInstances === collisionTrees ?
+        `Trunk instances exactly match collision trees: ${trunkInstances}` :
+        `Trunk instances (${trunkInstances}) differ from collision trees (${collisionTrees})`);
     }
     
     // Test 2: Extended Terrain Tree Collision

--- a/tests/e2e/perf-budget.spec.ts
+++ b/tests/e2e/perf-budget.spec.ts
@@ -14,30 +14,34 @@ import { gotoGame, startGame } from './helpers';
 // without value. WebKit/mobile keep owning the user-flow + touch specs.
 
 // --- Budget ceilings -------------------------------------------------------
-// Measured on Chromium (warm frame, 1280x720 viewport): calls 1783, triangles
-// ~105k, geometries 111, textures 11, programs 13. These are scene-dependent (the
-// same geometry the production bundle builds), not GPU/driver-dependent, so they
-// hold across Chromium builds. Ceilings are padded above those actuals as a
-// REGRESSION GUARD, not an aspirational target. Trees are still a Group-of-Mesh
-// per tree today (NOT InstancedMesh — src/mountains/trees.ts), so draw-call count
-// is inherently high; these pin "no worse than today" and tighten automatically
-// if instancing lands.
+// Measured on Chromium (warm frame, 1280x720 viewport, deterministic forest seed):
+// calls ~252, triangles ~176k, geometries 86, textures 11, programs 16. These are
+// scene-dependent (the same geometry the production bundle builds), not
+// GPU/driver-dependent, so they hold across Chromium builds. Ceilings are padded
+// above those actuals as a REGRESSION GUARD, not an aspirational target.
 //
-// calls/triangles are LOOSE catastrophe ceilings: frustum culling AND the
-// per-frame shadow-map pass make them swing frame-to-frame (measured peak ~2700
-// calls vs ~1800 steady), so a tight pin would flake. They still catch a
-// catastrophic blowup (losing geometry pooling / instancing would multiply trees
-// per-instance, easily 2x+). The TIGHT regression guards are
+// The forest is now InstancedMesh (src/mountains/trees.ts): the whole forest draws
+// as 5 InstancedMeshes (~5 colour + ~5 shadow draws) instead of a Group-of-~20-meshes
+// PER tree, which collapsed draw calls from ~2700 peak to ~252. So `calls` is now a
+// TIGHT regression guard: a revert to per-tree meshes would push it back into the
+// thousands, which the 800 ceiling flags immediately (was a loose 3500 when trees
+// were un-instanced).
+//
+// `triangles` stays a LOOSE ceiling: a forest-wide InstancedMesh has a huge bounding
+// sphere and effectively never frustum-culls, so every tree instance is always
+// rasterized (the documented instancing tradeoff — see trees.ts buildForest /
+// avalanche.ts:88). That raised triangles from ~125k (per-tree, culled) to ~176k,
+// still a small fraction of the rasterizer budget; the shadow pass also makes it
+// swing frame-to-frame, so a tight pin would flake. The other TIGHT guards are
 // geometries/textures/programs — trees.ts pools shared trunk/cone/branch
-// geometries+materials, so those live counts must NOT grow per object; a
-// regression back to per-tree geometry would push `geometries` from ~110 into the
-// hundreds, which the tight pin flags.
+// geometries+materials, so those live counts must NOT grow per object; a regression
+// back to per-tree geometry would push `geometries` from ~86 into the hundreds.
 const BUDGET = {
-  calls: 3500, // draw calls per frame (measured peak ~2700; loose catastrophe ceiling)
-  triangles: 350_000, // rasterized triangles per frame (measured peak ~125k; loose)
-  geometries: 130, // live BufferGeometry count (measured ~111; TIGHT — pooled, must stay bounded)
+  calls: 800, // draw calls per frame (measured peak ~252; TIGHT — instancing must hold)
+  triangles: 350_000, // rasterized triangles per frame (measured peak ~176k; loose — forest never culls)
+  geometries: 130, // live BufferGeometry count (measured ~86; TIGHT — pooled, must stay bounded)
   textures: 25, // live texture count (measured 11; TIGHT)
-  programs: 25, // compiled shader programs (measured 13; TIGHT — catches shader-compile blowups)
+  programs: 25, // compiled shader programs (measured 16; TIGHT — catches shader-compile blowups)
 };
 
 type PerfInfo = {

--- a/tests/trees-tests.js
+++ b/tests/trees-tests.js
@@ -123,6 +123,35 @@ async function main() {
     assert(positions2.length > 0, 're-init still returns tree positions');
   }
 
+  // --- Multi-scene teardown is scene-local (Codex review #221) -----------------
+  // addTrees must clear/dispose only the forest in the scene it is given. A second
+  // scene's addTrees must NOT remove or dispose the forest still live in the first
+  // scene. Listen for the InstancedMesh 'dispose' event on scene A's forest, then
+  // populate scene B and assert A was left untouched (the regression would no-op the
+  // remove against B but still dispose A's meshes, leaving disposed forest in A).
+  {
+    const sceneA = new THREE.Scene();
+    Trees.addTrees(sceneA);
+    const forestA = /** @type {any[]} */ (sceneA.children.filter(c => c.name === 'forestInstanced'));
+    assert(forestA.length >= 1, 'scene A gets its own forest', `${forestA.length} meshes`);
+
+    let sceneADisposed = false;
+    forestA.forEach(m => m.addEventListener('dispose', () => { sceneADisposed = true; }));
+
+    const sceneB = new THREE.Scene();
+    Trees.addTrees(sceneB);
+
+    assert(!sceneADisposed,
+      "addTrees on a second scene does not dispose the first scene's forest");
+    const forestAAfter = /** @type {any[]} */ (sceneA.children.filter(c => c.name === 'forestInstanced'));
+    assert(forestAAfter.length === forestA.length,
+      'first scene keeps its forest when a second scene is populated',
+      `${forestAAfter.length} meshes still in scene A`);
+    const forestB = /** @type {any[]} */ (sceneB.children.filter(c => c.name === 'forestInstanced'));
+    assert(forestB.length >= 1, 'second scene gets its own independent forest',
+      `${forestB.length} meshes`);
+  }
+
   console.log(`\n=================================`);
   console.log(`Trees tests completed: ${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);

--- a/tests/trees-tests.js
+++ b/tests/trees-tests.js
@@ -1,0 +1,134 @@
+// @ts-check
+/**
+ * Unit tests for the Trees module (src/mountains/trees.ts) after the forest was
+ * converted to InstancedMesh rendering (PR #221).
+ *
+ * The live game's `addTrees` instanced path is exercised by the browser/e2e suites,
+ * but the Group-returning `createTree` shim, the Object3D-emitting
+ * `addBranchesAtLayer`/`addSnowCaps` shims, the legacy palette materials they rebuild
+ * from, and the dispose-on-reinit teardown are not reachable from the running game
+ * (which only ever takes the instanced path). They ARE the public API surface other
+ * callers/headless consumers rely on, so this test drives them directly. Everything
+ * here is headless-safe: THREE constructs scene objects without a WebGL context, the
+ * terrain samplers are analytic, and the bark/foliage normal maps are null without a
+ * `document` (the instanced materials treat a null normalMap as no map).
+ *
+ * Node-only test in the CommonJS + dynamic-`import()` style of the other loader-based
+ * suites (terrain-tests.js, player-state-tests.js). Run with the .js -> .ts resolve
+ * hook so trees.ts's `./terrain.js` etc. imports resolve to their .ts siblings:
+ *   node --import ./tests/loaders/register-ts-resolve.mjs tests/trees-tests.js
+ */
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, name, message) {
+  if (cond) {
+    passed++;
+    console.log(`✅ PASS: ${name}${message ? ' - ' + message : ''}`);
+  } else {
+    failed++;
+    console.log(`❌ FAIL: ${name}${message ? ' - ' + message : ''}`);
+  }
+}
+
+async function main() {
+  const THREE = await import('three');
+  const { Trees } = await import('../src/trees.js');
+
+  // --- createTree shim: returns a real Group of individual Meshes --------------
+  // Exercises createTree -> collectTree/collectBranchesAtLayer/collectSnowCaps ->
+  // meshFromDesc, plus the legacy getTrunkMaterials/getFoliageMaterials/
+  // getSnowMaterial the rebuilt Meshes draw from.
+  {
+    const tree = Trees.createTree(1.0);
+    assert(tree instanceof THREE.Group, 'createTree returns a Group');
+    assert(tree.children.length > 3, 'createTree Group has the expected parts',
+      `${tree.children.length} child meshes`);
+    assert(tree.children.every(c => c instanceof THREE.Mesh),
+      'every createTree child is a Mesh');
+
+    const trunk = /** @type {any} */ (tree.children[0]);
+    assert(trunk && trunk.material && trunk.material.isMeshStandardMaterial,
+      'createTree trunk uses a shared MeshStandardMaterial');
+    assert(trunk.castShadow === true, 'createTree parts cast shadows');
+
+    // Scale variation is applied (canonical geometry resized, not duplicated).
+    const small = Trees.createTree(0.5);
+    assert(small instanceof THREE.Group && small.children.length > 0,
+      'createTree honours a scale argument');
+  }
+
+  // --- addBranchesAtLayer shim: appends branch meshes to a parent --------------
+  {
+    const parent = new THREE.Object3D();
+    Trees.addBranchesAtLayer(parent, new THREE.Vector3(0, 8, 0), 2.0);
+    assert(parent.children.length >= 3, 'addBranchesAtLayer appends branches',
+      `${parent.children.length} branches`);
+    assert(parent.children.every(c => c instanceof THREE.Mesh),
+      'addBranchesAtLayer children are Meshes');
+  }
+
+  // --- addSnowCaps shim: appends a snow cap (and sometimes patches) ------------
+  // Force the patch branch (Math.random() > 0.4) so the optional snow-patch loop is
+  // covered deterministically, then restore the RNG.
+  {
+    const tree = new THREE.Object3D();
+    const realRandom = Math.random;
+    Math.random = () => 0.99; // always take the patch branch, fixed sizes
+    try {
+      Trees.addSnowCaps(tree, 12, 1.0);
+    } finally {
+      Math.random = realRandom;
+    }
+    assert(tree.children.length >= 1, 'addSnowCaps appends a snow cap (+ patches)',
+      `${tree.children.length} snow meshes`);
+    assert(tree.children.every(c => c instanceof THREE.Mesh),
+      'addSnowCaps children are Meshes');
+  }
+
+  // --- addTrees: builds the instanced forest, rebuilds cleanly on re-init -------
+  {
+    const scene = new THREE.Scene();
+    const positions = Trees.addTrees(scene);
+    assert(Array.isArray(positions) && positions.length > 0,
+      'addTrees returns a non-empty treePositions array', `${positions.length} trees`);
+
+    const forest = /** @type {any[]} */ (scene.children.filter(c => c.name === 'forestInstanced'));
+    assert(forest.length >= 1 && forest.length <= 5,
+      'forest renders as a handful of InstancedMeshes', `${forest.length} meshes`);
+    assert(forest.every(m => m.isInstancedMesh), 'forest meshes are InstancedMeshes');
+
+    const trunk = forest.find(m => m.userData.forestPart === 'trunk');
+    assert(!!trunk, 'a trunk InstancedMesh is tagged via userData.forestPart');
+    // One trunk instance per placed tree — the exact contract the browser test checks.
+    assert(trunk && trunk.count === positions.length,
+      'trunk instance count equals treePositions.length',
+      trunk ? `${trunk.count} === ${positions.length}` : 'no trunk mesh');
+
+    // Tinted families carry per-instance colour; snow does not.
+    assert(trunk && trunk.instanceColor != null,
+      'trunk InstancedMesh has per-instance colour');
+    const snowCap = forest.find(m => m.userData.forestPart === 'snowCap');
+    assert(!snowCap || snowCap.instanceColor == null,
+      'snow caps use a shared white material (no instanceColor)');
+
+    // Re-init: a second addTrees must dispose the old forest and rebuild without
+    // accumulating duplicate InstancedMeshes in the scene (covers the teardown loop).
+    const positions2 = Trees.addTrees(scene);
+    const forest2 = /** @type {any[]} */ (scene.children.filter(c => c.name === 'forestInstanced'));
+    assert(forest2.length === forest.length,
+      're-init rebuilds the forest without duplicating instanced meshes',
+      `${forest2.length} meshes after re-init`);
+    assert(positions2.length > 0, 're-init still returns tree positions');
+  }
+
+  console.log(`\n=================================`);
+  console.log(`Trees tests completed: ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Trees test harness crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Trees were the last scenery holdout still assembling each tree as a `THREE.Group` of ~14–35 individual `Mesh` objects. The GPU **resource** pool (5 geometries, 19 materials, 2 normal maps) was already shared — but sharing a geometry/material does **not** merge draws, so a few-hundred-tree forest still issued **thousands of draw calls per frame**, doubled by the shadow pass. On weaker/mobile GPUs this was the dominant cost.

This renders the whole forest as **5 `InstancedMesh`es** (one per geometry), tinted per-instance via `setColorAt` from the existing HSL palettes — the textbook fix, and the pattern `avalanche.ts`/`snowtracks.ts` already use.

## Measured improvement (Chromium, deterministic forest seed, 1280×720)

| Metric | Before (per-tree Groups) | After (instanced) |
|---|---|---|
| **Draw calls (peak)** | ~2700 | **252** |
| Triangles (peak) | ~125k | ~176k¹ |
| Live geometries | ~111 | 86 |
| Compiled programs | 13 | 16 |

The forest collapses to exactly 5 InstancedMeshes: trunk **210** (= tree count), cone 811, branch 3255, snowCap 210, snowPatch 537 — **~5 colour + ~5 shadow draws** total instead of thousands.

¹ A forest-wide `InstancedMesh` has a huge bounding sphere and effectively never frustum-culls, so every tree instance is always rasterized (documented tradeoff — see `buildForest` / `avalanche.ts:88`). Triangles rise but stay a small fraction of the rasterizer budget; the net draw-call win dwarfs it.

## What changed

- **Colour palettes** extracted as `THREE.Color[]` (`getTrunkColors`/`getFoliageColors`) — the single source of truth feeding **both** the per-instance `setColorAt` tinting and the legacy palette materials.
- **3 white instanced materials** (bark/foliage + shared white snow), tinted per-instance via `instanceColor` (ColorManagement is off + output is LinearSRGB, so `setHSL` maps through unchanged → identical look).
- `createTree`/`addBranchesAtLayer`/`addSnowCaps` became **transform-emitting collectors** recording a world matrix (+ palette index) per part into per-geometry buckets, running the **same randomisation in the same order** (byte-identical RNG draws). `addTrees` collects every tree into one bucket set, then `buildForest` allocates the meshes.
- Thin **Group-/Object3D-returning shims** preserved for the `Trees` API contract & headless callers, rebuilt from the same collectors so the two paths cannot drift.
- **Scene cleanup + dispose**: keys off the tracked `forestInstanced` meshes (not Groups); `InstancedMesh.dispose()` frees only the per-forest `instanceMatrix`/`instanceColor` (pooled geometries/materials stay app-lifetime).

## Risk to gameplay: none

`treePositions` (the collision source of truth) and the physics kernel are **untouched** — trees are cosmetic, so collision and the **physics-invariant harness are unaffected**. No harness churn expected.

## Verification

- ✅ `npm run typecheck` (0 errors)
- ✅ `npm test` — full node suite (exit 0)
- ✅ `npm run test:tree-collision`, `test:contract`, `test:terrain`, `test:regression`
- ✅ Browser suite **95 passed / 0 failed**; all 7 tree tests green, incl. *"Forest rendered as 5 InstancedMesh(es)"* and *"Trunk instances exactly match collision trees: 227"*.

### Test updates
- Browser tree test now asserts **trunk-instance count == `treePositions.length`** (exact, replacing the old ±10% Group tally).
- e2e perf-budget tightens the draw-call ceiling **3500 → 800** (now a real instancing regression guard — a revert to per-tree meshes would blow back into the thousands) and documents the triangle tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEXz6xsSxFEq7d3LsbByg)_