### PR TITLE
Fixed-timestep accumulator: frame-rate-independent physics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,24 +193,45 @@ is skipped (reproducing the original Loading/Get-Ready timing exactly) for the
 `?test=` suites (`window.isTestMode`), automated runs (`navigator.webdriver`), and
 `prefers-reduced-motion`; `?intro=force` / `?intro=off` override that for QA.
 
-Per-frame order in `animate(time)` (each step depends on the previous):
+**Fixed-timestep loop.** `animate(time)` advances physics with a **fixed-timestep
+accumulator** (`src/game/fixed-timestep.ts`), not the raw render delta. Physics only ever
+steps in `FIXED_DT = 1/60` s substeps — exactly the rate the invariant harness pins
+(`physics_invariant_harness.js` drives the kernel at `1/60`) — so the live build advances
+physics at the same rate the suite tests, the per-step displacement is `velocity / 60`
+(well under any collision radius → tunnel-risk frames are zero by construction), and the
+trajectory is **frame-rate independent** (identical at 30 / 50 / 144 FPS and under jitter;
+gated by `fixed_timestep_harness.js`). `MAX_SUBSTEPS = 8` is the spiral-of-death guard
+(~133 ms ceiling) — the same ceiling the old `min(delta, 0.1)` clamp imposed, expressed as
+a step count, so a slow frame *slows time* rather than tunnelling. The physics kernel
+(`snowman/physics.ts`) is **unchanged** — at `1/60`, `dragFactor` is an identity.
+
+Per-frame order in `animate(time)`:
 
 ```
-delta = min((time - lastTime)/1000, 0.1)        // clamp
-updateSnowman(delta)                             // input + physics → pos/velocity
-  Flex.update(...)                               // cosmetic flex (reads result only)
-  Sfx.jump()/land(force)/updateSkiing(...)       // SFX: takeoff/touchdown + wind/edge bed (reads result only)
-Snow.updateSnowflakes(...)
-snowTrails.update(delta, snowman, isInAir)       // carve/fade ski grooves (cosmetic, reads pos only)
-CourseModule.update(pos, elapsed, snowman)       // splits, progress HUD, ghost
-avalanche.trigger/update/checkBurial/hasPassed   // + EffectsModule.updateAvalanche + Sfx.setAvalanche
-Snow.updateSnowSplash(...)  (position restored after, so particles can't move player)
-updateCamera()                                   // cameraManager follows snowman
-updateTimerDisplay()
-shake = EffectsModule.tickCamera(camera, delta, speed)   // FOV + shake offset
-renderer.render(scene, camera)
-camera.position -= shake                          // revert so smoothing stays clean
+frameDelta = (time - lastTime)/1000
+plan = planSubsteps(frameDelta, accumulator)     // ceiling-cap @ MAX_SUBSTEPS·FIXED_DT, count substeps
+
+for each of plan.substeps:  stepFixed(FIXED_DT)   // the fixed grid (run-outcome-gating work):
+  Physics.stepPlayer(FIXED_DT)                    //   input + physics → pos/velocity
+  reduce frame events (takeoff/justLanded/grade)  //   so a mid-frame jump+land isn't dropped (§5)
+  CourseModule.update(pos, elapsed, snowman)      //   splits, progress HUD, ghost, FINISH check
+  avalanche.checkBurial(...)                      //   game-over check (boulder advance is per-frame)
+  Diag.record(FIXED_DT, ...)                      //   telemetry per substep → step = velocity/60
+
+renderFrame(frameDelta, alpha)                    // once per render frame (cosmetic / world / render):
+  applySnowmanObservers(...)                      //   HUD, landing shake/toast, Flex, Sfx (reads result only)
+  Snow.updateSnowflakes / snowTrails / Sky.update
+  avalanche.trigger/update/hasPassed + Effects.updateAvalanche + Sfx.setAvalanche
+  Snow.updateSnowSplash(...)  (position restored after, so particles can't move player)
+  updateCamera()  at lerp(prevPos, curPos, alpha) // interpolated to de-alias non-60 panels
+  updateTimerDisplay()
+  shake = EffectsModule.tickCamera(camera, frameDelta, speed); renderer.render(...); camera.position -= shake
 ```
+
+`updateSnowman(delta)` is retained as a **compat seam** (re-published on `window` for the
+browser suites): it runs one `stepFixed(delta)` + `applySnowmanObservers(delta)` — a single
+combined frame at an arbitrary delta — but never the world-advance / render. The live loop
+above never calls it.
 
 ```
  input (Controls) ─┐

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,43 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Fixed-timestep accumulator: frame-rate-independent physics
+- **The run loop now steps physics in fixed `1/60` s substeps**, not the raw render delta.
+  Previously `animate(time)` advanced the kernel with the variable `min(delta, 0.1)` frame
+  time, which makes the steady state frame-rate dependent (the #209 bug class — see
+  `diagnostics.ts`): at low FPS a single `pos += velocity·delta` step can exceed an
+  obstacle's collision radius (tunnelling through a tree) and a per-frame-vs-per-second
+  mismatch in any force balloons terminal speed. A fixed-timestep **accumulator**
+  (`src/game/fixed-timestep.ts`, `planSubsteps`) removes the cause: physics only ever
+  advances in `FIXED_DT = 1/60` steps — *exactly the rate the invariant harness pins* — so
+  the live build advances physics at the same rate the suite tests, the per-step
+  displacement is `velocity/60` (well under any collision radius → tunnel-risk frames are
+  zero by construction), and the **trajectory is frame-rate independent** (identical at
+  30 / 50 / 144 FPS and under jitter). `MAX_SUBSTEPS = 8` is the spiral-of-death guard: the
+  same ~133 ms ceiling the old `0.1` s clamp imposed, expressed as a step count, so a very
+  slow frame *slows time* rather than tunnelling — a strictly better failure mode.
+- **The physics kernel (`snowman/physics.ts`) is unchanged.** At `1/60`, `dragFactor` is an
+  identity, so the kernel is byte-identical to the harness's `1/60` world — the
+  physics-invariant harness (which drives the kernel directly) is unaffected, proving the
+  kernel didn't move. The accumulator lives entirely in `src/game/main-loop.ts`.
+- **Loop split (`main-loop.ts`).** `stepFixed(FIXED_DT)` runs anything that changes physics
+  state or could be *missed between frames* — the physics advance, course progress + finish,
+  avalanche burial, and the read-only `Diag.record` (per substep, so the step it sees is the
+  fixed-grid displacement → `tunnelRiskFrames == 0`). `renderFrame(frameDelta, alpha)` runs
+  everything purely visual once per render frame — HUD, Flex, SFX, particles, sky, ski
+  trails, the avalanche advance + UI, and the camera/snowman render **interpolated** at
+  `lerp(prevPos, curPos, alpha)` to de-alias non-60 panels. Landing/takeoff **events are
+  reduced across a frame's substeps** so a jump-and-land that completes mid-frame still fires
+  its whoosh/thump/toast (and the meaningful-jumps #47 finish-frame guarantee is preserved).
+  `updateSnowman(delta)` is kept as a compat seam (`stepFixed` + the snowman-observer layer,
+  no world-advance/render) so the browser suites can still drive one frame by bare name.
+- **Tests.** `tests/fixed-timestep-tests.js` unit-covers the pure accumulator
+  (`planSubsteps`/`lerp`: substep counting, the spiral guard, frame-rate-invariant totals);
+  `tests/verification/fixed_timestep_harness.js` drives the **real** accumulator over the
+  **real** kernel + terrain + obstacles and gates (1) byte-identical trajectories across
+  render rates and (2) `tunnelRiskFrames == 0`, with the old variable-dt loop as a contrast.
+  Both run under `npm run test:fixed-timestep` (added to the default `npm test` chain).
+
 ### Three.js rendering perf: shared tree geometry/material pools + renderer tuning
 - **Trees (`src/mountains/trees.ts`) were the forest's odd one out.** The avalanche
   boulders and ski tracks already share a single geometry/material, but each of the

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -14,8 +14,14 @@ Companion docs: [`ARCHITECTURE.md`](ARCHITECTURE.md) (how the modules fit togeth
 ## 1. Conventions
 
 - **Units.** 1 world unit = 1 metre for HUD purposes. Time is in seconds; `delta`
-  is the per-frame timestep, **capped at 0.1 s** in the animation loop so a stalled
-  tab cannot teleport the snowman.
+  is the physics timestep. The live loop integrates physics with a **fixed timestep**
+  (`delta = 1/60` s, the rate the invariant harness pins), running as many fixed
+  substeps per render frame as the elapsed time requires — see the fixed-timestep
+  accumulator in [`ARCHITECTURE.md`](ARCHITECTURE.md) §5. A render frame runs **at most
+  `MAX_SUBSTEPS = 8`** substeps (~133 ms ceiling, the spiral-of-death guard that replaces
+  the old `min(delta, 0.1)` clamp), so a stalled tab slows time rather than teleporting
+  the snowman. Because every step is `1/60`, the trajectory is frame-rate independent and
+  the per-step displacement (`velocity/60`) never skips an obstacle's collision radius.
 - **Axes.** `+y` is up. The fall line runs along `-z`: the player starts near
   `z = -15` and skis toward `z = -195`. `x` is the cross-slope (left/right) axis.
 - **Downhill velocity is negative `z`.** Spawning, the avalanche, and the finish

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:fixed-timestep && npm run test:stress",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -39,6 +39,7 @@
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",
     "test:stress": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/forward_stress_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/avalanche_framerate_harness.js",
+    "test:fixed-timestep": "node --import ./tests/loaders/register-ts-resolve.mjs tests/fixed-timestep-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/fixed_timestep_harness.js",
     "test:browser": "node tests/puppeteer-runner.js",
     "test:browser:coverage": "BROWSER_COVERAGE=1 node tests/puppeteer-runner.js",
     "test:e2e": "PLAYWRIGHT_FORCE_ASYNC_LOADER=1 playwright test",

--- a/src/game/fixed-timestep.ts
+++ b/src/game/fixed-timestep.ts
@@ -1,0 +1,77 @@
+// fixed-timestep.ts — the fixed-timestep accumulator math for the run loop.
+//
+// WHY THIS EXISTS
+// ---------------
+// The live game loop used to step physics with the real, variable render delta
+// (`pos.x += velocity.x * delta`), which makes the steady state frame-rate
+// dependent: at low FPS a single step can exceed an obstacle's collision radius
+// (tunnelling through trees) and a per-frame-vs-per-second mismatch in any force
+// path balloons terminal speed (the #209 bug class — see diagnostics.ts).
+//
+// A fixed timestep removes the cause: physics only ever advances in FIXED_DT
+// (1/60 s) steps — exactly the rate the invariant harness pins
+// (tests/verification/physics_invariant_harness.js drives the kernel at 1/60) —
+// so the live build advances physics at the same rate the suite tests, the
+// per-step displacement is `velocity / 60` (well under any collision radius at
+// any sane speed), and tunnel-risk frames go to zero by construction.
+//
+// This module is the PURE, dependency-free core of that accumulator: it owns no
+// THREE/DOM state, so it unit-tests headlessly and the frame-rate-equivalence /
+// tunnel-risk harnesses can drive the SAME stepping logic the live loop runs.
+// main-loop.ts imports it and supplies the actual per-substep / per-frame work.
+
+/** The fixed physics step (60 Hz) — the rate the invariant harness pins. Physics
+ *  only ever advances in steps of this size, regardless of the render rate, so
+ *  `dragFactor(1/60)` is an identity and the kernel stays byte-identical to the
+ *  harness's 1/60 world. */
+export const FIXED_DT = 1 / 60;
+
+/** Spiral-of-death guard: the most fixed substeps a single render frame may run
+ *  (~133 ms ceiling). Mirrors the old `Math.min(delta, 0.1)` delta clamp as a
+ *  step count — beyond it the game *slows down* (leftover real time is dropped)
+ *  rather than tunnelling, the same ceiling, a strictly better failure mode. */
+export const MAX_SUBSTEPS = 8;
+
+/** The decision a single render frame produces from the accumulator. */
+export interface SubstepPlan {
+  /** Number of fixed FIXED_DT physics substeps to run this frame. */
+  substeps: number;
+  /** Leftover time carried into the next frame (< FIXED_DT after a normal frame). */
+  accumulator: number;
+  /** `accumulator / FIXED_DT` in [0, 1): the render-interpolation factor between
+   *  the last two physics states (0 = exactly on a step boundary). */
+  alpha: number;
+}
+
+/**
+ * Advance the accumulator by one render frame's elapsed time and decide how many
+ * fixed substeps to run. PURE — returns the plan, never mutates its inputs.
+ *
+ * `frameDelta` is the real seconds since the previous frame. It is ceiling-capped
+ * at `maxSubsteps * fixedDt` first, so a long pause (GC, backgrounded tab) cannot
+ * queue an unbounded burst of substeps — the excess real time is dropped, which is
+ * the spiral-of-death guard expressed as the old 0.1 s clamp.
+ */
+export function planSubsteps(
+  frameDelta: number,
+  accumulator: number,
+  fixedDt: number = FIXED_DT,
+  maxSubsteps: number = MAX_SUBSTEPS,
+): SubstepPlan {
+  // Clamp to [0, ceiling]: a negative/NaN delta can't rewind, a huge one can't burst.
+  const capped = Math.min(Math.max(frameDelta, 0) || 0, maxSubsteps * fixedDt);
+  let acc = accumulator + capped;
+  let substeps = 0;
+  while (acc >= fixedDt && substeps < maxSubsteps) {
+    acc -= fixedDt;
+    substeps += 1;
+  }
+  const alpha = acc / fixedDt;
+  return { substeps, accumulator: acc, alpha };
+}
+
+/** Scalar linear interpolation, for smoothing the rendered position between the
+ *  two bracketing physics states when the render rate doesn't divide 60 evenly. */
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -1,9 +1,30 @@
-// Per-frame run loop for SnowGlider: physics step + HUD, camera follow, the
-// requestAnimationFrame loop (course progress, avalanche, snow splash, camera juice,
-// render), and the window-resize handler. Extracted from snowglider.ts as
-// `createMainLoop(deps)`; the coordinator injects the constructed scene handles +
-// run/player state and re-publishes `updateSnowman`/`updateCamera` on `window`.
-// Mechanical move — per-frame ordering and behavior are unchanged.
+// Per-frame run loop for SnowGlider: a FIXED-TIMESTEP accumulator that advances the
+// physics + run-outcome checks in fixed 1/60 s substeps and runs the cosmetic/observer
+// layer (HUD, camera, render, particles, avalanche UI) once per render frame.
+// Extracted from snowglider.ts as `createMainLoop(deps)`; the coordinator injects the
+// constructed scene handles + run/player state and re-publishes `updateSnowman`/
+// `updateCamera` on `window`.
+//
+// WHY FIXED TIMESTEP (the bug class it closes)
+// --------------------------------------------
+// The loop used to step physics with the real, variable render delta. That makes the
+// steady state frame-rate dependent (the #209 class — see diagnostics.ts): at low FPS a
+// single `pos += velocity * delta` step can exceed an obstacle's collision radius and
+// tunnel through a tree, and a per-frame-vs-per-second mismatch in any force balloons
+// terminal speed. Stepping physics ONLY in FIXED_DT (1/60 s) substeps — exactly the rate
+// physics_invariant_harness.js pins the kernel at — removes the cause: the per-step
+// displacement is `velocity / 60` (well under any collision radius), tunnel-risk frames go
+// to zero by construction, and the live build advances physics at the same rate the suite
+// tests. The physics kernel (snowman/physics.ts) is UNCHANGED; the accumulator lives here.
+//
+// SPLIT: fixed substep vs render frame
+//   - stepFixed(FIXED_DT)  — runs anything that changes physics state or could be MISSED
+//     between frames: the physics advance, course progress + finish, avalanche burial, and
+//     the read-only Diag.record (per substep, so the step it sees is the fixed-grid
+//     displacement and tunnelRisk stays zero).
+//   - renderFrame(frameDelta, alpha) — runs anything purely visual or smoothing-based on
+//     the real frame delta: HUD, Flex, Sfx, snow/sky/trails, avalanche advance + UI, and
+//     the interpolated camera + render. None of it touches the physics state.
 
 import { Controls } from '../controls.js';
 import { Snow } from '../snow.js';
@@ -15,14 +36,36 @@ import { Sfx } from '../sfx.js';
 import { Diag } from '../diagnostics.js';
 import { EffectsModule, type ShakeOffset } from '../effects.js';
 import { Physics, type PlayerState } from '../player-state.js';
+import type { LandingQuality, UpdateResult } from '../snowman.js';
 import { updateStatsHud, updateTimerDisplay } from '../ui/hud.js';
 import { AVALANCHE_TRIGGER_DISTANCE, type SceneContext } from './scene-setup.js';
+import { FIXED_DT, MAX_SUBSTEPS, lerp, planSubsteps } from './fixed-timestep.js';
 
 export interface MainLoopDeps extends
   Pick<SceneContext, 'state' | 'scene' | 'camera' | 'renderer' | 'cameraManager' |
     'snowman' | 'snowSplash' | 'treePositions' | 'rockPositions'> {
   player: PlayerState;
   showGameOver: (reason: string) => void;
+}
+
+// Whether to render the snowman/camera at the interpolated position between the two
+// bracketing physics states (removes temporal aliasing when the render rate doesn't
+// divide 60 evenly, e.g. 144 Hz or 50 Hz). Flip to false to render at the latest
+// physics state instead (no interpolation latency, minor stutter on non-60 panels).
+const RENDER_INTERPOLATION = true;
+
+/** Events that can fire on ANY substep within a frame and must NOT be dropped if only
+ *  the last substep's result is read (a jump+land completing mid-frame). Reduced across
+ *  the frame's substeps, then fired once in renderFrame. */
+interface FrameEvents {
+  justLanded: boolean;
+  tookOff: boolean;
+  landingQuality: LandingQuality | null;
+  landingForce: number;
+}
+
+function freshEvents(): FrameEvents {
+  return { justLanded: false, tookOff: false, landingQuality: null, landingForce: 0 };
 }
 
 export function createMainLoop(deps: MainLoopDeps) {
@@ -34,24 +77,32 @@ export function createMainLoop(deps: MainLoopDeps) {
   const pos = player.pos;
   const velocity = player.velocity;
 
-  // Previous-frame air state, so we can fire a takeoff whoosh on the ground→air
-  // transition (the kernel's UpdateResult exposes justLanded but no justJumped).
+  // Previous-substep air state, so we can fire a takeoff whoosh on the ground→air
+  // transition (the kernel's UpdateResult exposes justLanded but no justJumped). Tracked
+  // across substeps so a takeoff in any substep of a frame is caught (§5).
   let prevInAir = false;
+  // The most recent per-frame physics result, cached so the cosmetic layer still has a
+  // result to read on a frame that ran zero substeps (render rate above 60 Hz).
+  let lastResult: UpdateResult | null = null;
+  // The fixed-timestep accumulator (leftover real time not yet consumed by a substep).
+  let accumulator = 0;
 
-  // --- Update Snowman: Physics-based Movement ---
-  function updateSnowman(delta: number) {
-    // We no longer need to add test hooks every frame as they're set up at initialization
-    // and after resets. This improves performance.
+  // --- One fixed physics substep ------------------------------------------------------
+  // Advances the player one FIXED_DT step and runs everything that gates the run outcome
+  // (course finish, avalanche burial) on the fixed grid, plus the read-only Diag record.
+  // Reduces the per-substep events into `events`. Returns the per-substep result.
+  function stepFixed(dt: number, events: FrameEvents): UpdateResult {
+    // Test hooks are installed at init / after resets; in the live loop they are present.
     const activeShowGameOver = typeof window.showGameOver === 'function'
       ? window.showGameOver
       : showGameOver;
 
-    // Advance the player one frame. Physics.stepPlayer wraps Snowman.updateSnowman
-    // (the unchanged physics kernel) and writes the mutated scalars back into the
-    // typed `player` state, returning the per-frame result for the HUD/camera.
+    // Advance the player one fixed step. Physics.stepPlayer wraps Snowman.updateSnowman
+    // (the unchanged physics kernel) and writes the mutated scalars back into the typed
+    // `player` state. At FIXED_DT the kernel is byte-identical to the invariant harness.
     const result = Physics.stepPlayer(player, {
       snowman,
-      delta,
+      delta: dt,
       controls: Controls.getControls(),
       getTerrainHeight: Snow.getTerrainHeight,
       getTerrainGradient: Snow.getTerrainGradient,
@@ -66,56 +117,40 @@ export function createMainLoop(deps: MainLoopDeps) {
       bankAirScore: (points: number) => { if (CourseModule) CourseModule.addAirScore(points); }
     });
 
-    // Update game stats display (speed/altitude/slope/technique). The slope
-    // readout is the terrain steepness under the player: gradient magnitude
-    // (rise/run = tan θ), the same measure the terrain code uses for placement.
-    const grad = Snow.getTerrainGradient(pos.x, pos.z);
-    const slopeRatio = Math.sqrt(grad.x * grad.x + grad.z * grad.z);
-    updateStatsHud(result, pos, player.isInAir, slopeRatio);
-
-    // Camera shake on a meaningful landing (scales with time spent aloft).
-    if (result.justLanded && result.landingForce > 0.25 && EffectsModule) {
-      EffectsModule.addShake(Math.min(1.2, result.landingForce * 0.6));
+    // Reduce the frame's events across its substeps so none is dropped (§5): a takeoff,
+    // a landing, or its grade can fire on any substep within a single render frame.
+    if (result.justLanded) events.justLanded = true;
+    if (result.isInAir && !prevInAir) events.tookOff = true;
+    if (result.landingQuality) {
+      events.landingQuality = result.landingQuality;
+      events.landingForce = result.landingForce;
     }
-
-    // Meaningful jumps (#47): on a graded *manual*-jump landing, toast the air time
-    // + grade. landingQuality is non-null only for a player-initiated jump, so
-    // auto-jumps / hop turns / coasting never toast. (The air score itself is banked
-    // inside the step via bankAirScore above, so a finish-frame jump still counts.)
-    if (result.justLanded && result.landingQuality && CourseModule) {
-      CourseModule.flashAir(result.landingQuality, result.landingForce);
-    }
-
-    // Cosmetic flexibility / jiggle (issue #53). Purely visual: runs AFTER the physics
-    // kernel so it can read the per-frame result, and only writes child-mesh transforms —
-    // it never touches pos/velocity, so the physics-invariant harness is unaffected.
-    const flexSpeed = result.currentSpeed;
-    Flex.update(snowman, delta, {
-      speed: flexSpeed,
-      technique: result.technique,
-      turnRate: flexSpeed > 1e-3 ? velocity.x / flexSpeed : 0, // zero-speed guard (no 0/0 NaN)
-      justLanded: result.justLanded,
-      landingForce: result.landingForce,
-      isInAir: player.isInAir
-    });
-
-    // Sound effects (issue #158): a takeoff whoosh on the ground→air transition, a
-    // touchdown thump scaled by air time, and the continuous wind + ski-edge bed.
-    // Reads the per-frame result only — never pos/velocity — so the physics-invariant
-    // harness is unaffected, and every call is a no-op until the SFX context is
-    // unlocked by the start gesture.
-    if (result.isInAir && !prevInAir) Sfx.jump();
-    if (result.justLanded) Sfx.land(result.landingForce);
     prevInAir = result.isInAir;
-    Sfx.updateSkiing(result.currentSpeed, result.technique, result.isInAir);
 
-    // Frame-rate / physics telemetry (diagnostics.ts). READ-ONLY observer, wired in
-    // beside Sfx/Flex: it reads the per-frame result + pos only and never touches
-    // pos/velocity, so the physics-invariant harness is unaffected and it is a no-op
-    // under automation. It watches the dt the real device produces and the speed/step
-    // that ride on it, surfacing the frame-rate-dependence bug class (#209) live.
+    // --- Course progress: split timing, progress HUD, ghost racing, finish check ---
+    // On the fixed grid because the finish gate (pos.z < -195) decides the run outcome
+    // and must not be skipped over by a large variable step.
+    if (CourseModule) {
+      const elapsed = (performance.now() - state.startTime) / 1000;
+      CourseModule.update(pos, elapsed, snowman);
+    }
+
+    // --- Avalanche burial (game-over) check ---
+    // On the fixed grid for the same reason: burial decides the run outcome. The boulder
+    // physics advance + UI stay per render frame (renderFrame); only the outcome-gating
+    // collision test runs here, against the current boulder positions.
+    const avalanche = state.avalanche;
+    if (avalanche && state.avalancheTriggered && avalanche.checkBurial(snowman.position)) {
+      showGameOver("Buried by avalanche!");
+    }
+
+    // Frame-rate / physics telemetry (diagnostics.ts). READ-ONLY observer: it reads the
+    // per-substep result + pos only and never touches pos/velocity, so the physics-
+    // invariant harness is unaffected and it is a no-op under automation. Recorded PER
+    // SUBSTEP at FIXED_DT, so the step it sees is the fixed-grid displacement
+    // (velocity / 60) — which is exactly why tunnelRisk frames go to zero now.
     Diag.record({
-      dt: delta,
+      dt,
       speed: result.currentSpeed,
       x: pos.x,
       z: pos.z,
@@ -123,7 +158,169 @@ export function createMainLoop(deps: MainLoopDeps) {
       isInAir: player.isInAir,
     });
 
-    // Update timer in the updateTimerDisplay function which is called separately
+    lastResult = result;
+    return result;
+  }
+
+  // --- Snowman-observer cosmetic layer (HUD / landing juice / flex / SFX) --------------
+  // Reads the latest physics result + the reduced frame events, never the physics state,
+  // so the physics-invariant harness is unaffected. Shared by the live renderFrame (once
+  // per render frame) and the updateSnowman compat seam (once per direct call), so the two
+  // never drift. A no-op when no substep produced a result yet (result == null).
+  function applySnowmanObservers(delta: number, result: UpdateResult | null, events: FrameEvents) {
+    if (!result) return;
+
+    // Update game stats display (speed/altitude/slope/technique). The slope readout is the
+    // terrain steepness under the player: gradient magnitude (rise/run = tan θ).
+    const grad = Snow.getTerrainGradient(pos.x, pos.z);
+    const slopeRatio = Math.sqrt(grad.x * grad.x + grad.z * grad.z);
+    updateStatsHud(result, pos, player.isInAir, slopeRatio);
+
+    // Camera shake on a meaningful landing (scales with time spent aloft).
+    if (events.justLanded && events.landingForce > 0.25 && EffectsModule) {
+      EffectsModule.addShake(Math.min(1.2, events.landingForce * 0.6));
+    }
+
+    // Meaningful jumps (#47): on a graded *manual*-jump landing, toast the air time +
+    // grade. landingQuality is non-null only for a player-initiated jump (auto-jumps /
+    // hop turns / coasting never toast). The air score itself is banked inside the step.
+    if (events.justLanded && events.landingQuality && CourseModule) {
+      CourseModule.flashAir(events.landingQuality, events.landingForce);
+    }
+
+    // Cosmetic flexibility / jiggle (issue #53). Purely visual: only writes child-mesh
+    // transforms, never pos/velocity, so the physics-invariant harness is unaffected.
+    const flexSpeed = result.currentSpeed;
+    Flex.update(snowman, delta, {
+      speed: flexSpeed,
+      technique: result.technique,
+      turnRate: flexSpeed > 1e-3 ? velocity.x / flexSpeed : 0, // zero-speed guard (no 0/0 NaN)
+      justLanded: events.justLanded,
+      landingForce: events.landingForce,
+      isInAir: player.isInAir
+    });
+
+    // Sound effects (issue #158): a takeoff whoosh on the ground→air transition, a
+    // touchdown thump scaled by air time, and the continuous wind + ski-edge bed. Fired
+    // from the reduced events, so a jump+land completing mid-frame still sounds. Reads the
+    // per-frame result only — never pos/velocity — and is a no-op until the SFX context is
+    // unlocked by the start gesture.
+    if (events.tookOff) Sfx.jump();
+    if (events.justLanded) Sfx.land(events.landingForce);
+    Sfx.updateSkiing(result.currentSpeed, result.technique, result.isInAir);
+  }
+
+  // --- The per-render-frame cosmetic / world layer ------------------------------------
+  // The snowman observers (above) plus everything else purely visual or smoothing-based:
+  // particles, sky, ski trails, the avalanche advance + UI, and the interpolated camera +
+  // render. Runs once per render frame on the real frame delta; none of it touches the
+  // physics state. `result` is null only before the first substep of a run.
+  function renderFrame(frameDelta: number, alpha: number, result: UpdateResult | null, events: FrameEvents) {
+    applySnowmanObservers(frameDelta, result, events);
+
+    Snow.updateSnowflakes(frameDelta, pos, scene);
+
+    // Dynamic ski trails / snow accumulation (#17): carve fading grooves behind the skis
+    // that fresh snow covers back over. Purely cosmetic — reads position only.
+    state.snowTrails?.update(frameDelta, snowman, player.isInAir);
+
+    // Advance the golden-hour↔midday sun cycle (sun position/colour, sky exposure, fog).
+    // Purely atmospheric; a no-op under reduced motion. (#163)
+    Sky.update(frameDelta);
+
+    // --- Avalanche advance + telegraph (burial is checked on the fixed grid) ---
+    const avalanche = state.avalanche;
+    if (avalanche) {
+      // Trigger avalanche based on distance traveled (simple geometric trigger).
+      // Player starts at z=-15 and moves in -Z direction (downhill).
+      const distanceTraveled = state.lastAvalancheZ - pos.z;
+
+      if (!state.avalancheTriggered && distanceTraveled > AVALANCHE_TRIGGER_DISTANCE) {
+        avalanche.trigger(snowman.position);
+        state.avalancheTriggered = true;
+        console.log("Avalanche triggered! Distance traveled:", distanceTraveled.toFixed(1));
+      }
+
+      // Update avalanche physics
+      avalanche.update(frameDelta);
+
+      // Reset avalanche if it has passed the player (survived!)
+      if (state.avalancheTriggered && avalanche.hasPassed(snowman.position)) {
+        console.log("Avalanche passed - player survived!");
+        avalanche.reset();
+        state.avalancheTriggered = false;
+        state.lastAvalancheZ = pos.z; // Reset trigger point for potential next avalanche
+      }
+
+      // Telegraph the threat: banner, "distance behind you" meter, vignette, shake.
+      if (EffectsModule) {
+        const avActive = state.avalancheTriggered && avalanche.active;
+        const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
+        EffectsModule.updateAvalanche(avActive, avDist);
+        // Avalanche rumble crescendos with the same proximity the banner uses (#158).
+        Sfx.setAvalanche(avActive, avDist);
+      }
+    }
+
+    // Save player position before snow splash effect updates
+    const playerPosBefore = {
+      x: snowman.position.x,
+      y: snowman.position.y,
+      z: snowman.position.z
+    };
+
+    // Update snow splash particles - pass all required parameters
+    Snow.updateSnowSplash(snowSplash, frameDelta, snowman, velocity, player.isInAir, scene);
+
+    // Ensure snowman position wasn't affected by particles
+    snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
+
+    // Render the snowman/camera at the interpolated position between the two bracketing
+    // physics states, so the render rate not dividing 60 evenly doesn't alias. The
+    // physics state stays authoritative at the fixed grid: we restore snowman.position
+    // after the render (same save/revert pattern the camera shake below uses).
+    let interpSaved: { x: number; y: number; z: number } | null = null;
+    if (RENDER_INTERPOLATION && renderPrev) {
+      interpSaved = { x: snowman.position.x, y: snowman.position.y, z: snowman.position.z };
+      snowman.position.set(
+        lerp(renderPrev.x, interpSaved.x, alpha),
+        lerp(renderPrev.y, interpSaved.y, alpha),
+        lerp(renderPrev.z, interpSaved.z, alpha),
+      );
+    }
+
+    updateCamera();
+    updateTimerDisplay(state.gameActive, state.startTime); // Update the timer display
+
+    // Camera juice: speed-based FOV + shake. Apply for the render only, then revert the
+    // positional offset so the camera manager's own smoothing stays clean.
+    let _shake: ShakeOffset | null = null;
+    if (EffectsModule) {
+      const spd = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
+      _shake = EffectsModule.tickCamera(camera, frameDelta, spd);
+    }
+    renderer.render(scene, camera);
+    if (_shake) {
+      camera.position.x -= _shake.x;
+      camera.position.y -= _shake.y;
+      camera.position.z -= _shake.z;
+    }
+
+    // Restore the authoritative (non-interpolated) physics position for the next substep.
+    if (interpSaved) snowman.position.set(interpSaved.x, interpSaved.y, interpSaved.z);
+  }
+
+  // --- Update Snowman (compat seam) ---------------------------------------------------
+  // Re-published on `window` so the browser test suites can drive the live game one frame
+  // by bare name (updateSnowman(delta)). Runs a single combined step at the given delta:
+  // the fixed-grid work (physics + course progress + burial) plus the snowman-observer
+  // cosmetic layer (HUD / Flex / SFX), matching what one frame did before this refactor.
+  // It deliberately does NOT advance the world particles or render — the live rAF loop
+  // (the accumulator below) owns those once per render frame.
+  function updateSnowman(delta: number) {
+    const events = freshEvents();
+    const result = stepFixed(delta, events);
+    applySnowmanObservers(delta, result, events);
   }
 
   // --- Update Camera: Follow the Snowman ---
@@ -137,109 +334,45 @@ export function createMainLoop(deps: MainLoopDeps) {
     );
   }
 
-  // --- Animation Loop ---
+  // --- Animation Loop -----------------------------------------------------------------
   let lastTime = 0;
+  // The snowman render position at the START of this frame's substeps (the earlier of the
+  // two states the interpolation brackets). Null before the first substep of a run.
+  let renderPrev: { x: number; y: number; z: number } | null = null;
   function animate(time: number) {
     if (state.gameActive) {
       requestAnimationFrame(animate);
-      const delta = Math.min((time - lastTime) / 1000, 0.1); // Cap delta to avoid jumps
+      // Real seconds since the last frame. planSubsteps ceiling-caps it at
+      // MAX_SUBSTEPS * FIXED_DT (the spiral-of-death guard) before consuming it.
+      const frameDelta = (time - lastTime) / 1000;
       lastTime = time;
 
       // Only set up test hooks if they're missing
       if (!window.testHooks) {
         console.log("Test hooks missing in animation loop, reinstalling");
-        // addTestHooks(pos, showGameOver, getTerrainHeight) — matches the two other
-        // call sites; the stray `gameActive` arg here was a latent bug (it landed in
-        // the getTerrainHeight slot), surfaced by the type-checker.
         Snowman.addTestHooks(pos, showGameOver, Snow.getTerrainHeight);
       }
 
-      updateSnowman(delta);
-      Snow.updateSnowflakes(delta, pos, scene);
+      const plan = planSubsteps(frameDelta, accumulator);
+      accumulator = plan.accumulator;
 
-      // Dynamic ski trails / snow accumulation (#17): carve fading grooves behind
-      // the skis that fresh snow covers back over. Purely cosmetic — reads position
-      // only, never the physics state.
-      state.snowTrails?.update(delta, snowman, player.isInAir);
-
-      // Advance the golden-hour↔midday sun cycle (sun position/colour, sky
-      // exposure, fog). Purely atmospheric; a no-op under reduced motion. (#163)
-      Sky.update(delta);
-
-      // --- Course progress: split timing, progress HUD, ghost racing ---
-      if (CourseModule) {
-        const elapsed = (performance.now() - state.startTime) / 1000;
-        CourseModule.update(pos, elapsed, snowman);
+      // Run the fixed substeps, remembering the player position just BEFORE the LAST one:
+      // `alpha` is the fraction past that final completed step, so the render interpolates
+      // between the penultimate and final physics states (not across the whole frame).
+      const events = freshEvents();
+      let result: UpdateResult | null = lastResult;
+      let prevState: { x: number; y: number; z: number } | null = null;
+      for (let i = 0; i < plan.substeps; i++) {
+        prevState = { x: snowman.position.x, y: snowman.position.y, z: snowman.position.z };
+        result = stepFixed(FIXED_DT, events);
+        // A substep can end the run (finish / crash / burial); stop stepping a dead run.
+        if (!state.gameActive) break;
       }
+      // Only bracket interpolation when a substep actually moved the player this frame;
+      // otherwise render at the current (unchanged) state.
+      renderPrev = prevState;
 
-      // --- Avalanche Logic ---
-      const avalanche = state.avalanche;
-      if (avalanche) {
-        // Trigger avalanche based on distance traveled (simple geometric trigger)
-        // Player starts at z=-15 and moves in -Z direction (downhill)
-        const distanceTraveled = state.lastAvalancheZ - pos.z;
-
-        if (!state.avalancheTriggered && distanceTraveled > AVALANCHE_TRIGGER_DISTANCE) {
-          avalanche.trigger(snowman.position);
-          state.avalancheTriggered = true;
-          console.log("Avalanche triggered! Distance traveled:", distanceTraveled.toFixed(1));
-        }
-
-        // Update avalanche physics
-        avalanche.update(delta);
-
-        // Check for burial (collision with avalanche)
-        if (avalanche.checkBurial(snowman.position)) {
-          showGameOver("Buried by avalanche!");
-        }
-
-        // Reset avalanche if it has passed the player (survived!)
-        if (state.avalancheTriggered && avalanche.hasPassed(snowman.position)) {
-          console.log("Avalanche passed - player survived!");
-          avalanche.reset();
-          state.avalancheTriggered = false;
-          state.lastAvalancheZ = pos.z; // Reset trigger point for potential next avalanche
-        }
-
-        // Telegraph the threat: banner, "distance behind you" meter, vignette, shake.
-        if (EffectsModule) {
-          const avActive = state.avalancheTriggered && avalanche.active;
-          const avDist = avActive ? avalanche.getClosestDistance(snowman.position) : Infinity;
-          EffectsModule.updateAvalanche(avActive, avDist);
-          // Avalanche rumble crescendos with the same proximity the banner uses (#158).
-          Sfx.setAvalanche(avActive, avDist);
-        }
-      }
-
-      // Save player position before snow splash effect updates
-      const playerPosBefore = {
-        x: snowman.position.x,
-        y: snowman.position.y,
-        z: snowman.position.z
-      };
-
-      // Update snow splash particles - pass all required parameters
-      Snow.updateSnowSplash(snowSplash, delta, snowman, velocity, player.isInAir, scene);
-
-      // Ensure snowman position wasn't affected by particles
-      snowman.position.set(playerPosBefore.x, playerPosBefore.y, playerPosBefore.z);
-
-      updateCamera();
-      updateTimerDisplay(state.gameActive, state.startTime); // Update the timer display
-
-      // Camera juice: speed-based FOV + shake. Apply for the render only, then revert
-      // the positional offset so the camera manager's own smoothing stays clean.
-      let _shake: ShakeOffset | null = null;
-      if (EffectsModule) {
-        const spd = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z);
-        _shake = EffectsModule.tickCamera(camera, delta, spd);
-      }
-      renderer.render(scene, camera);
-      if (_shake) {
-        camera.position.x -= _shake.x;
-        camera.position.y -= _shake.y;
-        camera.position.z -= _shake.z;
-      }
+      renderFrame(frameDelta, plan.alpha, result, events);
     } else if (state.animationRunning) {
       state.animationRunning = false;
     }
@@ -250,6 +383,8 @@ export function createMainLoop(deps: MainLoopDeps) {
   // while `lastTime` remains private to the loop.
   function startLoop() {
     lastTime = performance.now();
+    accumulator = 0;
+    renderPrev = null;
     animate(lastTime);
   }
 
@@ -261,3 +396,6 @@ export function createMainLoop(deps: MainLoopDeps) {
 
   return { updateSnowman, updateCamera, animate, startLoop, handleResize };
 }
+
+// Re-export the accumulator surface for the frame-rate-equivalence / tunnel-risk harnesses.
+export { FIXED_DT, MAX_SUBSTEPS, planSubsteps };

--- a/tests/README.md
+++ b/tests/README.md
@@ -268,6 +268,17 @@ the two contracts that the browser/Node unit tests can't easily assert end-to-en
   synthetic slope) and asserts the 10-FPS/60-FPS front-travel ratio stays near 1 and all
   boulder state stays finite. Guards the per-frame-friction regression fixed alongside
   this harness (the same bug class as PR #209). Also run via `npm run test:stress`.
+- **`fixed_timestep_harness.js`** — frame-rate-EQUIVALENCE + no-tunnelling gate for the
+  fixed-timestep run loop. Drives the loop's **real** accumulator
+  (`src/game/fixed-timestep.ts` `planSubsteps`, the exact function `main-loop.ts` uses)
+  over the real kernel + terrain + trees/rocks and gates the two guarantees the fixed step
+  newly provides: **(1)** the same run produces a **byte-identical trajectory** at 30 / 50 /
+  144 FPS and under a jittery schedule vs the 60 FPS reference (the variable-dt loop diverges
+  — shown as a contrast); **(2)** replayed through the diagnostics classifier at `1/60`, every
+  physics substep's step is `velocity/60`, so **`tunnelRiskFrames == 0`** and the
+  collision-check granularity is frame-rate-independent (the old per-frame granularity grew
+  with frame time — the tunnelling precondition). The pure accumulator math is unit-covered in
+  `tests/fixed-timestep-tests.js`. Both run via `npm run test:fixed-timestep` (also in `npm test`).
 - **`results.txt`** — the recorded output from the last full verification run.
 
 ```bash

--- a/tests/fixed-timestep-tests.js
+++ b/tests/fixed-timestep-tests.js
@@ -1,0 +1,106 @@
+// @ts-check
+// fixed-timestep-tests.js — unit coverage for the PURE fixed-timestep accumulator math
+// (src/game/fixed-timestep.ts) that the run loop uses to advance physics in fixed 1/60 s
+// substeps regardless of render rate. These assert the bookkeeping the determinism /
+// no-tunnelling guarantee rests on; the integration proof (kernel trajectories match
+// across frame rates) lives in tests/verification/fixed_timestep_harness.js.
+//
+// Run via the register-ts-resolve loader so the `.ts` source resolves headlessly.
+const { pathToFileURL } = require('url');
+const path = require('path');
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  condition ? pass++ : fail++;
+}
+function near(a, b, eps = 1e-9) { return Math.abs(a - b) <= eps; }
+
+(async () => {
+  await import(pathToFileURL(path.join(__dirname, 'loaders', 'register-ts-resolve.mjs')).href);
+  const { FIXED_DT, MAX_SUBSTEPS, planSubsteps, lerp } = await import('../src/game/fixed-timestep.ts');
+
+  console.log('--- constants ---');
+  check('FIXED_DT is 1/60 (the rate the invariant harness pins)', near(FIXED_DT, 1 / 60));
+  check('MAX_SUBSTEPS is 8 (~133 ms ceiling)', MAX_SUBSTEPS === 8);
+
+  console.log('\n--- planSubsteps: exact-60-FPS frame consumes exactly one substep ---');
+  {
+    const p = planSubsteps(FIXED_DT, 0);
+    check('one substep', p.substeps === 1);
+    check('accumulator drained to ~0', near(p.accumulator, 0));
+    check('alpha ~0', near(p.alpha, 0));
+  }
+
+  console.log('\n--- planSubsteps: sub-60 render frame runs multiple substeps ---');
+  {
+    // A 20 FPS frame (0.05 s) is exactly 3 fixed steps.
+    const p = planSubsteps(0.05, 0);
+    check('three substeps at 20 FPS', p.substeps === 3);
+    check('no remainder', near(p.accumulator, 0));
+  }
+
+  console.log('\n--- planSubsteps: high-refresh frame carries a remainder, runs 0 substeps ---');
+  {
+    // A 144 FPS frame (~0.00694 s) is below one fixed step: 0 substeps, accumulate.
+    const p = planSubsteps(1 / 144, 0);
+    check('zero substeps below the fixed step', p.substeps === 0);
+    check('remainder carried in accumulator', near(p.accumulator, 1 / 144));
+    check('alpha = accumulator / FIXED_DT in [0,1)', p.alpha >= 0 && p.alpha < 1 && near(p.alpha, (1 / 144) / FIXED_DT));
+  }
+
+  console.log('\n--- planSubsteps: remainder accumulates across frames into a step ---');
+  {
+    // Two 144 FPS frames (~0.0139 s) still under one step; the third crosses it.
+    let acc = 0, total = 0;
+    for (let i = 0; i < 3; i++) { const p = planSubsteps(1 / 144, acc); acc = p.accumulator; total += p.substeps; }
+    check('a substep eventually fires once enough time accrues', total === 1);
+    check('leftover stays below one fixed step', acc >= 0 && acc < FIXED_DT);
+  }
+
+  console.log('\n--- planSubsteps: spiral-of-death guard caps substeps per frame ---');
+  {
+    // A 2 s pause would be 120 steps; the ceiling clamps it to MAX_SUBSTEPS and drops the rest.
+    const p = planSubsteps(2.0, 0);
+    check('substeps capped at MAX_SUBSTEPS', p.substeps === MAX_SUBSTEPS);
+    check('excess real time dropped (accumulator < FIXED_DT)', p.accumulator < FIXED_DT);
+  }
+
+  console.log('\n--- planSubsteps: pathological deltas cannot rewind or burst ---');
+  {
+    const neg = planSubsteps(-1, 0);
+    check('negative delta runs no substeps', neg.substeps === 0 && near(neg.accumulator, 0));
+    const nan = planSubsteps(NaN, 0);
+    check('NaN delta runs no substeps (no burst)', nan.substeps === 0 && Number.isFinite(nan.accumulator));
+  }
+
+  console.log('\n--- planSubsteps: total substeps over a descent are frame-rate INVARIANT ---');
+  {
+    // The core determinism property: the same in-game time advances the SAME number of
+    // fixed substeps no matter how it is chopped into frames, so the kernel sees an
+    // identical sequence of FIXED_DT steps at every render rate.
+    const SECONDS = 10;
+    function totalSubsteps(frameDt) {
+      let acc = 0, total = 0, t = 0;
+      while (t < SECONDS - 1e-12) { const p = planSubsteps(frameDt, acc); acc = p.accumulator; total += p.substeps; t += frameDt; }
+      return total;
+    }
+    const expected = Math.round(SECONDS / FIXED_DT); // 600
+    const at60 = totalSubsteps(1 / 60);
+    const at30 = totalSubsteps(1 / 30);
+    const at144 = totalSubsteps(1 / 144);
+    // Equal to within one substep across rates — the only slack is sub-FIXED_DT
+    // floating-point residue at the frame boundaries, never a per-rate force scaling.
+    check(`60 FPS over ${SECONDS}s runs ~${expected} substeps`, Math.abs(at60 - expected) <= 1);
+    check('30 FPS runs the same total (±1)', Math.abs(at30 - at60) <= 1);
+    check('144 FPS runs the same total (±1)', Math.abs(at144 - at60) <= 1);
+  }
+
+  console.log('\n--- lerp ---');
+  check('lerp endpoints', near(lerp(2, 8, 0), 2) && near(lerp(2, 8, 1), 8));
+  check('lerp midpoint', near(lerp(2, 8, 0.5), 5));
+
+  console.log(`\nFIXED-TIMESTEP UNIT TESTS: ${fail === 0 ? 'OK ✅' : 'FAIL ❌'} (${pass} passed, ${fail} failed)`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });

--- a/tests/verification/fixed_timestep_harness.js
+++ b/tests/verification/fixed_timestep_harness.js
@@ -1,0 +1,237 @@
+// @ts-check
+// fixed_timestep_harness.js
+// Frame-rate-EQUIVALENCE + NO-TUNNELLING gate for the fixed-timestep run loop.
+//
+// Sibling to forward_stress_harness.js (PR #209). That harness drives the physics kernel
+// directly at a handful of fixed rates and gates that speed stays bounded and nothing
+// tunnels. This one drives the run loop's REAL fixed-timestep accumulator
+// (src/game/fixed-timestep.ts `planSubsteps`, the exact function main-loop.ts uses) over
+// the REAL kernel + REAL terrain + REAL trees/rocks, and gates the two NEW guarantees the
+// accumulator newly provides — the ones the old variable-dt loop could not:
+//
+//   1. FRAME-RATE EQUIVALENCE — because the loop now only ever advances physics in fixed
+//      FIXED_DT (1/60 s) steps, the SAME run produces a byte-identical trajectory at 30 /
+//      50 / 144 FPS and under a jittery variable frame schedule, vs the 60 FPS reference.
+//      The render rate only regroups identical substeps; it never changes the dt the kernel
+//      integrates. The old variable-dt loop fails this (reported as the [CONTRAST] below).
+//
+//   2. FRAME-RATE-INVARIANT COLLISION GRANULARITY / NO TUNNELLING (tunnelRiskFrames == 0) —
+//      replayed through the diagnostics classifier (src/diagnostics.ts, the live runtime
+//      detector) at FIXED_DT, every PHYSICS substep's step is `velocity / 60`, far under the
+//      smallest obstacle radius AND independent of render rate, so the tunnel-risk frame
+//      count is zero by construction at any FPS. The old per-frame loop's collision-check
+//      granularity instead GREW with frame time (per-frame step ~ velocity * frameDelta) —
+//      the precondition for the "floor it forward and blow through a tree" tunnelling bug,
+//      reported as the [CONTRAST]. (NB: the kernel's PR #209 drag fix already bounds terminal
+//      speed, so at today's ~8 m/s cruise neither loop tunnels on a gentle descent; the fixed
+//      step makes the granularity STRUCTURALLY frame-rate-independent, so a future change that
+//      raised speeds could not reintroduce low-FPS tunnelling.)
+//
+// Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/fixed_timestep_harness.js
+const { pathToFileURL } = require('url');
+const path = require('path');
+
+// Minimal browser globals the kernel + tree/rock placement touch (no DOM/WebGL).
+const g = /** @type {any} */ (globalThis);
+g.window = { location: { search: '' }, matchMedia: () => ({ matches: false }), terrainMesh: null };
+g.document = undefined; // trees/rocks skip canvas textures when document is absent
+try { Object.defineProperty(global, 'navigator', { value: { webdriver: false }, configurable: true }); } catch { /* keep existing */ }
+
+// Seeded PRNG so tree/rock placement and the kernel's auto-turn are reproducible and the
+// ONLY variable across the frame-rate sweep is how time is chopped into render frames.
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+}
+
+function makeScene() {
+  const children = [];
+  return /** @type {any} */ ({ children, add(o) { children.push(o); }, remove(o) { const i = children.indexOf(o); if (i >= 0) children.splice(i, 1); }, userData: {} });
+}
+
+function fakeSnowman() {
+  const ski = () => ({ position: { x: 0 }, rotation: { x: 0, y: 0, z: 0 } });
+  return /** @type {any} */ ({
+    position: { x: 0, y: 0, z: 0, set(x, y, z) { this.x = x; this.y = y; this.z = z; } },
+    rotation: { x: 0, y: Math.PI, z: 0 },
+    userData: { targetRotationY: Math.PI, currentRotX: 0, currentRotZ: 0,
+                leftSki: ski(), rightSki: ski(), leftSkiBaseX: -1, rightSkiBaseX: 1 },
+  });
+}
+
+(async () => {
+  await import(pathToFileURL(path.join(__dirname, '..', 'loaders', 'register-ts-resolve.mjs')).href);
+  const { Snowman } = await import('../../src/snowman.ts');
+  const terrain = await import('../../src/mountains/terrain.ts');
+  const { Trees } = await import('../../src/mountains/trees.ts');
+  const { addRocks, rockCollisionRadius, ROCK_COLLISION_MIN_SIZE } = await import('../../src/mountains/rocks.ts');
+  const { FIXED_DT, planSubsteps } = await import('../../src/game/fixed-timestep.ts');
+  const { classifyFrame, foldFrame, emptySummary, DEFAULT_CONFIG } = await import('../../src/diagnostics.ts');
+  const { getTerrainHeight, getTerrainGradient, getDownhillDirection } = terrain;
+
+  const TREE_RADIUS = 2.5;
+  const SEEDS = [12345, 777, 42, 9001];
+  const HOLD_UP = { left: false, right: false, up: true, down: false, jump: false };
+
+  // Build the obstacle field for a seed (silenced placement logs).
+  function buildField(seed) {
+    Math.random = makeRng(seed);
+    const scene = makeScene();
+    const _log = console.log, _warn = console.warn;
+    console.log = () => {}; console.warn = () => {};
+    const treePositions = Trees.addTrees(scene);
+    const rockPositions = addRocks(scene);
+    console.log = _log; console.warn = _warn;
+    return { treePositions, rockPositions };
+  }
+
+  // Fresh descent state at the spawn.
+  function spawn() {
+    const pos = { x: 0, z: -15, y: getTerrainHeight(0, -15) };
+    const velocity = { x: 0, z: -3 };
+    const snowman = fakeSnowman();
+    snowman.position.set(pos.x, pos.y, pos.z);
+    const st = { isInAir: false, verticalVelocity: 0, lastTerrainHeight: getTerrainHeight(0, -15),
+                 airTime: 0, jumpCooldown: 0, turnPhase: 0, currentTurnDirection: 0, turnChangeCooldown: 3 };
+    return { pos, velocity, snowman, st };
+  }
+
+  // One kernel substep (mirrors main-loop.ts stepFixed's physics advance).
+  function kernelStep(world, dt, treePositions, rockPositions) {
+    const { pos, velocity, snowman, st } = world;
+    const next = Snowman.updateSnowman(snowman, dt, pos, velocity, st.isInAir, st.verticalVelocity,
+      st.lastTerrainHeight, st.airTime, st.jumpCooldown, HOLD_UP, st.turnPhase, st.currentTurnDirection,
+      st.turnChangeCooldown, 3.0, getTerrainHeight, getTerrainGradient, getDownhillDirection,
+      treePositions, true, () => {}, rockPositions);
+    snowman.position.set(pos.x, pos.y, pos.z);
+    world.st = next;
+    return next;
+  }
+
+  // --- Drive the REAL accumulator at a given frame schedule for EXACTLY `targetSubsteps`
+  // fixed steps. Because every rate runs the identical sequence of FIXED_DT kernel calls
+  // (same seed -> same auto-turn RNG, same constant controls), the only thing that varies
+  // is how render frames group those substeps — which cannot change the result. ---
+  function runAccumulator(seed, frameDtFn, targetSubsteps, field, record) {
+    Math.random = makeRng(0xC0FFEE ^ seed); // identical kernel RNG stream across rates
+    const world = spawn();
+    let acc = 0, done = 0, frameIdx = 0;
+    while (done < targetSubsteps) {
+      const plan = planSubsteps(frameDtFn(frameIdx++), acc);
+      acc = plan.accumulator;
+      for (let i = 0; i < plan.substeps && done < targetSubsteps; i++) {
+        kernelStep(world, FIXED_DT, field.treePositions, field.rockPositions);
+        done++;
+        if (record) record(world); // per-SUBSTEP record (FIXED_DT) — the diagnostics view
+      }
+    }
+    return { x: world.pos.x, z: world.pos.z, vx: world.velocity.x, vz: world.velocity.z };
+  }
+
+  // --- Legacy variable-dt loop (the OLD behavior): one kernel call per render frame at the
+  // capped frame delta. Used only as a CONTRAST to show the bug the accumulator removes. ---
+  function runLegacy(seed, frameDt, seconds, field, record) {
+    Math.random = makeRng(0xC0FFEE ^ seed);
+    const world = spawn();
+    let t = 0;
+    while (t < seconds - 1e-9) {
+      const dt = Math.min(frameDt, 0.1); // the old loop's delta cap
+      const prevX = world.pos.x, prevZ = world.pos.z;
+      kernelStep(world, dt, field.treePositions, field.rockPositions);
+      t += frameDt;
+      if (record) record(world, prevX, prevZ);
+    }
+    return { x: world.pos.x, z: world.pos.z };
+  }
+
+  const SCHEDULES = {
+    '60': () => 1 / 60,
+    '30': () => 1 / 30,
+    '50': () => 1 / 50,
+    '144': () => 1 / 144,
+    'jitter': (() => { const r = makeRng(0xBEEF); return () => (r() < 0.1 ? 0.1 : 1 / 60); })(),
+  };
+  const TARGET_SUBSTEPS = 480; // ~8 in-game seconds of fixed steps
+
+  let hardFail = false;
+
+  // === 1) Frame-rate equivalence [GATING] ===========================================
+  console.log('=== Fixed-timestep run loop: equivalence + no-tunnelling ===');
+  console.log('\n--- 1) Frame-rate EQUIVALENCE: accumulator trajectory is identical at 30/50/144/jitter vs 60 [GATING] ---');
+  const EPS = 1e-9;
+  let worstGap = 0, worstCtx = '';
+  for (const seed of SEEDS) {
+    const field = buildField(seed);
+    // A fresh jitter schedule per seed so the variable run isn't a fixed pattern.
+    const jitter = (() => { const r = makeRng(0xBEEF ^ seed); return () => (r() < 0.1 ? 0.1 : 1 / 60); })();
+    const ref = runAccumulator(seed, SCHEDULES['60'], TARGET_SUBSTEPS, field, null);
+    for (const [name, fn] of [['30', SCHEDULES['30']], ['50', SCHEDULES['50']], ['144', SCHEDULES['144']], ['jitter', jitter]]) {
+      const r = runAccumulator(seed, fn, TARGET_SUBSTEPS, field, null);
+      const gap = Math.hypot(r.x - ref.x, r.z - ref.z) + Math.hypot(r.vx - ref.vx, r.vz - ref.vz);
+      if (gap > worstGap) { worstGap = gap; worstCtx = `${name} FPS, seed ${seed}`; }
+    }
+  }
+  const equivalent = worstGap < EPS;
+  console.log('  worst trajectory+velocity gap vs the 60 FPS reference:', worstGap.toExponential(2), `(${worstCtx})`, '| eps:', EPS.toExponential(0));
+  console.log('  PASS:', equivalent ? 'every render rate reproduces the 60 FPS trajectory exactly ✅' : 'a render rate diverged from 60 FPS ❌');
+  if (!equivalent) hardFail = true;
+
+  // [CONTRAST] the old variable-dt loop diverges across frame rates (why this fix exists).
+  {
+    const field = buildField(SEEDS[0]);
+    const ref = runLegacy(SEEDS[0], 1 / 60, 8, field, null);
+    const low = runLegacy(SEEDS[0], 1 / 10, 8, field, null);
+    const gap = Math.hypot(low.x - ref.x, low.z - ref.z);
+    console.log('  [CONTRAST] old variable-dt loop, 10 FPS vs 60 FPS over 8s:', gap.toFixed(1), 'u apart — the divergence the accumulator removes');
+  }
+
+  // === 2) No tunnelling: tunnelRiskFrames == 0 at low FPS [GATING] ====================
+  console.log('\n--- 2) NO TUNNELLING: diagnostics reports zero tunnelRiskFrames driving the loop at low FPS [GATING] ---');
+  // Use the SMALLEST guarded obstacle radius, exactly as snowglider.ts wires Diag.
+  const cfg = { ...DEFAULT_CONFIG, collisionRadius: Math.min(TREE_RADIUS, rockCollisionRadius(ROCK_COLLISION_MIN_SIZE)) };
+  let totalTunnelFixed = 0, worstStepFixed = 0;
+  for (const seed of SEEDS) {
+    const field = buildField(seed);
+    for (const name of ['144', '60', '30', '50', 'jitter']) {
+      const summary = emptySummary();
+      let prev = null;
+      const record = (world) => {
+        const sample = { dt: FIXED_DT, speed: Math.hypot(world.velocity.x, world.velocity.z), x: world.pos.x, z: world.pos.z, technique: 'glide', isInAir: world.st.isInAir };
+        const flags = classifyFrame(prev, sample, cfg);
+        foldFrame(summary, sample, flags);
+        prev = { x: sample.x, z: sample.z };
+      };
+      const jitter = (() => { const r = makeRng(0xBEEF ^ seed); return () => (r() < 0.1 ? 0.1 : 1 / 60); })();
+      const fn = name === 'jitter' ? jitter : SCHEDULES[name];
+      runAccumulator(seed, fn, TARGET_SUBSTEPS, field, record);
+      totalTunnelFixed += summary.tunnelRiskFrames;
+      if (summary.stepMax > worstStepFixed) worstStepFixed = summary.stepMax;
+    }
+  }
+  const noTunnel = totalTunnelFixed === 0 && worstStepFixed < cfg.collisionRadius;
+  console.log('  collision radius guarded:', cfg.collisionRadius.toFixed(2), '| worst per-SUBSTEP step:', worstStepFixed.toFixed(3));
+  console.log('  tunnelRiskFrames across all seeds x rates:', totalTunnelFixed);
+  console.log('  PASS:', noTunnel ? 'every fixed substep stays inside the collision radius ✅' : 'a substep stepped past an obstacle disk ❌');
+  if (!noTunnel) hardFail = true;
+
+  // [CONTRAST] the old per-frame loop's collision-check granularity (worst per-frame step)
+  // GROWS with frame time, while the fixed substep stays constant at every render rate —
+  // the structural frame-rate dependence the fixed step removes (the tunnelling precondition).
+  {
+    const field = buildField(SEEDS[0]);
+    const worstFrameStep = (frameDt) => {
+      let worst = 0;
+      runLegacy(SEEDS[0], frameDt, 8, field, (world, prevX, prevZ) => {
+        worst = Math.max(worst, Math.hypot(world.pos.x - prevX, world.pos.z - prevZ));
+      });
+      return worst;
+    };
+    const s60 = worstFrameStep(1 / 60), s30 = worstFrameStep(1 / 30), s10 = worstFrameStep(1 / 10);
+    console.log('  [CONTRAST] old variable-dt loop worst per-frame step: 60FPS=' + s60.toFixed(3),
+      '30FPS=' + s30.toFixed(3), '10FPS=' + s10.toFixed(3),
+      '— granularity scales with frame time; the fixed substep stays', worstStepFixed.toFixed(3), 'u at every rate');
+  }
+
+  console.log(`\nFIXED-TIMESTEP HARNESS: ${hardFail ? 'FAIL ❌ (a gating check failed)' : 'OK ✅ (frame-rate equivalent; zero tunnel risk)'}`);
+  process.exit(hardFail ? 1 : 0);
+})().catch((e) => { console.error('FATAL', e); process.exit(1); });


### PR DESCRIPTION
## Summary

Restructures the hot run loop (`src/game/main-loop.ts`) to advance physics with a **fixed-timestep accumulator** instead of the raw, variable render delta. This closes the `#209` frame-rate-dependence bug class *at the source* rather than patching it per-force.

The old loop stepped the kernel with `min(delta, 0.1)`, which makes the steady state frame-rate dependent: at low FPS a single `pos += velocity·delta` step can exceed an obstacle's collision radius (tunnelling through a tree), and any per-frame-vs-per-second force mismatch balloons terminal speed. Stepping physics **only** in `FIXED_DT = 1/60` s substeps — exactly the rate `physics_invariant_harness.js` pins the kernel at — removes the cause:

- the per-step displacement is `velocity / 60`, well under any collision radius → **tunnel-risk frames are zero by construction** at any render rate;
- the trajectory is **frame-rate independent** — byte-identical at 30 / 50 / 144 FPS and under a jittery schedule;
- the live build advances physics at the same rate the suite tests — *the thing tested becomes the thing that runs*.

The physics kernel (`snowman/physics.ts`) is **unchanged**: at `1/60`, `dragFactor` is an identity, so the kernel is byte-identical to the harness's `1/60` world. The accumulator lives entirely in the loop.

## What changed

- **`src/game/fixed-timestep.ts`** (new) — the pure, dependency-free accumulator core (`FIXED_DT`, `MAX_SUBSTEPS`, `planSubsteps`, `lerp`). No THREE/DOM state, so it unit-tests headlessly and the harnesses drive the *same* stepping logic the live loop uses.
- **`src/game/main-loop.ts`** — split the per-frame work:
  - `stepFixed(FIXED_DT)` runs anything that changes physics state or could be *missed between frames*: the physics advance, course progress + finish, avalanche burial, and the read-only `Diag.record` (per substep, so the step it sees is the fixed-grid displacement → `tunnelRiskFrames == 0`).
  - `renderFrame(frameDelta, alpha)` runs everything purely visual once per render frame: HUD, Flex, SFX, particles, sky, ski trails, the avalanche advance + UI, and the camera/snowman render **interpolated** at `lerp(prevPos, curPos, alpha)` to de-alias non-60 panels.
  - Landing/takeoff **events are reduced across a frame's substeps**, so a jump-and-land that completes mid-frame still fires its whoosh/thump/toast (and the meaningful-jumps `#47` finish-frame guarantee is preserved).
  - `MAX_SUBSTEPS = 8` is the spiral-of-death guard — the same ~133 ms ceiling the old `min(delta, 0.1)` clamp imposed, as a step count, so a very slow frame *slows time* rather than tunnelling.
  - `updateSnowman(delta)` is retained as a compat seam (one `stepFixed` + the snowman-observer layer; no world-advance/render) so the browser suites can still drive one frame by bare name.
- **docs** — `ARCHITECTURE.md` §5, `PHYSICS.md` §1, `CHANGELOG.md`, and `tests/README.md` updated for the new loop.

## Tests

- **`tests/fixed-timestep-tests.js`** (new) — unit-covers the pure accumulator: substep counting, the spiral guard, pathological/negative/NaN deltas, and frame-rate-invariant substep totals.
- **`tests/verification/fixed_timestep_harness.js`** (new) — drives the **real** accumulator over the **real** kernel + terrain + trees/rocks and gates the two newly-guaranteed properties:
  1. **frame-rate equivalence** — the 30/50/144/jitter trajectory matches the 60 FPS reference to `0.0` (vs the old variable-dt loop, ~4 u apart — shown as a contrast);
  2. **`tunnelRiskFrames == 0`** via the diagnostics classifier, with the old loop's collision-check granularity (0.137 → 0.273 → 0.785 u as FPS drops) shown as the contrast.
- Wired into `npm test` via the new `test:fixed-timestep` script.

### Verification run

- `npm run typecheck`, `npm run lint` — clean (0 errors).
- `npm test` — full Node suite green, including `test:verify` (invariant harness **byte-identical** — proves the kernel didn't move), `test:stress` (forward + avalanche frame-rate harnesses), `test:physics`, `test:regression`, `test:fixed-timestep`.
- `npm run test:browser` — all suites pass (game/physics/collision/jump/tree/avalanche = 87 passed, 0 failed in the unified run; camera = 9/9 verified in isolation). `updateCamera()` is byte-identical, so camera tests are unaffected.

## Notes / tradeoffs

- **Interpolation latency** — rendering at `alpha` adds up to ~1 fixed step (~16 ms) of visual latency; acceptable for this game and gated behind a one-line `RENDER_INTERPOLATION` switch.
- **Very low FPS slows time** — by design (spiral guard), the identical ceiling to today's `0.1` s clamp, strictly preferable to tunnelling.
- No new UI / no rendered-visual change at 60 FPS, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVDB79sUnzpDeCTBEH6h8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVDB79sUnzpDeCTBEH6h8F)_