### PR TITLE
Fixed-timestep accumulator in the run loop (determinism / frame-rate independence)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,24 +193,45 @@ is skipped (reproducing the original Loading/Get-Ready timing exactly) for the
 `?test=` suites (`window.isTestMode`), automated runs (`navigator.webdriver`), and
 `prefers-reduced-motion`; `?intro=force` / `?intro=off` override that for QA.
 
-Per-frame order in `animate(time)` (each step depends on the previous):
+**Fixed-timestep accumulator (`src/game/fixed-step.ts`).** The loop advances physics
+ONLY in fixed `FIXED_DT = 1/60` s steps, accumulating real frame time and draining it
+one fixed step at a time (`planFrameSteps`, capped at `MAX_SUBSTEPS = 8` per frame —
+the spiral-of-death guard, ~133 ms, the same ceiling as the old `min(delta, 0.1)`
+clamp). This makes the live game advance physics at exactly the rate the
+physics-invariant harness pins (it drives the kernel at `1/60`), so `dragFactor(60Hz)`
+collapses to an identity and the per-substep position step is `velocity / 60` —
+well under the 2.5u collision radius at any sane speed, so the tree-tunnelling and
+frame-rate-dependent terminal-speed bug class (#209) is closed by construction. The
+kernel (`snowman/physics.ts`) is unchanged; the accumulator lives entirely in
+`main-loop.ts`. The trajectory is frame-rate independent (30 / 50 / 144 / jittery FPS
+all trace the same fixed grid — gated by `tests/verification/fixed_timestep_harness.js`).
+
+Per-frame order in `animate(time)`:
 
 ```
-delta = min((time - lastTime)/1000, 0.1)        // clamp
-updateSnowman(delta)                             // input + physics → pos/velocity
-  Flex.update(...)                               // cosmetic flex (reads result only)
-  Sfx.jump()/land(force)/updateSkiing(...)       // SFX: takeoff/touchdown + wind/edge bed (reads result only)
-Snow.updateSnowflakes(...)
-snowTrails.update(delta, snowman, isInAir)       // carve/fade ski grooves (cosmetic, reads pos only)
-CourseModule.update(pos, elapsed, snowman)       // splits, progress HUD, ghost
-avalanche.trigger/update/checkBurial/hasPassed   // + EffectsModule.updateAvalanche + Sfx.setAvalanche
-Snow.updateSnowSplash(...)  (position restored after, so particles can't move player)
-updateCamera()                                   // cameraManager follows snowman
-updateTimerDisplay()
-shake = EffectsModule.tickCamera(camera, delta, speed)   // FOV + shake offset
-renderer.render(scene, camera)
-camera.position -= shake                          // revert so smoothing stays clean
+frameDelta = (time - lastTime)/1000                 // real elapsed; planFrameSteps caps it
+plan = planFrameSteps(accumulator, frameDelta)      // → { substeps, accumulator, alpha }
+for each of plan.substeps:  stepFixed()             // FIXED-GRID work (gates run outcome):
+  physicsStep(1/60)                                 //   input + kernel → pos/velocity
+  CourseModule.update(pos, elapsed, snowman)        //   splits/progress/ghost + finish line
+  avalanche.checkBurial(snowman.position)           //   burial = game over
+  Diag.record({dt: 1/60, ...})                      //   per-substep telemetry (tunnelRisk → 0)
+  (events justLanded/tookOff/landingQuality reduced across substeps — never dropped)
+renderFrame(frameDelta, result, events, alpha)      // ONCE PER FRAME (cosmetics; never physics):
+  applyObservers(...)                               //   HUD + Flex + SFX one-shots/bed + shake/toast
+  Snow.updateSnowflakes / snowTrails / Sky.update
+  avalanche.trigger/update/hasPassed                //   boulder advance + UI + Sfx.setAvalanche
+  Snow.updateSnowSplash(...)  (position restored after, so particles can't move player)
+  snowman.position = lerp(prevPos, curPos, alpha)   //   render interpolation (INTERPOLATE_RENDER)
+  updateCamera() / updateTimerDisplay()
+  shake = EffectsModule.tickCamera(camera, frameDelta, speed)
+  renderer.render(scene, camera);  camera.position -= shake;  restore authoritative pos
 ```
+
+`updateSnowman(delta)` is preserved as a backward-compatible single-step entry
+(`physicsStep` + `applyObservers` at the given delta) for the gameplay browser tests
+and the `window.updateSnowman` seam, which call it directly and expect one physics
+advance; the live loop uses `stepFixed` + `renderFrame` instead.
 
 ```
  input (Controls) ─┐

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,43 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Fixed-timestep accumulator in the run loop (determinism / frame-rate independence)
+- **The hot loop (`src/game/main-loop.ts`) now advances physics on a fixed `1/60` s
+  grid.** Previously `animate()` stepped the kernel once per render frame at a variable,
+  clamped `delta`. That re-exposed the #209 bug class on slow devices: a per-frame
+  position step `pos += velocity * delta` could exceed the 2.5u tree collision radius
+  (tunnelling straight through), and large-`dt` semi-implicit Euler diverged in
+  trajectory and landing timing. A new pure, DOM-free module **`src/game/fixed-step.ts`**
+  (`FIXED_DT = 1/60`, `MAX_SUBSTEPS = 8`, `planFrameSteps`) accumulates real frame time
+  and drains it one fixed step at a time; the loop runs `stepFixed()` 0..8 times per
+  frame and `renderFrame()` once.
+- **Why it's safe.** The physics kernel (`snowman/physics.ts`) is **unchanged** — the
+  accumulator lives entirely in the loop. The physics-invariant harness already drives
+  the kernel at `1/60`, so it stays byte-identical (it's the proof the kernel didn't
+  move); `dragFactor(60Hz)` collapses to an identity at the fixed step. The live game
+  now advances physics at exactly the rate the suite pins.
+- **Split physics from cosmetics.** `stepFixed()` runs only what gates run outcome (the
+  kernel step, course progress + finish, avalanche **burial**, per-substep diagnostics);
+  `renderFrame()` runs the per-frame observer/cosmetic layer (HUD, flex, SFX, snow, sky,
+  avalanche advance/UI, interpolated camera, render) on the real frame delta. Per-substep
+  **events** (`justLanded`, the ground→air takeoff edge, `landingQuality`) are reduced
+  across a frame's substeps so a jump/land completed mid-frame still fires its
+  whoosh/thump/toast/shake exactly once. Render interpolation (`alpha`) places the
+  snowman between the last two fixed states so motion stays smooth on panels whose
+  refresh doesn't divide 60 (144 Hz, 50 Hz); the physics state stays authoritative.
+- **`updateSnowman(delta)` preserved.** The gameplay browser tests and the
+  `window.updateSnowman` seam call it directly with an explicit delta and expect one
+  physics advance + the observer layer; it now composes the same shared `physicsStep` +
+  `applyObservers` helpers, so its behaviour is unchanged while the live loop uses the
+  accumulator.
+- **Tests.** New `tests/verification/fixed_timestep_harness.js` (wired into
+  `npm run test:stress`) drives the LOOP (not the kernel) at 30 / 50 / 144 / jittery FPS
+  and asserts the trajectory is byte-identical to the `1/60` reference (the variable-dt
+  loop drifts ~26u), that diagnostics reports **zero** `tunnelRisk` frames where a
+  high-speed variable-dt step reports many, and that one huge frame is capped at
+  `MAX_SUBSTEPS` with the accumulator left `< FIXED_DT`. The invariant/stress harnesses
+  and the 95-test browser suite stay green.
+
 ### Three.js rendering perf: shared tree geometry/material pools + renderer tuning
 - **Trees (`src/mountains/trees.ts`) were the forest's odd one out.** The avalanche
   boulders and ski tracks already share a single geometry/material, but each of the

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",
-    "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/avalanche_framerate_harness.js",
+    "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/avalanche_framerate_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/fixed_timestep_harness.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -75,8 +75,11 @@ export const FPS_BANDS: FpsBand[] = [
 ];
 
 export interface DiagConfig {
-  /** The run-loop's delta clamp (main-loop caps delta at 0.1 s). A frame whose dt sits
-   *  at the cap means the device dropped to/below 1/cap FPS — the regime the bug bit. */
+  /** Legacy per-frame delta clamp (the pre-accumulator loop used min(delta, 0.1)). Since
+   *  the fixed-timestep refactor the loop records one sample PER FIXED SUBSTEP at
+   *  FIXED_DT (1/60 s), so live samples never sit at this cap — tunnelRisk is now zero by
+   *  construction. Kept for the headless harnesses that still feed variable dt directly,
+   *  and as the "device below 1/cap FPS" threshold for those. */
   frameCapSec: number;
   /** Smallest obstacle collision radius the discrete point-vs-disk check guards (trees
    *  use 2.5). A per-frame step >= this could skip the disk entirely → tunnel risk. */

--- a/src/game/fixed-step.ts
+++ b/src/game/fixed-step.ts
@@ -1,0 +1,87 @@
+// fixed-step.ts — the fixed-timestep accumulator at the heart of the main loop's
+// determinism / frame-rate-independence refactor.
+//
+// WHY THIS EXISTS
+// ---------------
+// The physics kernel (snowman/physics.ts) integrates with semi-implicit Euler and a
+// per-frame drag factor re-derived to 60 Hz. At a *variable* render delta two things
+// drift with frame rate (the #209 bug class diagnostics.ts watches live):
+//   1. the per-frame position step `pos += velocity * dt` can exceed an obstacle's
+//      collision radius (2.5u) at low FPS, so the discrete point-vs-disk check is
+//      skipped entirely — the "floor it forward and tunnel through the trees" bug;
+//   2. large-dt Euler diverges from small-dt in trajectory and landing timing.
+//
+// The fix is to advance physics ONLY ever in fixed 1/60 s steps, regardless of the
+// render rate, accumulating real frame time and draining it one fixed step at a time.
+// Then the per-step displacement is `velocity / 60` (well under 2.5u at any sane
+// speed) and tunnel risk goes to zero by construction. 1/60 s is exactly the dt the
+// physics-invariant harness pins (it drives the kernel directly at 1/60), so the live
+// game advances physics at the same rate the suite tests — the thing tested becomes
+// the thing that runs, and `dragFactor(60Hz)` collapses to an identity.
+//
+// This module is the pure, DOM-free seam: `planFrameSteps` decides how many fixed
+// substeps a render frame's elapsed time should run and how much leftover to carry.
+// main-loop.ts wires it to the real kernel + cosmetics; the frame-rate-equivalence
+// harness drives the same function against the kernel to prove the trajectory is
+// frame-rate independent.
+
+/** The fixed physics step. Equals the dt the physics-invariant harness pins, so the
+ *  live loop advances the kernel at exactly the tested rate. */
+export const FIXED_DT = 1 / 60;
+
+/** Spiral-of-death guard: the most fixed steps a single slow render frame may run
+ *  (~133 ms of physics). Beyond this the game slows down rather than tunnelling —
+ *  the same ceiling the old `Math.min(delta, 0.1)` clamp imposed (0.1 s ≈ 6 steps),
+ *  expressed as a step count and with no tunnelling. A strictly better failure mode. */
+export const MAX_SUBSTEPS = 8;
+
+/** How a render frame's elapsed time maps onto the fixed grid. */
+export interface FrameStepPlan {
+  /** Number of fixed physics substeps to run this frame. */
+  substeps: number;
+  /** Leftover accumulator (< FIXED_DT under the maintained invariant) carried to the
+   *  next frame. */
+  accumulator: number;
+  /** Render-interpolation factor in [0, 1): how far between the last two fixed states
+   *  the render should sit (`leftover / FIXED_DT`). */
+  alpha: number;
+}
+
+/**
+ * Plan a render frame's fixed substeps. Adds the (ceiling-capped) frame delta to the
+ * carried accumulator, then drains whole fixed steps up to MAX_SUBSTEPS.
+ *
+ * The frame delta is capped at `maxSubsteps * fixedDt` BEFORE accumulating, which is
+ * the spiral-of-death guard: a long pause (tab backgrounded, GC hitch) can never queue
+ * an unbounded number of physics steps. Because a normal frame always drains the
+ * accumulator below `fixedDt`, the carried accumulator stays < fixedDt by induction, so
+ * `alpha` stays in [0, 1).
+ *
+ * Pure and DOM-free so the loop and the frame-rate-equivalence harness share the exact
+ * same stepping discipline.
+ */
+export function planFrameSteps(
+  accumulator: number,
+  frameDeltaSec: number,
+  fixedDt: number = FIXED_DT,
+  maxSubsteps: number = MAX_SUBSTEPS,
+): FrameStepPlan {
+  // Guard against a non-finite / negative frame delta (e.g. a clock anomaly) so a
+  // single bad frame can never poison the accumulator.
+  const safeDelta = Number.isFinite(frameDeltaSec) && frameDeltaSec > 0 ? frameDeltaSec : 0;
+  const capped = Math.min(safeDelta, maxSubsteps * fixedDt);
+  let acc = accumulator + capped;
+  let substeps = 0;
+  while (acc >= fixedDt && substeps < maxSubsteps) {
+    acc -= fixedDt;
+    substeps++;
+  }
+  const alpha = fixedDt > 0 ? Math.min(acc / fixedDt, 1) : 0;
+  return { substeps, accumulator: acc, alpha };
+}
+
+/** Linear interpolation, used to render the player/camera between the last two fixed
+ *  physics states (removes temporal aliasing on panels whose rate doesn't divide 60). */
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -1,9 +1,26 @@
-// Per-frame run loop for SnowGlider: physics step + HUD, camera follow, the
-// requestAnimationFrame loop (course progress, avalanche, snow splash, camera juice,
-// render), and the window-resize handler. Extracted from snowglider.ts as
-// `createMainLoop(deps)`; the coordinator injects the constructed scene handles +
-// run/player state and re-publishes `updateSnowman`/`updateCamera` on `window`.
-// Mechanical move — per-frame ordering and behavior are unchanged.
+// Per-frame run loop for SnowGlider. Restructured around a FIXED-TIMESTEP ACCUMULATOR
+// (see game/fixed-step.ts): physics only ever advances in fixed 1/60 s substeps,
+// while cosmetics/observers run once per render frame on the real frame delta. This
+// closes the frame-rate-dependence bug class (#209) — tunnelling and divergent
+// terminal behaviour at low FPS — by construction, and makes the live build advance
+// physics at exactly the rate the physics-invariant harness pins. The physics kernel
+// (snowman/physics.ts) is UNCHANGED; the accumulator lives entirely here.
+//
+// Three responsibilities are kept distinct:
+//   - stepFixed(dt)   — the fixed-grid work that gates run outcome: the physics step,
+//                       collision (inside the kernel), course progress + finish, and
+//                       avalanche burial. Runs 0..MAX_SUBSTEPS times per frame.
+//   - renderFrame(..) — the per-frame cosmetic/observer layer: HUD, flex, SFX, snow,
+//                       sky, avalanche advance/UI, camera, render. Runs once per frame
+//                       on the real frame delta and never affects the physics state.
+//   - updateSnowman(delta) — a backward-compatible single-step entry (physics step +
+//                       observer layer) preserved for the gameplay browser tests and
+//                       the `window.updateSnowman` seam, which call it directly with an
+//                       explicit delta and expect one physics advance.
+//
+// Extracted from snowglider.ts as `createMainLoop(deps)`; the coordinator injects the
+// constructed scene handles + run/player state and re-publishes
+// `updateSnowman`/`updateCamera` on `window`.
 
 import { Controls } from '../controls.js';
 import { Snow } from '../snow.js';
@@ -15,7 +32,9 @@ import { Sfx } from '../sfx.js';
 import { Diag } from '../diagnostics.js';
 import { EffectsModule, type ShakeOffset } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
+import type { LandingQuality, UpdateResult } from '../snowman.js';
 import { updateStatsHud, updateTimerDisplay } from '../ui/hud.js';
+import { FIXED_DT, MAX_SUBSTEPS, lerp, planFrameSteps } from './fixed-step.js';
 import { AVALANCHE_TRIGGER_DISTANCE, type SceneContext } from './scene-setup.js';
 
 export interface MainLoopDeps extends
@@ -23,6 +42,27 @@ export interface MainLoopDeps extends
     'snowman' | 'snowSplash' | 'treePositions' | 'rockPositions'> {
   player: PlayerState;
   showGameOver: (reason: string) => void;
+}
+
+// Render the player/camera between the last two fixed physics states (alpha in [0,1)),
+// removing temporal aliasing on panels whose refresh doesn't divide 60 (144 Hz, 50 Hz).
+// Physics state stays authoritative on the fixed grid; only the rendered transform is
+// interpolated. Flip to false to render the latest fixed state directly (minor stutter
+// on non-60 panels, ~1 fixed step less visual latency) — a one-line switch, per the plan.
+const INTERPOLATE_RENDER = true;
+
+/** Events that can fire on ANY substep within a render frame. Reduced across the
+ *  frame's substeps so a jump/land that completes mid-frame is never dropped (its
+ *  whoosh/thump/toast/shake), then consumed once in renderFrame. */
+interface FrameEvents {
+  tookOff: boolean;                       // ground->air edge seen on some substep
+  justLanded: boolean;                    // a landing occurred on some substep
+  landingForce: number;                   // force of that landing (for SFX + shake)
+  landingQuality: LandingQuality | null;  // grade of a *manual*-jump landing (toast)
+}
+
+function freshFrameEvents(): FrameEvents {
+  return { tookOff: false, justLanded: false, landingForce: 0, landingQuality: null };
 }
 
 export function createMainLoop(deps: MainLoopDeps) {
@@ -34,24 +74,34 @@ export function createMainLoop(deps: MainLoopDeps) {
   const pos = player.pos;
   const velocity = player.velocity;
 
-  // Previous-frame air state, so we can fire a takeoff whoosh on the ground→air
+  // Previous-substep air state, so we can fire a takeoff whoosh on the ground->air
   // transition (the kernel's UpdateResult exposes justLanded but no justJumped).
+  // Tracked across substeps (not just frames) so an in-frame takeoff still registers.
   let prevInAir = false;
 
-  // --- Update Snowman: Physics-based Movement ---
-  function updateSnowman(delta: number) {
-    // We no longer need to add test hooks every frame as they're set up at initialization
-    // and after resets. This improves performance.
+  // Fixed-timestep accumulator state. `accumulator` carries leftover real time between
+  // frames; prev/curPos hold the last two fixed physics positions for render
+  // interpolation. Seeded from the spawn position so a frame with zero substeps (high
+  // refresh rate) renders the player exactly at rest.
+  let accumulator = 0;
+  const prevPos = { x: pos.x, y: pos.y, z: pos.z };
+  const curPos = { x: pos.x, y: pos.y, z: pos.z };
+
+  // --- Physics advance for one step at `dt` (shared by the fixed loop + the
+  // backward-compatible updateSnowman entry). Runs the unchanged kernel via
+  // Physics.stepPlayer, reduces the per-step events into `events`, and tracks the
+  // air-state edge. Returns the per-step result for the HUD / camera. ---
+  function physicsStep(dt: number, events: FrameEvents): UpdateResult {
     const activeShowGameOver = typeof window.showGameOver === 'function'
       ? window.showGameOver
       : showGameOver;
 
-    // Advance the player one frame. Physics.stepPlayer wraps Snowman.updateSnowman
-    // (the unchanged physics kernel) and writes the mutated scalars back into the
-    // typed `player` state, returning the per-frame result for the HUD/camera.
+    // Advance the player one fixed step. Physics.stepPlayer wraps Snowman.updateSnowman
+    // (the unchanged physics kernel) and writes the mutated scalars back into the typed
+    // `player` state, returning the per-step result.
     const result = Physics.stepPlayer(player, {
       snowman,
-      delta,
+      delta: dt,
       controls: Controls.getControls(),
       getTerrainHeight: Snow.getTerrainHeight,
       getTerrainGradient: Snow.getTerrainGradient,
@@ -66,54 +116,231 @@ export function createMainLoop(deps: MainLoopDeps) {
       bankAirScore: (points: number) => { if (CourseModule) CourseModule.addAirScore(points); }
     });
 
-    // Update game stats display (speed/altitude/slope/technique). The slope
-    // readout is the terrain steepness under the player: gradient magnitude
-    // (rise/run = tan θ), the same measure the terrain code uses for placement.
+    // Reduce the substep's events into the frame aggregate (§5): events can fire on any
+    // substep, so OR/accumulate them rather than reading only the last substep's result.
+    if (result.isInAir && !prevInAir) events.tookOff = true; // ground->air edge within substeps
+    if (result.justLanded) {
+      events.justLanded = true;
+      events.landingForce = result.landingForce;
+    }
+    if (result.landingQuality) events.landingQuality = result.landingQuality;
+    prevInAir = result.isInAir;
+
+    return result;
+  }
+
+  // --- The per-frame cosmetic/observer layer that reads the physics result but never
+  // mutates physics state (HUD, camera shake, landing toast, flex, SFX). Shared by the
+  // render frame and the backward-compatible updateSnowman entry. `frameDelta` is the
+  // real render delta (cosmetics are smoothing-based and run on wall-clock time). ---
+  function applyObservers(frameDelta: number, result: UpdateResult, events: FrameEvents): void {
+    // Update game stats display (speed/altitude/slope/technique). The slope readout is
+    // the terrain steepness under the player: gradient magnitude (rise/run = tan θ).
     const grad = Snow.getTerrainGradient(pos.x, pos.z);
     const slopeRatio = Math.sqrt(grad.x * grad.x + grad.z * grad.z);
     updateStatsHud(result, pos, player.isInAir, slopeRatio);
 
-    // Camera shake on a meaningful landing (scales with time spent aloft).
-    if (result.justLanded && result.landingForce > 0.25 && EffectsModule) {
-      EffectsModule.addShake(Math.min(1.2, result.landingForce * 0.6));
+    // Camera shake on a meaningful landing (scales with time spent aloft). Fired once
+    // per frame from the aggregated event so a landing on substep 2 of 3 still shakes.
+    if (events.justLanded && events.landingForce > 0.25 && EffectsModule) {
+      EffectsModule.addShake(Math.min(1.2, events.landingForce * 0.6));
     }
 
-    // Meaningful jumps (#47): on a graded *manual*-jump landing, toast the air time
-    // + grade. landingQuality is non-null only for a player-initiated jump, so
-    // auto-jumps / hop turns / coasting never toast. (The air score itself is banked
-    // inside the step via bankAirScore above, so a finish-frame jump still counts.)
-    if (result.justLanded && result.landingQuality && CourseModule) {
-      CourseModule.flashAir(result.landingQuality, result.landingForce);
+    // Meaningful jumps (#47): on a graded *manual*-jump landing, toast the air time +
+    // grade. landingQuality is non-null only for a player-initiated jump, so auto-jumps
+    // / hop turns / coasting never toast. (The air score itself is banked inside the
+    // step via bankAirScore, so a finish-frame jump still counts.)
+    if (events.justLanded && events.landingQuality && CourseModule) {
+      CourseModule.flashAir(events.landingQuality, events.landingForce);
     }
 
-    // Cosmetic flexibility / jiggle (issue #53). Purely visual: runs AFTER the physics
-    // kernel so it can read the per-frame result, and only writes child-mesh transforms —
-    // it never touches pos/velocity, so the physics-invariant harness is unaffected.
+    // Cosmetic flexibility / jiggle (issue #53). Purely visual: only writes child-mesh
+    // transforms — it never touches pos/velocity, so the physics-invariant harness is
+    // unaffected. Runs on the real frame delta (smoothing-based).
     const flexSpeed = result.currentSpeed;
-    Flex.update(snowman, delta, {
+    Flex.update(snowman, frameDelta, {
       speed: flexSpeed,
       technique: result.technique,
       turnRate: flexSpeed > 1e-3 ? velocity.x / flexSpeed : 0, // zero-speed guard (no 0/0 NaN)
-      justLanded: result.justLanded,
-      landingForce: result.landingForce,
+      justLanded: events.justLanded,
+      landingForce: events.landingForce,
       isInAir: player.isInAir
     });
 
-    // Sound effects (issue #158): a takeoff whoosh on the ground→air transition, a
-    // touchdown thump scaled by air time, and the continuous wind + ski-edge bed.
-    // Reads the per-frame result only — never pos/velocity — so the physics-invariant
-    // harness is unaffected, and every call is a no-op until the SFX context is
-    // unlocked by the start gesture.
-    if (result.isInAir && !prevInAir) Sfx.jump();
-    if (result.justLanded) Sfx.land(result.landingForce);
-    prevInAir = result.isInAir;
+    // Sound effects (issue #158): a takeoff whoosh on the ground->air transition, a
+    // touchdown thump scaled by air time, and the continuous wind + ski-edge bed. The
+    // one-shots fire from the aggregated events so a jump/land completed mid-frame isn't
+    // dropped; the continuous bed reads the latest substep's result. Reads the result
+    // only — never pos/velocity — and is a no-op until the SFX context is unlocked.
+    if (events.tookOff) Sfx.jump();
+    if (events.justLanded) Sfx.land(events.landingForce);
     Sfx.updateSkiing(result.currentSpeed, result.technique, result.isInAir);
+  }
 
-    // Frame-rate / physics telemetry (diagnostics.ts). READ-ONLY observer, wired in
-    // beside Sfx/Flex: it reads the per-frame result + pos only and never touches
-    // pos/velocity, so the physics-invariant harness is unaffected and it is a no-op
-    // under automation. It watches the dt the real device produces and the speed/step
-    // that ride on it, surfacing the frame-rate-dependence bug class (#209) live.
+  // --- One FIXED physics substep: the kernel advance plus the fixed-grid work that
+  // gates run outcome (course progress + finish, avalanche burial) and the per-step
+  // diagnostics sample. Anything that could be MISSED between frames belongs here, on
+  // the fixed grid; cosmetics run once per frame in renderFrame. ---
+  function stepFixed(events: FrameEvents): UpdateResult {
+    const result = physicsStep(FIXED_DT, events);
+
+    // --- Course progress: split timing, progress HUD, ghost racing, finish line. ---
+    // On the fixed grid so a gate / finish can't be skipped between render frames.
+    if (CourseModule) {
+      const elapsed = (performance.now() - state.startTime) / 1000;
+      CourseModule.update(pos, elapsed, snowman);
+    }
+
+    // --- Avalanche burial check (game-over). On the fixed grid: the player advances in
+    // fixed steps, so a burial can't be tunnelled past between render frames. Boulder
+    // advance + UI stay in renderFrame (cosmetic / proximity readout). ---
+    const avalanche = state.avalanche;
+    if (avalanche && avalanche.checkBurial(snowman.position)) {
+      const activeShowGameOver = typeof window.showGameOver === 'function'
+        ? window.showGameOver
+        : showGameOver;
+      activeShowGameOver("Buried by avalanche!");
+    }
+
+    // Frame-rate / physics telemetry (diagnostics.ts). READ-ONLY observer: reads the
+    // per-step result + pos only and never touches pos/velocity. Recorded PER FIXED
+    // SUBSTEP at FIXED_DT, so the step it measures is `velocity / 60` and tunnelRisk
+    // frames go to zero by construction regardless of render rate (#209). A no-op under
+    // automation.
+    Diag.record({
+      dt: FIXED_DT,
+      speed: result.currentSpeed,
+      x: pos.x,
+      z: pos.z,
+      technique: result.technique,
+      isInAir: player.isInAir,
+    });
+
+    return result;
+  }
+
+  // --- The per-render-frame layer: cosmetics/observers, avalanche advance/UI, the
+  // interpolated camera follow, camera juice, and the render. Runs once per frame on
+  // the real `frameDelta`; `alpha` is the render-interpolation factor. ---
+  function renderFrame(frameDelta: number, result: UpdateResult, events: FrameEvents, alpha: number): void {
+    // HUD / flex / SFX / landing toast / shake (reads the physics result; never writes it).
+    applyObservers(frameDelta, result, events);
+
+    // Keep the rendered transform authoritative (= latest fixed state) for the snow /
+    // avalanche logic below, in case the previous frame left an interpolated value on it.
+    snowman.position.set(curPos.x, curPos.y, curPos.z);
+
+    Snow.updateSnowflakes(frameDelta, pos, scene);
+
+    // Dynamic ski trails / snow accumulation (#17): carve fading grooves behind the
+    // skis that fresh snow covers back over. Purely cosmetic — reads position only.
+    state.snowTrails?.update(frameDelta, snowman, player.isInAir);
+
+    // Advance the golden-hour<->midday sun cycle (sun position/colour, sky exposure,
+    // fog). Purely atmospheric; a no-op under reduced motion. (#163)
+    Sky.update(frameDelta);
+
+    // --- Avalanche advance + UI (boulder physics, banner, proximity meter, rumble).
+    // The burial check that gates game-over runs on the fixed grid (stepFixed); this is
+    // the cosmetic/advance half. ---
+    const avalanche = state.avalanche;
+    if (avalanche) {
+      // Trigger avalanche based on distance traveled (simple geometric trigger).
+      // Player starts at z=-15 and moves in -Z direction (downhill).
+      const distanceTraveled = state.lastAvalancheZ - pos.z;
+
+      if (!state.avalancheTriggered && distanceTraveled > AVALANCHE_TRIGGER_DISTANCE) {
+        avalanche.trigger(snowman.position);
+        state.avalancheTriggered = true;
+        console.log("Avalanche triggered! Distance traveled:", distanceTraveled.toFixed(1));
+      }
+
+      // Update avalanche physics (cosmetic boulders; burial already checked per substep).
+      avalanche.update(frameDelta);
+
+      // Reset avalanche if it has passed the player (survived!)
+      if (state.avalancheTriggered && avalanche.hasPassed(snowman.position)) {
+        console.log("Avalanche passed - player survived!");
+        avalanche.reset();
+        state.avalancheTriggered = false;
+        state.lastAvalancheZ = pos.z; // Reset trigger point for potential next avalanche
+      }
+
+      // Telegraph the threat: banner, "distance behind you" meter, vignette, shake.
+      if (EffectsModule) {
+        const avActive = state.avalancheTriggered && avalanche.active;
+        const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
+        EffectsModule.updateAvalanche(avActive, avDist);
+        // Avalanche rumble crescendos with the same proximity the banner uses (#158).
+        Sfx.setAvalanche(avActive, avDist);
+      }
+    }
+
+    // Save player position before snow splash effect updates.
+    const playerPosBefore = {
+      x: snowman.position.x,
+      y: snowman.position.y,
+      z: snowman.position.z
+    };
+
+    // Update snow splash particles - pass all required parameters.
+    Snow.updateSnowSplash(snowSplash, frameDelta, snowman, velocity, player.isInAir, scene);
+
+    // Ensure snowman position wasn't affected by particles.
+    snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
+
+    // Render interpolation: place the snowman between the last two fixed physics states
+    // so motion stays smooth on panels whose refresh doesn't divide 60. The physics
+    // state itself stays authoritative on the fixed grid; we restore it after rendering.
+    if (INTERPOLATE_RENDER && alpha > 0) {
+      snowman.position.set(
+        lerp(prevPos.x, curPos.x, alpha),
+        lerp(prevPos.y, curPos.y, alpha),
+        lerp(prevPos.z, curPos.z, alpha),
+      );
+    }
+
+    updateCamera();
+    updateTimerDisplay(state.gameActive, state.startTime); // Update the timer display
+
+    // Camera juice: speed-based FOV + shake. Apply for the render only, then revert the
+    // positional offset so the camera manager's own smoothing stays clean.
+    let _shake: ShakeOffset | null = null;
+    if (EffectsModule) {
+      const spd = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
+      _shake = EffectsModule.tickCamera(camera, frameDelta, spd);
+    }
+    renderer.render(scene, camera);
+    if (_shake) {
+      camera.position.x -= _shake.x;
+      camera.position.y -= _shake.y;
+      camera.position.z -= _shake.z;
+    }
+
+    // Restore the authoritative (latest fixed) position so physics reads and the next
+    // frame's prevPos capture are never seeded from the interpolated render transform.
+    if (INTERPOLATE_RENDER && alpha > 0) {
+      snowman.position.set(curPos.x, curPos.y, curPos.z);
+    }
+  }
+
+  // --- Backward-compatible single-step entry. The gameplay browser tests and the
+  // `window.updateSnowman` seam call this directly with an explicit delta and expect
+  // ONE physics advance plus the observer layer (HUD/flex/SFX/shake/toast) — the
+  // pre-accumulator behaviour. It deliberately does NOT run course / avalanche / camera
+  // / render (those lived in the animation loop, not in updateSnowman), so the test
+  // semantics are unchanged. The live loop uses stepFixed + renderFrame instead. ---
+  function updateSnowman(delta: number) {
+    if (!window.testHooks) {
+      console.log("Test hooks missing, reinstalling");
+      Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
+    }
+    const events = freshFrameEvents();
+    const result = physicsStep(delta, events);
+    applyObservers(delta, result, events);
+
+    // Diagnostics parity with the pre-refactor single-step path (a no-op under
+    // automation, where these tests run). The live loop records per fixed substep.
     Diag.record({
       dt: delta,
       speed: result.currentSpeed,
@@ -122,8 +349,6 @@ export function createMainLoop(deps: MainLoopDeps) {
       technique: result.technique,
       isInAir: player.isInAir,
     });
-
-    // Update timer in the updateTimerDisplay function which is called separately
   }
 
   // --- Update Camera: Follow the Snowman ---
@@ -139,117 +364,63 @@ export function createMainLoop(deps: MainLoopDeps) {
 
   // --- Animation Loop ---
   let lastTime = 0;
+  // The most recent per-step result, retained so a render frame that ran zero physics
+  // substeps (refresh rate above 60 Hz) can still drive the cosmetic layer.
+  let lastResult: UpdateResult | null = null;
   function animate(time: number) {
     if (state.gameActive) {
       requestAnimationFrame(animate);
-      const delta = Math.min((time - lastTime) / 1000, 0.1); // Cap delta to avoid jumps
+      // Real elapsed render time. planFrameSteps caps it at MAX_SUBSTEPS * FIXED_DT
+      // (the spiral-of-death guard, ~133 ms — the same ceiling as the old 0.1 s clamp).
+      const frameDelta = (time - lastTime) / 1000;
       lastTime = time;
 
-      // Only set up test hooks if they're missing
+      // Only set up test hooks if they're missing.
       if (!window.testHooks) {
         console.log("Test hooks missing in animation loop, reinstalling");
-        // addTestHooks(pos, showGameOver, getTerrainHeight) — matches the two other
-        // call sites; the stray `gameActive` arg here was a latent bug (it landed in
-        // the getTerrainHeight slot), surfaced by the type-checker.
         Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
       }
 
-      updateSnowman(delta);
-      Snow.updateSnowflakes(delta, pos, scene);
-
-      // Dynamic ski trails / snow accumulation (#17): carve fading grooves behind
-      // the skis that fresh snow covers back over. Purely cosmetic — reads position
-      // only, never the physics state.
-      state.snowTrails?.update(delta, snowman, player.isInAir);
-
-      // Advance the golden-hour↔midday sun cycle (sun position/colour, sky
-      // exposure, fog). Purely atmospheric; a no-op under reduced motion. (#163)
-      Sky.update(delta);
-
-      // --- Course progress: split timing, progress HUD, ghost racing ---
-      if (CourseModule) {
-        const elapsed = (performance.now() - state.startTime) / 1000;
-        CourseModule.update(pos, elapsed, snowman);
+      // Advance physics on the FIXED grid: drain whole 1/60 s steps from the
+      // accumulator. Events are reduced across the frame's substeps so a jump/land that
+      // completes mid-frame still fires its SFX/toast/shake exactly once in renderFrame.
+      const plan = planFrameSteps(accumulator, frameDelta, FIXED_DT, MAX_SUBSTEPS);
+      accumulator = plan.accumulator;
+      const events = freshFrameEvents();
+      let result: UpdateResult | null = null;
+      for (let i = 0; i < plan.substeps; i++) {
+        // Snapshot the pre-step position for render interpolation, then advance.
+        prevPos.x = curPos.x; prevPos.y = curPos.y; prevPos.z = curPos.z;
+        result = stepFixed(events);
+        curPos.x = pos.x; curPos.y = pos.y; curPos.z = pos.z;
+        // A finish / crash / burial during a substep stops the run — drop the remaining
+        // substeps so we don't keep stepping a dead run (matches the old single-step
+        // loop, which advanced once per frame and checked gameActive next frame).
+        if (!state.gameActive) break;
       }
 
-      // --- Avalanche Logic ---
-      const avalanche = state.avalanche;
-      if (avalanche) {
-        // Trigger avalanche based on distance traveled (simple geometric trigger)
-        // Player starts at z=-15 and moves in -Z direction (downhill)
-        const distanceTraveled = state.lastAvalancheZ - pos.z;
-
-        if (!state.avalancheTriggered && distanceTraveled > AVALANCHE_TRIGGER_DISTANCE) {
-          avalanche.trigger(snowman.position);
-          state.avalancheTriggered = true;
-          console.log("Avalanche triggered! Distance traveled:", distanceTraveled.toFixed(1));
-        }
-
-        // Update avalanche physics
-        avalanche.update(delta);
-
-        // Check for burial (collision with avalanche)
-        if (avalanche.checkBurial(snowman.position)) {
-          showGameOver("Buried by avalanche!");
-        }
-
-        // Reset avalanche if it has passed the player (survived!)
-        if (state.avalancheTriggered && avalanche.hasPassed(snowman.position)) {
-          console.log("Avalanche passed - player survived!");
-          avalanche.reset();
-          state.avalancheTriggered = false;
-          state.lastAvalancheZ = pos.z; // Reset trigger point for potential next avalanche
-        }
-
-        // Telegraph the threat: banner, "distance behind you" meter, vignette, shake.
-        if (EffectsModule) {
-          const avActive = state.avalancheTriggered && avalanche.active;
-          const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
-          EffectsModule.updateAvalanche(avActive, avDist);
-          // Avalanche rumble crescendos with the same proximity the banner uses (#158).
-          Sfx.setAvalanche(avActive, avDist);
-        }
-      }
-
-      // Save player position before snow splash effect updates
-      const playerPosBefore = {
-        x: snowman.position.x,
-        y: snowman.position.y,
-        z: snowman.position.z
-      };
-
-      // Update snow splash particles - pass all required parameters
-      Snow.updateSnowSplash(snowSplash, delta, snowman, velocity, player.isInAir, scene);
-
-      // Ensure snowman position wasn't affected by particles
-      snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
-
-      updateCamera();
-      updateTimerDisplay(state.gameActive, state.startTime); // Update the timer display
-
-      // Camera juice: speed-based FOV + shake. Apply for the render only, then revert
-      // the positional offset so the camera manager's own smoothing stays clean.
-      let _shake: ShakeOffset | null = null;
-      if (EffectsModule) {
-        const spd = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
-        _shake = EffectsModule.tickCamera(camera, delta, spd);
-      }
-      renderer.render(scene, camera);
-      if (_shake) {
-        camera.position.x -= _shake.x;
-        camera.position.y -= _shake.y;
-        camera.position.z -= _shake.z;
-      }
+      // Render once per frame on the real delta. If zero substeps ran this frame (high
+      // refresh rate), reuse the latest result so the HUD/cosmetics still update; the
+      // physics state is unchanged so this is purely a redraw.
+      if (!result) result = lastResult;
+      if (result) renderFrame(frameDelta, result, events, plan.alpha);
+      lastResult = result;
     } else if (state.animationRunning) {
       state.animationRunning = false;
     }
   }
 
   // Seed the frame clock and kick the loop. Replaces the lifecycle sites' previous
-  // `lastTime = performance.now(); animate(lastTime)` so the first delta stays ~0
-  // while `lastTime` remains private to the loop.
+  // `lastTime = performance.now(); animate(lastTime)` so the first delta stays ~0 while
+  // `lastTime` remains private to the loop. Also resets the accumulator + interpolation
+  // anchors so a fresh run starts on the fixed grid from the current position.
   function startLoop() {
     lastTime = performance.now();
+    accumulator = 0;
+    prevPos.x = pos.x; prevPos.y = pos.y; prevPos.z = pos.z;
+    curPos.x = pos.x; curPos.y = pos.y; curPos.z = pos.z;
+    prevInAir = player.isInAir;
+    lastResult = null;
     animate(lastTime);
   }
 

--- a/tests/verification/fixed_timestep_harness.js
+++ b/tests/verification/fixed_timestep_harness.js
@@ -1,0 +1,308 @@
+// @ts-check
+// fixed_timestep_harness.js
+// Frame-rate-INDEPENDENCE gate for the run loop's fixed-timestep accumulator
+// (src/game/fixed-step.ts + game/main-loop.ts). Sibling to forward_stress_harness.js
+// and avalanche_framerate_harness.js, but it targets the LOOP, not the kernel.
+//
+// physics_invariant_harness.js proves the kernel is byte-identical at 1/60. This
+// harness proves the thing built on top of it: when the loop advances physics through
+// the accumulator (planFrameSteps), the trajectory it produces is independent of the
+// render frame rate — 30, 50, 144 Hz and a jittery variable rate all trace the SAME
+// fixed-grid path the kernel pins, because physics only ever advances in 1/60 s steps.
+// The pre-accumulator variable-dt loop fails this (coarse-dt Euler drifts with FPS);
+// the accumulator is what makes it pass.
+//
+// It guards three properties:
+//
+//   1. FRAME-RATE EQUIVALENCE [GATING] — driving the accumulator at any render rate
+//      and any jitter executes the same ordered sequence of 1/60 s kernel steps, so the
+//      state after K fixed steps is byte-identical to a direct K-step reference run.
+//      (Contrast: the variable-dt loop driving the kernel at dt = 1/FPS drifts tens of
+//      units — reported as a diagnostic.)
+//   2. TUNNEL-FREE BY CONSTRUCTION [GATING] — every fixed substep moves velocity * 1/60,
+//      so at any sane speed the per-step displacement stays well under the 2.5u collision
+//      radius regardless of render FPS. Shown via diagnostics.ts: the accumulator path
+//      reports ZERO tunnelRisk frames where a 10-FPS variable-dt step at the same speed
+//      reports many.
+//   3. SPIRAL-OF-DEATH GUARD [GATING] — a single huge frame delta (tab backgrounded, GC
+//      hitch) runs at most MAX_SUBSTEPS steps and leaves the accumulator < FIXED_DT, so
+//      one slow frame can never queue an unbounded number of physics steps.
+//
+// Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/fixed_timestep_harness.js
+const { pathToFileURL } = require('url');
+const path = require('path');
+
+// Minimal browser globals the kernel + tree/rock placement + diagnostics touch (no
+// DOM/WebGL). addEventListener is a no-op so Diag.init's error-handler wiring is safe.
+const g = /** @type {any} */ (globalThis);
+g.window = {
+  location: { search: '' },
+  matchMedia: () => ({ matches: false }),
+  terrainMesh: null,
+  addEventListener: () => {},
+};
+g.document = undefined; // trees/rocks skip canvas textures; Diag skips the DOM overlay
+try { Object.defineProperty(global, 'navigator', { value: { webdriver: false }, configurable: true }); } catch { /* keep existing */ }
+
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+function makeScene() {
+  const children = [];
+  return /** @type {any} */ ({ children, add(o) { children.push(o); }, remove(o) { const i = children.indexOf(o); if (i >= 0) children.splice(i, 1); }, userData: {} });
+}
+
+function fakeSnowman() {
+  const ski = () => ({ position: { x: 0 }, rotation: { x: 0, y: 0, z: 0 } });
+  return /** @type {any} */ ({
+    position: { x: 0, y: 0, z: 0, set(x, y, z) { this.x = x; this.y = y; this.z = z; } },
+    rotation: { x: 0, y: Math.PI, z: 0 },
+    userData: { targetRotationY: Math.PI, currentRotX: 0, currentRotZ: 0,
+                leftSki: ski(), rightSki: ski(), leftSkiBaseX: -1, rightSkiBaseX: 1 },
+  });
+}
+
+const UP = { left: false, right: false, up: true, down: false, jump: false };
+const mk = (over) => ({ ...UP, ...over });
+
+(async () => {
+  await import(pathToFileURL(path.join(__dirname, '..', 'loaders', 'register-ts-resolve.mjs')).href);
+  const { Snowman } = await import('../../src/snowman.ts');
+  const terrain = await import('../../src/mountains/terrain.ts');
+  const { Trees } = await import('../../src/mountains/trees.ts');
+  const { addRocks } = await import('../../src/mountains/rocks.ts');
+  const { FIXED_DT, MAX_SUBSTEPS, planFrameSteps } = await import('../../src/game/fixed-step.ts');
+  const { Diag } = await import('../../src/diagnostics.ts');
+  const { getTerrainHeight, getTerrainGradient, getDownhillDirection } = terrain;
+
+  const COLLISION_RADIUS = 2.5; // mirrors collision.ts default treeCollisionRadius
+  let hardFail = false;
+
+  // Build the (seeded) obstacle field once; reused across every scenario so the only
+  // variable is how render frames are chunked into fixed steps.
+  function buildField(seed) {
+    Math.random = makeRng(seed);
+    const scene = makeScene();
+    const _log = console.log, _warn = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const treePositions = Trees.addTrees(scene);
+    const rockPositions = addRocks(scene);
+    console.log = _log; console.warn = _warn;
+    return { treePositions, rockPositions };
+  }
+
+  // Fresh kernel state + snowman at the spawn, optionally with an injected velocity.
+  function freshRun(vx = 0, vz = -3) {
+    const snowman = fakeSnowman();
+    const pos = { x: 0, z: -15, y: getTerrainHeight(0, -15) };
+    const velocity = { x: vx, z: vz };
+    snowman.position.set(pos.x, pos.y, pos.z);
+    const st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, -15),
+                 airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+    return { snowman, pos, velocity, st };
+  }
+
+  // One fixed 1/60 s kernel step. `controls` are keyed to the GLOBAL fixed-step index by
+  // the caller, so two render schedules that execute the same number of steps feed the
+  // kernel the same inputs in the same order — the basis of the equivalence gate.
+  function kernelStep(env, field, controls) {
+    const { snowman, pos, velocity, st } = env;
+    Math.random = env.turnRng; // deterministic auto-turn, independent of frame schedule
+    const r = Snowman.updateSnowman(snowman, FIXED_DT, pos, velocity, st.isInAir, st.verticalVelocity,
+      st.lastTerrainHeight, st.airTime, st.jumpCooldown, controls, st.turnPhase, st.currentTurnDirection,
+      st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
+      field.treePositions, true, () => {}, field.rockPositions);
+    env.st = { isInAir: r.isInAir, verticalVelocity: r.verticalVelocity, lastTerrainHeight: r.lastTerrainHeight,
+               airTime: r.airTime, jumpCooldown: r.jumpCooldown, turnPhase: r.turnPhase,
+               currentTurnDirection: r.currentTurnDirection, turnChangeCooldown: r.turnChangeCooldown };
+    snowman.position.set(pos.x, pos.y, pos.z);
+    return r;
+  }
+
+  // Reference: K fixed steps driven directly (the trajectory the harness pins).
+  function referenceRun(seed, field, K, controlsFn) {
+    const env = freshRun();
+    env.turnRng = makeRng(0xC0FFEE ^ seed);
+    for (let k = 0; k < K; k++) kernelStep(env, field, controlsFn(k));
+    return env;
+  }
+
+  // The same K fixed steps, but reached by feeding a render-frame schedule through the
+  // accumulator (planFrameSteps), exactly as game/main-loop.ts does. Stops the instant K
+  // steps have executed (mid-frame if needed) so the final state is comparable to the
+  // reference. Returns the final state + the worst per-substep displacement seen.
+  function accumulatorRun(seed, field, K, controlsFn, nextDelta) {
+    const env = freshRun();
+    env.turnRng = makeRng(0xC0FFEE ^ seed);
+    let accumulator = 0, executed = 0, maxStep = 0;
+    let guard = 0; // wall-clock frame cap so a bug can't spin forever
+    while (executed < K && guard++ < K * 4 + 1000) {
+      const plan = planFrameSteps(accumulator, nextDelta(), FIXED_DT, MAX_SUBSTEPS);
+      accumulator = plan.accumulator;
+      for (let i = 0; i < plan.substeps && executed < K; i++) {
+        const px = env.pos.x, pz = env.pos.z;
+        kernelStep(env, field, controlsFn(executed));
+        maxStep = Math.max(maxStep, Math.hypot(env.pos.x - px, env.pos.z - pz));
+        executed++;
+      }
+    }
+    return { env, executed, maxStep };
+  }
+
+  function stateGap(a, b) {
+    return Math.hypot(a.pos.x - b.pos.x, a.pos.z - b.pos.z) +
+           Math.hypot(a.velocity.x - b.velocity.x, a.velocity.z - b.velocity.z) +
+           Math.abs(a.pos.y - b.pos.y);
+  }
+
+  // ============================================================================
+  // 1) FRAME-RATE EQUIVALENCE [GATING]
+  // ============================================================================
+  // Controls keyed to the fixed-step index (a time-keyed slalom): identical input
+  // sequence for any schedule that executes the same number of steps.
+  const controlsFn = (k) => {
+    const tSec = k * FIXED_DT;
+    return Math.floor(tSec / 1.2) % 2 === 0 ? mk({ right: true }) : mk({ left: true });
+  };
+  const SEEDS = [12345, 777, 42];
+  const SIM_SECONDS = 6;
+  const K = Math.round(SIM_SECONDS / FIXED_DT); // fixed steps in the comparison window
+
+  // Render schedules: constant rates that DON'T divide 60 evenly (50, 144) plus 30, and
+  // a jittery variable rate (GC-hitch flavour). Each is a () => dt generator.
+  const schedules = {
+    '30fps': () => 1 / 30,
+    '50fps': () => 1 / 50,
+    '144fps': () => 1 / 144,
+    'jitter': (() => { const r = makeRng(0xBEEF); return () => (r() < 0.1 ? 0.05 : 1 / 60 + (r() - 0.5) * 0.01); })(),
+  };
+
+  let worstEquivGap = 0, worstEquivCtx = '';
+  for (const seed of SEEDS) {
+    const field = buildField(seed);
+    const ref = referenceRun(seed, field, K, controlsFn);
+    for (const [name, gen] of Object.entries(schedules)) {
+      const { env, executed } = accumulatorRun(seed, field, K, controlsFn, gen);
+      const gap = executed === K ? stateGap(env, ref) : Infinity;
+      if (gap > worstEquivGap) { worstEquivGap = gap; worstEquivCtx = `${name} seed ${seed} (executed ${executed}/${K})`; }
+    }
+  }
+  // Same FIXED_DT steps, same order, same inputs => byte-identical floating point.
+  const EQUIV_EPS = 1e-9;
+  const equiv = worstEquivGap < EQUIV_EPS;
+  console.log('=== Fixed-timestep accumulator: drive the LOOP at 30/50/144/jitter FPS ===');
+  console.log('\n--- 1) Frame-rate equivalence (trajectory matches the 1/60 reference) [GATING] ---');
+  console.log('  worst state gap vs 60 Hz fixed-grid reference:', worstEquivGap.toExponential(2), `(${worstEquivCtx})`, '| eps:', EQUIV_EPS);
+  console.log('  PASS:', equiv ? 'every render rate traces the identical fixed-grid path ✅' : 'a render rate drifted from the fixed grid ❌');
+  if (!equiv) hardFail = true;
+
+  // Contrast diagnostic: the OLD variable-dt loop (kernel stepped at dt = 1/FPS) drifts.
+  {
+    const seed = 12345;
+    const field = buildField(seed);
+    const ref = referenceRun(seed, field, K, controlsFn);
+    const env = freshRun();
+    env.turnRng = makeRng(0xC0FFEE ^ seed);
+    let t = 0, k = 0;
+    const dt = 1 / 10;
+    while (t < SIM_SECONDS) { kernelStepVar(env, field, controlsFn(k++), dt); t += dt; }
+    function kernelStepVar(e, f, controls, d) {
+      const { snowman, pos, velocity, st } = e;
+      Math.random = e.turnRng;
+      const r = Snowman.updateSnowman(snowman, d, pos, velocity, st.isInAir, st.verticalVelocity,
+        st.lastTerrainHeight, st.airTime, st.jumpCooldown, controls, st.turnPhase, st.currentTurnDirection,
+        st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
+        f.treePositions, true, () => {}, f.rockPositions);
+      e.st = { isInAir: r.isInAir, verticalVelocity: r.verticalVelocity, lastTerrainHeight: r.lastTerrainHeight,
+               airTime: r.airTime, jumpCooldown: r.jumpCooldown, turnPhase: r.turnPhase,
+               currentTurnDirection: r.currentTurnDirection, turnChangeCooldown: r.turnChangeCooldown };
+      snowman.position.set(pos.x, pos.y, pos.z);
+    }
+    const drift = stateGap(env, ref);
+    console.log('  [diagnostic] old variable-dt loop @10 FPS drift vs reference:', drift.toFixed(2),
+      '— coarse-dt Euler; what the accumulator removes');
+  }
+
+  // ============================================================================
+  // 2) TUNNEL-FREE BY CONSTRUCTION [GATING], via diagnostics.ts
+  // ============================================================================
+  // Drive the SAME high-speed descent two ways and let Diag classify the per-step
+  // displacement. Diag fires tunnelRisk when a recorded step >= the collision radius.
+  Diag.init({ frameCapSec: 0.1, collisionRadius: COLLISION_RADIUS });
+  const tunnelSeed = 9001;
+  const field = buildField(tunnelSeed);
+  const INJECT_VZ = -36; // well above terminal: a single 0.1 s step would clear 2.5u
+
+  // (a) Variable-dt loop @10 FPS: one Diag sample per frame at dt = 0.1.
+  Diag.reset();
+  {
+    const env = freshRun(0, INJECT_VZ);
+    env.turnRng = makeRng(0xC0FFEE ^ tunnelSeed);
+    let k = 0;
+    for (let f = 0; f < 25; f++) {
+      const r = Snowman.updateSnowman(env.snowman, 0.1, env.pos, env.velocity, env.st.isInAir, env.st.verticalVelocity,
+        env.st.lastTerrainHeight, env.st.airTime, env.st.jumpCooldown, UP, env.st.turnPhase, env.st.currentTurnDirection,
+        env.st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
+        field.treePositions, true, () => {}, field.rockPositions);
+      env.st = { isInAir: r.isInAir, verticalVelocity: r.verticalVelocity, lastTerrainHeight: r.lastTerrainHeight,
+                 airTime: r.airTime, jumpCooldown: r.jumpCooldown, turnPhase: r.turnPhase,
+                 currentTurnDirection: r.currentTurnDirection, turnChangeCooldown: r.turnChangeCooldown };
+      Diag.record({ dt: 0.1, speed: r.currentSpeed, x: env.pos.x, z: env.pos.z, technique: r.technique, isInAir: r.isInAir });
+      k++;
+    }
+  }
+  const varSnap = Diag.snapshot();
+  const varTunnel = varSnap.summary.tunnelRiskFrames;
+
+  // (b) Accumulator loop @10 FPS render: 6 fixed substeps per frame, one Diag sample per
+  // SUBSTEP at dt = FIXED_DT — the displacement the player actually moves.
+  Diag.reset();
+  {
+    const env = freshRun(0, INJECT_VZ);
+    env.turnRng = makeRng(0xC0FFEE ^ tunnelSeed);
+    let accumulator = 0;
+    for (let f = 0; f < 25; f++) {
+      const plan = planFrameSteps(accumulator, 0.1, FIXED_DT, MAX_SUBSTEPS);
+      accumulator = plan.accumulator;
+      for (let i = 0; i < plan.substeps; i++) {
+        const r = kernelStep(env, field, UP);
+        Diag.record({ dt: FIXED_DT, speed: r.currentSpeed, x: env.pos.x, z: env.pos.z, technique: r.technique, isInAir: r.isInAir });
+      }
+    }
+  }
+  const fixedSnap = Diag.snapshot();
+  const fixedTunnel = fixedSnap.summary.tunnelRiskFrames;
+
+  console.log('\n--- 2) Tunnel-free by construction (diagnostics tunnelRisk frames) [GATING] ---');
+  console.log(`  variable-dt @10 FPS (inject vz=${INJECT_VZ}): tunnelRiskFrames =`, varTunnel,
+    `| stepMax = ${varSnap.summary.stepMax.toFixed(2)}u`);
+  console.log('  fixed-step accumulator (same descent):     tunnelRiskFrames =', fixedTunnel,
+    `| stepMax = ${fixedSnap.summary.stepMax.toFixed(2)}u`);
+  const tunnelFree = fixedTunnel === 0 && fixedSnap.summary.stepMax < COLLISION_RADIUS && varTunnel > 0;
+  console.log('  PASS:', tunnelFree
+    ? 'accumulator keeps every step under the radius where variable-dt tunnels ✅'
+    : 'expected zero tunnel frames under the accumulator and >0 under variable-dt ❌');
+  if (!tunnelFree) hardFail = true;
+
+  // ============================================================================
+  // 3) SPIRAL-OF-DEATH GUARD [GATING]
+  // ============================================================================
+  // A single enormous frame delta must run at most MAX_SUBSTEPS steps and leave the
+  // accumulator below FIXED_DT (so alpha stays in [0,1) and time can't pile up).
+  const huge = planFrameSteps(0, 5.0, FIXED_DT, MAX_SUBSTEPS); // 5 s frame (tab backgrounded)
+  const guardOk = huge.substeps === MAX_SUBSTEPS && huge.accumulator < FIXED_DT &&
+                  huge.alpha >= 0 && huge.alpha < 1;
+  // And the maintained invariant: starting from acc < FIXED_DT, a normal frame leaves
+  // acc < FIXED_DT (induction base for alpha in [0,1)).
+  const normal = planFrameSteps(FIXED_DT * 0.9, 1 / 144, FIXED_DT, MAX_SUBSTEPS);
+  const invariantOk = normal.accumulator < FIXED_DT && normal.alpha < 1;
+  console.log('\n--- 3) Spiral-of-death guard + accumulator invariant [GATING] ---');
+  console.log(`  5 s frame => substeps=${huge.substeps} (cap ${MAX_SUBSTEPS}), leftover=${huge.accumulator.toFixed(4)} (< ${FIXED_DT.toFixed(4)}), alpha=${huge.alpha.toFixed(3)}`);
+  console.log('  PASS:', guardOk && invariantOk ? 'one slow frame is capped; accumulator stays bounded ✅' : 'spiral guard or invariant broken ❌');
+  if (!(guardOk && invariantOk)) hardFail = true;
+
+  console.log(`\nFIXED-TIMESTEP HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (frame-rate equivalent; tunnel-free; spiral-guarded)'}`);
+  process.exit(hardFail ? 1 : 0);
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });


### PR DESCRIPTION
## What

Restructure the hot loop (`src/game/main-loop.ts`) around a **fixed-timestep accumulator**: physics only ever advances in fixed `1/60` s steps, while cosmetics/observers run once per render frame on the real delta. This closes the frame-rate-dependence bug class (#209) — tree **tunnelling** and **divergent terminal behaviour** at low FPS — *by construction*, because the per-substep position step is `velocity / 60`, well under the 2.5u tree collision radius at any sane speed.

## Why it's safe for the invariant harness

The physics kernel (`src/snowman/physics.ts`) is **unchanged** — the accumulator lives entirely in the loop. The physics-invariant harness already drives the kernel at `1/60` on every step, so it stays **byte-identical** (it's the proof the kernel didn't move), and `dragFactor(60Hz)` collapses to an identity at the fixed step. The live game now advances physics at exactly the rate the suite pins — the thing tested becomes the thing that runs.

## How

New pure, DOM-free module **`src/game/fixed-step.ts`** (`FIXED_DT`, `MAX_SUBSTEPS = 8`, `planFrameSteps`) accumulates real frame time and drains whole fixed steps (spiral-of-death guard: ≤ 8 steps/frame ≈ 133 ms, the same ceiling as the old `min(delta, 0.1)` clamp).

The loop splits physics from cosmetics:

- **`stepFixed()`** — fixed-grid work that gates run outcome: the kernel step, course progress + finish, avalanche **burial**, and per-substep diagnostics.
- **`renderFrame()`** — per-frame observer/cosmetic layer: HUD, flex, SFX, snow, sky, avalanche advance/UI, interpolated camera, render.
- **Event aggregation** — per-substep events (`justLanded`, the ground→air takeoff edge, `landingQuality`) are reduced across a frame's substeps so a jump/land completed mid-frame still fires its whoosh/thump/toast/shake exactly once.
- **Render interpolation** (`alpha`) places the snowman between the last two fixed states so motion stays smooth on panels whose refresh doesn't divide 60 (144 Hz, 50 Hz); physics state stays authoritative. One-line switch (`INTERPOLATE_RENDER`).
- **`updateSnowman(delta)` preserved** — the gameplay browser tests and the `window.updateSnowman` seam call it directly with an explicit delta and expect one physics advance + the observer layer; it composes the same shared `physicsStep` + `applyObservers` helpers, so its behaviour is unchanged.

## Tests

New **`tests/verification/fixed_timestep_harness.js`** (wired into `npm run test:stress`) drives the **loop** (not the kernel) and gates:

1. **Frame-rate equivalence** — 30 / 50 / 144 / jittery FPS all trace a trajectory **byte-identical** (gap `0.0`) to the `1/60` reference. (Contrast: the old variable-dt loop drifts ~26u — reported as a diagnostic.)
2. **Tunnel-free by construction** — diagnostics reports **zero** `tunnelRisk` frames under the accumulator where a high-speed variable-dt `0.1` s step reports many (3 → 0).
3. **Spiral-of-death guard** — a 5 s frame runs at most `MAX_SUBSTEPS` steps and leaves the accumulator `< FIXED_DT`.

All existing suites stay green: `test:verify` (invariant + DOM smoke, byte-identical kernel), `test:stress` (forward + avalanche), `test:physics`, `test:regression`, `test:diagnostics`, and the full **95-test puppeteer browser suite** (which exercises the live loop + `updateSnowman` directly). `npm run lint`, `tsc --noEmit`, and `vite build` all clean.

Docs: `docs/ARCHITECTURE.md` §5 (per-frame order) and `docs/CHANGELOG.md` updated; the stale loop-cap comment in `diagnostics.ts` corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5HGg6gTTPoeDxizNnE2Rw

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5HGg6gTTPoeDxizNnE2Rw)_