### PR TITLE
Dispose/teardown audit: idempotent disposeGame() + listener hygiene

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -26,6 +26,7 @@
     "test:flex": "node --import ./tests/loaders/register-ts-resolve.mjs tests/snowman-flex-tests.js",
     "test:debris": "node tests/debris-tests.js",
     "test:leak": "node tests/leak-tests.js",
+    "test:teardown": "node --import ./tests/loaders/register-ts-resolve.mjs tests/teardown-tests.js",
     "test:intro": "node --import ./tests/loaders/register-ts-resolve.mjs tests/intro-tests.js",
     "test:sfx": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sfx-tests.js",
     "test:diagnostics": "node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-dom-tests.js",

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -49,6 +49,10 @@ export const AudioModule = (function() {
   let audio: HTMLAudioElement | null = null;
   let muted = false;
   let initialized = false;
+  // Live showMessage() toasts (node + auto-remove timer) so teardown() can clear any that
+  // are still on screen — they're fixed-position z-index:3000 divs that would otherwise
+  // linger over the host page after an unmount until their timeout fires.
+  const activeMessages = new Set<{ el: HTMLElement; timer: ReturnType<typeof setTimeout> }>();
 
   const AUDIO_PATH = 'assets/skullbeatz_bad_cat.mp3';
 
@@ -233,7 +237,9 @@ export const AudioModule = (function() {
         border-radius: 10px; font-size: 24px; z-index: 3000;
       `;
       document.body.appendChild(div);
-      setTimeout(() => div.remove(), duration);
+      // Track the node + timer so teardown() can clear a toast still on screen.
+      const entry = { el: div, timer: setTimeout(() => { div.remove(); activeMessages.delete(entry); }, duration) };
+      activeMessages.add(entry);
     },
     showAudioRetryPrompt: function() {},
 
@@ -243,6 +249,10 @@ export const AudioModule = (function() {
     // a remount. Idempotent and inert if nothing was ever started; `initialized` is reset
     // so a later init()/setupUI() rebuilds cleanly.
     teardown: function() {
+      // Clear any on-screen toasts (and their pending auto-remove timers) FIRST — showMessage
+      // isn't gated on AUDIO_ENABLED, so a toast can exist even when audio is disabled.
+      for (const { el, timer } of activeMessages) { clearTimeout(timer); el.remove(); }
+      activeMessages.clear();
       if (!AUDIO_ENABLED) return;
       if (audio) {
         // pause() halts playback; dropping the reference makes the (detached, paused)

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -235,7 +235,26 @@ export const AudioModule = (function() {
       document.body.appendChild(div);
       setTimeout(() => div.remove(), duration);
     },
-    showAudioRetryPrompt: function() {}
+    showAudioRetryPrompt: function() {},
+
+    // Stop the music and release the mute button (dispose-audit teardown / dev-HMR).
+    // The looping <audio> element and the `#audioControlBtn` are module-level, so without
+    // this they survive disposeGame — the track keeps playing and the button lingers over
+    // a remount. Idempotent and inert if nothing was ever started; `initialized` is reset
+    // so a later init()/setupUI() rebuilds cleanly.
+    teardown: function() {
+      if (!AUDIO_ENABLED) return;
+      if (audio) {
+        // pause() halts playback; dropping the reference makes the (detached, paused)
+        // element GC-eligible. We deliberately do NOT clear .src — assigning '' makes
+        // the media element fire a spurious "empty src" error event.
+        try { audio.pause(); } catch { /* detached element */ }
+        audio = null;
+      }
+      const btn = document.getElementById('audioControlBtn');
+      btn?.parentNode?.removeChild(btn);
+      initialized = false;
+    }
   };
 })();
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -544,6 +544,7 @@ function setupButtonTouchHandlers(signal?: AbortSignal) {
   });
   
   // Start observing the game over overlay
+  let delayedObserveTimer: ReturnType<typeof setTimeout> | null = null;
   const gameOverOverlay = document.getElementById('gameOverOverlay');
   if (gameOverOverlay) {
     gameOverObserver.observe(gameOverOverlay, {
@@ -551,8 +552,14 @@ function setupButtonTouchHandlers(signal?: AbortSignal) {
       attributeFilter: ['style']
     });
   } else {
-    // If game over overlay doesn't exist yet, wait a bit and try again
-    setTimeout(() => {
+    // If game over overlay doesn't exist yet, wait a bit and try again. On mobile this
+    // setup runs before setupScene() creates #gameOverOverlay, so this branch is armed.
+    delayedObserveTimer = setTimeout(() => {
+      delayedObserveTimer = null;
+      // Bail if teardown aborted during the 1s wait: without this the stale observer
+      // could re-attach to a freshly-remounted overlay (HMR) and bind the OLD restart
+      // touch handler to the new game.
+      if (signal && signal.aborted) return;
       const delayedOverlay = document.getElementById('gameOverOverlay');
       if (delayedOverlay) {
         gameOverObserver.observe(delayedOverlay, {
@@ -563,9 +570,13 @@ function setupButtonTouchHandlers(signal?: AbortSignal) {
     }, 1000);
   }
 
-  // MutationObserver has no AbortSignal option, so disconnect it explicitly on teardown
-  // (else a dev-HMR remount leaves a stale observer watching the old overlay).
-  if (signal) signal.addEventListener('abort', () => gameOverObserver.disconnect(), { once: true });
+  // MutationObserver has no AbortSignal option, so disconnect it explicitly on teardown —
+  // and cancel any pending delayed-observe so it can't re-arm a stale observer on a
+  // remounted overlay (else a dev-HMR remount leaks the old observer / restart handler).
+  if (signal) signal.addEventListener('abort', () => {
+    if (delayedObserveTimer !== null) { clearTimeout(delayedObserveTimer); delayedObserveTimer = null; }
+    gameOverObserver.disconnect();
+  }, { once: true });
 }
 
 // Controls is imported directly by snowglider.js and the controls browser test

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -56,20 +56,27 @@ const touchState: TouchState = {
   showVisualControls: false // Flag to enable visual touch controls (optional)
 };
 
-// Setup controls (keyboard + touch)
-function setupControls(): ControlState {
+// Setup controls (keyboard + touch).
+//
+// `signal` (optional): an AbortSignal tying EVERY listener registered here — keyboard,
+// touch, the resize handler, the button touch handlers, and the game-over MutationObserver
+// — to the game's teardown (disposeGame). Aborting it removes them all, so a dev-HMR
+// reload or an unmount/remount doesn't stack duplicate input handlers (e.g. `V` toggling
+// the camera once per stale keydown listener). Omitted by the internal re-init call in
+// toggleTouchControls and any caller that never tears down.
+function setupControls(signal?: AbortSignal): ControlState {
   // Set up keyboard controls
-  setupKeyboardControls();
-  
+  setupKeyboardControls(signal);
+
   // Set up touch controls
-  setupTouchControls();
+  setupTouchControls(signal);
 
   // Return the shared controls object
   return gameControls;
 }
 
 // Setup keyboard control handlers
-function setupKeyboardControls() {
+function setupKeyboardControls(signal?: AbortSignal) {
   // Handle keyboard down events
   const handleKeyDown = (event: KeyboardEvent) => {
     switch(event.key) {
@@ -135,16 +142,22 @@ function setupKeyboardControls() {
     }
   };
   
-  // Add keyboard listeners to both window and document for better coverage
-  window.addEventListener('keydown', handleKeyDown);
-  document.addEventListener('keydown', handleKeyDown);
-  
-  window.addEventListener('keyup', handleKeyUp);
-  document.addEventListener('keyup', handleKeyUp);
+  // Add keyboard listeners to both window and document for better coverage. The
+  // teardown signal (when supplied) lets disposeGame remove them on HMR/unmount.
+  const opts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
+  window.addEventListener('keydown', handleKeyDown, opts);
+  document.addEventListener('keydown', handleKeyDown, opts);
+
+  window.addEventListener('keyup', handleKeyUp, opts);
+  document.addEventListener('keyup', handleKeyUp, opts);
 }
 
 // Setup touch control handlers
-function setupTouchControls() {
+function setupTouchControls(signal?: AbortSignal) {
+  // Listener options: thread the teardown signal when present (passive:false is required
+  // for the touch handlers that preventDefault); else live for the page.
+  const opts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
+  const touchOpts: AddEventListenerOptions = signal ? { passive: false, signal } : { passive: false };
   // Detect if we're on a mobile device
   const isMobileDevice = (): boolean => {
     return (
@@ -159,7 +172,7 @@ function setupTouchControls() {
     touchState.showVisualControls = true;
     
     // Add touch event handlers for reset and restart buttons
-    setupButtonTouchHandlers();
+    setupButtonTouchHandlers(signal);
   }
   
   // Calculate and update touch regions based on screen dimensions
@@ -216,7 +229,7 @@ function setupTouchControls() {
   updateTouchRegions();
   
   // Update regions when window is resized
-  window.addEventListener('resize', updateTouchRegions);
+  window.addEventListener('resize', updateTouchRegions, opts);
   
   // Touches that begin inside a scrollable UI panel (the Controls / Ski Techniques
   // guides) must be handed to the browser so the panel can scroll natively. The
@@ -349,10 +362,10 @@ function setupTouchControls() {
   };
   
   // Add touch event listeners
-  document.addEventListener('touchstart', handleTouchStart, { passive: false });
-  document.addEventListener('touchmove', handleTouchMove, { passive: false });
-  document.addEventListener('touchend', handleTouchEnd, { passive: false });
-  document.addEventListener('touchcancel', handleTouchEnd, { passive: false });
+  document.addEventListener('touchstart', handleTouchStart, touchOpts);
+  document.addEventListener('touchmove', handleTouchMove, touchOpts);
+  document.addEventListener('touchend', handleTouchEnd, touchOpts);
+  document.addEventListener('touchcancel', handleTouchEnd, touchOpts);
   
   // Create visual indicators for touch controls
   function createOrUpdateVisualControls() {
@@ -472,7 +485,8 @@ export const Controls = {
 };
 
 // Function to add explicit touch handlers for game buttons
-function setupButtonTouchHandlers() {
+function setupButtonTouchHandlers(signal?: AbortSignal) {
+  const touchOpts: AddEventListenerOptions = signal ? { passive: false, signal } : { passive: false };
   // Add touch handlers to the reset button
   const resetBtn = document.getElementById('resetBtn');
   if (resetBtn) {
@@ -482,9 +496,9 @@ function setupButtonTouchHandlers() {
       if (typeof window.resetSnowman === 'function') {
         window.resetSnowman();
       }
-    }, { passive: false });
+    }, touchOpts);
   }
-  
+
   // Add touch handler to camera toggle button
   const cameraToggleBtn = document.getElementById('cameraToggleBtn');
   if (cameraToggleBtn) {
@@ -520,7 +534,7 @@ function setupButtonTouchHandlers() {
             if (typeof window.restartGame === 'function') {
               window.restartGame();
             }
-          }, { passive: false });
+          }, touchOpts);
           
           // Mark button as having touch handler to avoid duplicates
           restartButton.setAttribute('touch-handler-added', 'true');
@@ -548,6 +562,10 @@ function setupButtonTouchHandlers() {
       }
     }, 1000);
   }
+
+  // MutationObserver has no AbortSignal option, so disconnect it explicitly on teardown
+  // (else a dev-HMR remount leaves a stale observer watching the old overlay).
+  if (signal) signal.addEventListener('abort', () => gameOverObserver.disconnect(), { once: true });
 }
 
 // Controls is imported directly by snowglider.js and the controls browser test

--- a/src/course.ts
+++ b/src/course.ts
@@ -703,6 +703,21 @@ export const CourseModule = (function () {
     return { renderer, scene, camera };
   }
 
+  // Remove the course HUD DOM and clear the pending flash timer (dispose-audit teardown
+  // / dev-HMR). buildHud appends #courseHud + #courseFlash to document.body, and a
+  // finished run may have left a #courseResult panel; without this they linger over the
+  // host page after disposeGame. The ghost snowman / sparkline GPU resources live in the
+  // scene and are freed by disposeGame's scene sweep. Idempotent; init() rebuilds the HUD.
+  function teardown() {
+    if (flashTimer) { clearTimeout(flashTimer); flashTimer = null; }
+    hud.root?.remove();
+    hud.flash?.remove();
+    if (typeof document !== 'undefined') {
+      document.getElementById('courseResult')?.remove();
+    }
+    hud = {};
+  }
+
   return {
     init,
     reset,
@@ -711,6 +726,7 @@ export const CourseModule = (function () {
     addAirScore,
     hideHud,
     onFinish,
+    teardown,
     // exposed for potential tests
     _config: { START_Z, FINISH_Z, CHECKPOINT_Z, COURSE_LENGTH, splitPoints }
   };

--- a/src/course.ts
+++ b/src/course.ts
@@ -716,6 +716,12 @@ export const CourseModule = (function () {
       document.getElementById('courseResult')?.remove();
     }
     hud = {};
+    // Null the scene-owned handles so a remount rebuilds them. buildGates()/buildGhost()
+    // early-return while these are truthy, so leaving them pointing at the disposed
+    // scene's objects would silently skip adding the gates/ghost to the new scene. Their
+    // GPU resources are freed by disposeGame's scene sweep; this only drops the handles.
+    gateGroup = null;
+    ghost = null;
   }
 
   return {

--- a/src/course.ts
+++ b/src/course.ts
@@ -722,6 +722,14 @@ export const CourseModule = (function () {
     // GPU resources are freed by disposeGame's scene sweep; this only drops the handles.
     gateGroup = null;
     ghost = null;
+    // Drop the init() handles too, so this singleton doesn't retain the disposed
+    // renderer/camera/scene (and their object graph) after an embed/HMR unmount. init()
+    // re-sets all of them on the next mount.
+    scene = null;
+    getTerrainHeight = null;
+    createSnowman = null;
+    renderer = null;
+    camera = null;
   }
 
   return {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -326,8 +326,10 @@ class Diagnostics {
   private sink: DiagSink = () => {}; // structured-event transport (Firebase Analytics)
   private reportedAnomaly = false;   // physics anomaly reported once per run (debounce)
   private lastHealthEmitSec = 0;     // clock of the last session_health emit (heartbeat dedup)
-  private errorHandlersInstalled = false;
   private notes: Array<{ atSec: number; category: string; detail: Record<string, unknown> }> = [];
+  // Owns every window listener init() installs (keydown/pagehide/error/unhandledrejection)
+  // so teardown() can remove them all with one abort (dispose-audit / dev-HMR).
+  private ac: AbortController | null = null;
 
   /** Wire up the recorder. Safe to call once at startup. Honors the automation gate and
    *  the ?debug overlay flag; without a DOM it just enables the headless recorder.
@@ -346,6 +348,11 @@ class Diagnostics {
     this.active = !automated || optedIn;
     if (!this.active) return;
 
+    // Fresh controller for this run's window listeners (teardown() aborts it). Abort any
+    // previous one first so a re-init (remount) doesn't stack duplicate listeners.
+    if (this.ac) this.ac.abort();
+    this.ac = new AbortController();
+
     // Global error capture: there is no other window.onerror / unhandledrejection in the
     // app, so an uncaught throw in the rAF loop (a real "freezes" candidate) otherwise
     // vanishes. Route it through the same sink with the recent physics trace as context.
@@ -356,15 +363,16 @@ class Diagnostics {
 
     if (typeof document !== 'undefined') {
       if (wantOverlay) this.ensureOverlay();
+      const signal = this.ac.signal;
       // Hotkey: backtick toggles the overlay during normal play (off under automation).
       window.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === '`') this.toggleOverlay();
-      });
+      }, { signal });
       // Last-chance baseline flush: if the player navigates away mid-run or after a
       // game-over without pressing Reset, reset() never runs — so emit the owed
       // session_health here. pagehide is the reliable teardown hook on mobile (Safari
       // fires it where unload/beforeunload are unreliable); de-duped via flushHealthBaseline.
-      window.addEventListener('pagehide', () => this.flushHealthBaseline());
+      window.addEventListener('pagehide', () => this.flushHealthBaseline(), { signal });
       // Bug-report API: __snowgliderDiag.dump() returns the trace + verdict and, in a
       // browser, also downloads it as JSON so a tester can attach it to an issue.
       (window as unknown as { __snowgliderDiag?: unknown }).__snowgliderDiag = {
@@ -373,6 +381,20 @@ class Diagnostics {
         reset: () => this.reset(),
         overlay: (on?: boolean) => (on === undefined ? this.toggleOverlay() : on ? this.ensureOverlay() : this.hideOverlay()),
       };
+    }
+  }
+
+  /** Remove every window listener + global this singleton installed (dispose-audit
+   *  teardown / dev-HMR): the keydown/pagehide hotkey + the error/unhandledrejection
+   *  capture (one abort), the overlay DOM, and the `__snowgliderDiag` bug-report API —
+   *  whose closures retain `this` (and the injected report sink). init() re-installs them
+   *  on the next mount. Idempotent. */
+  teardown(): void {
+    if (this.ac) { this.ac.abort(); this.ac = null; }
+    this.hideOverlay();
+    this.active = false;
+    if (typeof window !== 'undefined') {
+      delete (window as unknown as { __snowgliderDiag?: unknown }).__snowgliderDiag;
     }
   }
 
@@ -469,8 +491,9 @@ class Diagnostics {
    *  current physics snapshot summary as context, routes it to the sink + console.error.
    *  Re-throws nothing; never swallows the browser's own default logging. */
   private installErrorHandlers(): void {
-    if (this.errorHandlersInstalled || typeof window === 'undefined') return;
-    this.errorHandlersInstalled = true;
+    // No re-install guard needed: init() aborts the previous controller before calling
+    // this, so the prior handlers are already gone (one live pair at a time).
+    if (typeof window === 'undefined') return;
     const context = () => {
       const sm = this.summary;
       return {
@@ -480,6 +503,8 @@ class Diagnostics {
         health: frameRateHealth(sm, this.cfg).level,
       };
     };
+    const signal = this.ac?.signal;
+    const opts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
     window.addEventListener('error', (e: ErrorEvent) => {
       this.emit('client_error', {
         message: String(e.message || 'error'),
@@ -488,7 +513,7 @@ class Diagnostics {
         stack: (e.error && e.error.stack ? String(e.error.stack) : '').slice(0, 600),
         ...context(),
       });
-    });
+    }, opts);
     window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
       const reason = e.reason;
       const msg = reason && reason.message ? reason.message : String(reason);
@@ -497,7 +522,7 @@ class Diagnostics {
         stack: (reason && reason.stack ? String(reason.stack) : '').slice(0, 600),
         ...context(),
       });
-    });
+    }, opts);
   }
 
   /** Throttled console warnings on the anomaly categories, so a live slow-device run

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -73,6 +73,7 @@ export const EffectsModule = (function () {
 
     // Red vignette (full-screen radial gradient overlay)
     const vignette = document.createElement('div');
+    vignette.id = 'avalancheVignette';
     Object.assign(vignette.style, {
       position: 'fixed', inset: '0', zIndex: '850', pointerEvents: 'none',
       opacity: '0', transition: reduceMotion ? 'none' : 'opacity 0.15s linear',
@@ -82,6 +83,7 @@ export const EffectsModule = (function () {
 
     // Warning banner
     const banner = document.createElement('div');
+    banner.id = 'avalancheBanner';
     Object.assign(banner.style, {
       position: 'fixed', top: '110px', left: '50%', transform: 'translateX(-50%)',
       zIndex: '902', padding: '10px 22px', borderRadius: '10px',
@@ -95,6 +97,7 @@ export const EffectsModule = (function () {
 
     // Danger meter (label + bar) showing how close the slide is behind you
     const meterWrap = document.createElement('div');
+    meterWrap.id = 'avalancheMeter';
     Object.assign(meterWrap.style, {
       position: 'fixed', top: '152px', left: '50%', transform: 'translateX(-50%)',
       zIndex: '902', width: 'min(300px, 80vw)', display: 'none',
@@ -221,7 +224,22 @@ export const EffectsModule = (function () {
     }
   }
 
-  return { init, updateAvalanche, addShake, tickCamera, reset };
+  // Remove the avalanche-warning DOM and reset transient state (dispose-audit teardown
+  // / dev-HMR). buildUI appends three fixed-position overlays to document.body; without
+  // this they linger over the host page after disposeGame. Idempotent; init() rebuilds.
+  function teardown() {
+    if (ui) {
+      ui.vignette.remove();
+      ui.banner.remove();
+      ui.meterWrap.remove();
+      ui = null;
+    }
+    shake = 0;
+    proximityShake = 0;
+    currentFov = BASE_FOV;
+  }
+
+  return { init, updateAvalanche, addShake, tickCamera, reset, teardown };
 })();
 
 // EffectsModule is imported directly by snowglider.js (issue #84).

--- a/src/game/lifecycle.ts
+++ b/src/game/lifecycle.ts
@@ -25,11 +25,19 @@ export interface LifecycleDeps extends
   // button (the loop keeps running), so it must reseed here or the stale pre-reset position
   // leaks into the render lerp and the first diagnostics step.
   resetLoopState: () => void;
+  // Optional AbortSignal tying the game-lifetime DOM listeners wired in initLifecycleUI
+  // (reset / camera-toggle / restart buttons) to disposeGame's teardown. Omitted by the
+  // lifecycle unit test, which never tears down.
+  signal?: AbortSignal;
 }
 
 export function createLifecycle(deps: LifecycleDeps) {
-  const { state, cameraManager, snowman, gameOverOverlay, restartButton, player, startLoop, resetLoopState } = deps;
+  const { state, cameraManager, snowman, gameOverOverlay, restartButton, player, startLoop, resetLoopState, signal } = deps;
   const pos = player.pos;
+  // Listener options for the game-lifetime button handlers below: thread the teardown
+  // signal when supplied so disposeGame can remove them, else live for the page.
+  const listenerOpts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
+  const touchOpts: AddEventListenerOptions = signal ? { passive: false, signal } : { passive: false };
 
   function resetSnowman() {
     // Reset the snowman + player physics state (position, velocity, camera, and the
@@ -168,7 +176,7 @@ export function createLifecycle(deps: LifecycleDeps) {
   // camera-toggle button (created + appended here), and the restart button.
   function initLifecycleUI() {
     // Initialize controls but don't reset the snowman yet
-    document.getElementById('resetBtn')!.addEventListener('click', resetSnowman);
+    document.getElementById('resetBtn')!.addEventListener('click', resetSnowman, listenerOpts);
 
     // Add camera toggle button
     const cameraToggleBtn = document.createElement('button');
@@ -189,16 +197,16 @@ export function createLifecycle(deps: LifecycleDeps) {
     cameraToggleBtn.style.userSelect = 'none';
 
     // Add both click and touchend events to ensure cross-platform compatibility
-    cameraToggleBtn.addEventListener('click', toggleCameraView);
+    cameraToggleBtn.addEventListener('click', toggleCameraView, listenerOpts);
     cameraToggleBtn.addEventListener('touchend', function(event) {
       event.preventDefault();
       toggleCameraView();
-    }, { passive: false });
+    }, touchOpts);
 
     document.body.appendChild(cameraToggleBtn);
 
     // Add event listener to restart button
-    restartButton.addEventListener('click', restartGame);
+    restartButton.addEventListener('click', restartGame, listenerOpts);
   }
 
   return { resetSnowman, restartGame, toggleCameraView, initLifecycleUI };

--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -51,7 +51,17 @@ export interface GameState {
   gameInitialized: boolean;          // true once the first run has been initialized
 }
 
-export function setupScene() {
+/**
+ * Build the scene, renderer, camera, DOM overlays, and every game subsystem once.
+ *
+ * @param signal optional AbortSignal that ties the game-lifetime DOM listeners
+ *   created here (the restart button's hover handlers) to `disposeGame`'s teardown —
+ *   aborting it removes them. Omitted by callers that never tear down (e.g. tests).
+ */
+export function setupScene(signal?: AbortSignal) {
+  // Listener options that wire game-lifetime handlers to the teardown AbortSignal
+  // when one is supplied (undefined => the listener simply lives for the page).
+  const listenerOpts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
   // --- Scene, Renderer and Camera ---
   // three.js enables color management (r152+) and physically-correct lights
   // (r155+ default) out of the box, both of which would shift SnowGlider's colors
@@ -144,10 +154,10 @@ export function setupScene() {
   restartButton.style.userSelect = 'none';
   restartButton.addEventListener('mouseenter', () => {
     restartButton.style.backgroundColor = '#ff725c';
-  });
+  }, listenerOpts);
   restartButton.addEventListener('mouseleave', () => {
     restartButton.style.backgroundColor = '#ff4136';
-  });
+  }, listenerOpts);
   gameOverOverlay.appendChild(restartButton);
 
   // Add to document

--- a/src/game/teardown.ts
+++ b/src/game/teardown.ts
@@ -116,9 +116,20 @@ export function disposeGame(ctx: SceneContext, teardownListeners?: () => void): 
   } catch (e) {
     console.log('disposeGame: renderer teardown skipped:', (e as Error).message);
   }
-  const canvas = ctx.renderer.domElement;
-  canvas.parentNode?.removeChild(canvas);
 
-  // 6. Game-lifetime DOM listeners (resize, buttons, …) — one abort removes them all.
+  // 6. Instance-owned DOM nodes. setupScene() appends the `#gameCanvas` wrapper (which
+  //    holds renderer.domElement) and `#gameOverOverlay`; initLifecycleUI() appends
+  //    `#cameraToggleBtn`. Removing only the canvas would leave the wrapper + overlay +
+  //    toggle button in the document, so a remount creates duplicate IDs and stale UI,
+  //    and getElementById('gameCanvas') / overlay queries hit the old empty node. Remove
+  //    every owner node. (The wrapper is the canvas's parent, so detaching it takes the
+  //    canvas with it.) Reset/start buttons authored in index.html are NOT ours to remove.
+  const removeNode = (el: Node | null | undefined): void => { el?.parentNode?.removeChild(el); };
+  removeNode(ctx.renderer.domElement.parentNode); // the #gameCanvas wrapper (+ its canvas)
+  removeNode(ctx.gameOverOverlay);
+  removeNode(typeof document !== 'undefined' ? document.getElementById('cameraToggleBtn') : null);
+
+  // 7. Game-lifetime DOM listeners (resize, keyboard/touch, buttons, …) — one abort
+  //    removes them all (Controls + scene-setup + lifecycle + the coordinator's resize).
   if (teardownListeners) teardownListeners();
 }

--- a/src/game/teardown.ts
+++ b/src/game/teardown.ts
@@ -127,7 +127,15 @@ export function disposeGame(ctx: SceneContext, teardownListeners?: () => void): 
   const removeNode = (el: Node | null | undefined): void => { el?.parentNode?.removeChild(el); };
   removeNode(ctx.renderer.domElement.parentNode); // the #gameCanvas wrapper (+ its canvas)
   removeNode(ctx.gameOverOverlay);
-  removeNode(typeof document !== 'undefined' ? document.getElementById('cameraToggleBtn') : null);
+  if (typeof document !== 'undefined') {
+    removeNode(document.getElementById('cameraToggleBtn'));
+    // Mobile visual controls (controls.ts appends these lazily on touch devices); they
+    // have no module state to null, so remove them by class here.
+    document.querySelectorAll('.touch-control').forEach((el) => el.remove());
+  }
+  // Subsystem HUD owned by CourseModule/EffectsModule (#courseHud, #courseFlash, the
+  // avalanche banner/meter/vignette) is removed by their own teardown(), invoked from
+  // the coordinator's disposeSnowGlider — those modules hold the node + state handles.
 
   // 7. Game-lifetime DOM listeners (resize, keyboard/touch, buttons, …) — one abort
   //    removes them all (Controls + scene-setup + lifecycle + the coordinator's resize).

--- a/src/game/teardown.ts
+++ b/src/game/teardown.ts
@@ -1,0 +1,122 @@
+// Teardown / disposal for SnowGlider (dispose-audit plan). A single idempotent
+// `disposeGame(ctx)` entry point that releases EVERY resource the one-shot
+// `setupScene()` allocated — the WebGL context, the scene graph's GPU buffers, the
+// subsystem InstancedMeshes, the pooled tree assets, the canvas DOM node, and the
+// game-lifetime DOM listeners — so the game can be unmounted cleanly.
+//
+// WHY THIS EXISTS (there is no production leak — see the plan §1)
+// --------------------------------------------------------------
+// The run/restart flow correctly REUSES the scene (lifecycle.ts resets state in
+// place and never rebuilds terrain/trees/snowman), so restarting leaks nothing and
+// this path is never on it. The teardown matters in three places the page-IS-the-game
+// model never exercised:
+//   1. Vite dev HMR — every hot edit re-evaluates the module graph; without a
+//      `import.meta.hot.dispose` hook the previous WebGL context, listeners, and GPU
+//      buffers are never released, stacking "too many active contexts" warnings and
+//      leaking memory across a dev session.
+//   2. Embedding / unmount — the moment SnowGlider lives in a route that can unmount
+//      (SPA, modal, portfolio site) navigation leaks the whole context + buffers.
+//   3. Forest rebuild groundwork — the instanced forest's per-forest instance buffers
+//      need disposal if the forest is ever rebuilt; this is the natural home for it.
+//
+// DEDUP IS LOAD-BEARING. Geometries/materials/textures are SHARED singletons (the
+// tree pools, one avalanche InstancedMesh, etc.), so a naive per-mesh `traverse`
+// dispose would free the same pooled buffer many times. `disposeSceneResources`
+// collects each UNIQUE resource into a Set and disposes it exactly once; the tree
+// pools are additionally nulled via `resetTreePools()` so a later rebuild re-creates
+// them instead of referencing freed handles.
+
+import * as THREE from 'three';
+import { resetTreePools } from '../trees.js';
+import type { SceneContext } from './scene-setup.js';
+
+// Idempotence guard, keyed on the context object (not a shared module bool) so each
+// SceneContext disposes at most once while distinct contexts — e.g. across test
+// cases — stay independent. A WeakSet lets a disposed context be GC'd.
+const disposedContexts = new WeakSet<object>();
+
+/**
+ * Dispose every UNIQUE GPU resource reachable from the scene graph, exactly once.
+ *
+ * Geometries, materials, and the textures hung off those materials (`map`,
+ * `normalMap`, …) are deduped through Sets before disposal, because the scene shares
+ * pooled singletons across many meshes — disposing per-traversed-mesh would free the
+ * same buffer repeatedly (and could free a resource still referenced elsewhere). The
+ * caller is responsible for nulling any module-level caches that point at these
+ * now-freed handles (see `resetTreePools`).
+ */
+export function disposeSceneResources(scene: THREE.Scene): void {
+  const geoms = new Set<THREE.BufferGeometry>();
+  const mats = new Set<THREE.Material>();
+  const texes = new Set<THREE.Texture>();
+
+  scene.traverse((obj) => {
+    const m = obj as THREE.Mesh;
+    if (m.geometry) geoms.add(m.geometry);
+    const mat = m.material;
+    if (Array.isArray(mat)) mat.forEach((x) => { if (x) mats.add(x); });
+    else if (mat) mats.add(mat);
+  });
+
+  // Collect textures off each material before disposing it (map/normalMap/etc.).
+  for (const mat of mats) {
+    const fields = mat as unknown as Record<string, unknown>;
+    for (const k of Object.keys(fields)) {
+      const v = fields[k];
+      if (v instanceof THREE.Texture) texes.add(v);
+    }
+    mat.dispose();
+  }
+  for (const g of geoms) g.dispose();
+  for (const t of texes) t.dispose();
+}
+
+/**
+ * Idempotently tear down a SnowGlider instance: stop the loop, free all GPU
+ * resources, drop the renderer + WebGL context, detach the canvas, and remove the
+ * game-lifetime DOM listeners (via the injected `teardownListeners`, which aborts the
+ * coordinator's AbortController). A second call with the same `ctx` is a no-op.
+ *
+ * Does NOT touch the run/restart flow — that path deliberately reuses the scene.
+ *
+ * @param ctx               the handles returned by `setupScene()`
+ * @param teardownListeners removes the game-lifetime listeners (AbortController.abort)
+ */
+export function disposeGame(ctx: SceneContext, teardownListeners?: () => void): void {
+  if (disposedContexts.has(ctx)) return; // idempotent: second dispose is a no-op
+  disposedContexts.add(ctx);
+
+  // 1. Stop the loop.
+  ctx.state.gameActive = false;
+  ctx.state.animationRunning = false;
+
+  // 2. Dispose every unique GPU resource reachable from the scene, once.
+  disposeSceneResources(ctx.scene);
+
+  // 3. Subsystems that own buffers/meshes (mirror their existing patterns). debris
+  //    disposes its owned fragments via reset(); snowTrails/avalanche detach their
+  //    InstancedMesh and free its geometry/material. Double-dispose with the scene
+  //    sweep above is safe (THREE's dispose tolerates a second call).
+  ctx.state.debris?.reset();
+  ctx.state.snowTrails?.dispose();
+  ctx.state.avalanche?.dispose();
+
+  // 4. Null the pooled tree singletons so a later rebuild re-creates them cleanly
+  //    instead of holding freed-but-still-referenced handles (the scene sweep already
+  //    disposed the scene-attached ones; this frees the rest and clears the caches).
+  resetTreePools();
+
+  // 5. Renderer + WebGL context. Wrapped because forceContextLoss touches the live GL
+  //    context, which can throw in a headless / already-lost environment.
+  try {
+    ctx.renderer.dispose();
+    ctx.renderer.forceContextLoss();
+  } catch (e) {
+    console.log('disposeGame: renderer teardown skipped:', (e as Error).message);
+  }
+  const canvas = ctx.renderer.domElement;
+  canvas.parentNode?.removeChild(canvas);
+
+  // 6. Game-lifetime DOM listeners (resize, buttons, …) — one abort removes them all.
+  if (teardownListeners) teardownListeners();
+}

--- a/src/game/teardown.ts
+++ b/src/game/teardown.ts
@@ -63,7 +63,9 @@ export function disposeSceneResources(scene: THREE.Scene): void {
     const fields = mat as unknown as Record<string, unknown>;
     for (const k of Object.keys(fields)) {
       const v = fields[k];
-      if (v instanceof THREE.Texture) texes.add(v);
+      // `instanceof` narrows to Texture<any, any>; cast to the canonical Texture
+      // type so the Set.add argument is type-safe (no-unsafe-argument).
+      if (v instanceof THREE.Texture) texes.add(v as THREE.Texture);
     }
     mat.dispose();
   }

--- a/src/game/teardown.ts
+++ b/src/game/teardown.ts
@@ -44,11 +44,17 @@ const disposedContexts = new WeakSet<object>();
  * same buffer repeatedly (and could free a resource still referenced elsewhere). The
  * caller is responsible for nulling any module-level caches that point at these
  * now-freed handles (see `resetTreePools`).
+ *
+ * InstancedMesh nodes (the forest, avalanche boulders, snow-trail grooves) own
+ * per-instance GPU buffers (`instanceMatrix`/`instanceColor`) that `geometry.dispose()`
+ * does NOT free — only `InstancedMesh.dispose()` does. They are disposed here too so the
+ * sweep actually releases every GPU buffer, not just the shared geometry/material.
  */
 export function disposeSceneResources(scene: THREE.Scene): void {
   const geoms = new Set<THREE.BufferGeometry>();
   const mats = new Set<THREE.Material>();
   const texes = new Set<THREE.Texture>();
+  const instanced = new Set<THREE.InstancedMesh>();
 
   scene.traverse((obj) => {
     const m = obj as THREE.Mesh;
@@ -56,6 +62,10 @@ export function disposeSceneResources(scene: THREE.Scene): void {
     const mat = m.material;
     if (Array.isArray(mat)) mat.forEach((x) => { if (x) mats.add(x); });
     else if (mat) mats.add(mat);
+    // InstancedMesh owns instanceMatrix/instanceColor buffers freed only by its own
+    // dispose() (geometry/material handled above). Each is a distinct scene node, so no
+    // dedup is needed — but a Set keeps the disposal uniform and double-call-safe.
+    if ((obj as THREE.InstancedMesh).isInstancedMesh) instanced.add(obj as THREE.InstancedMesh);
   });
 
   // Collect textures off each material before disposing it (map/normalMap/etc.).
@@ -71,6 +81,9 @@ export function disposeSceneResources(scene: THREE.Scene): void {
   }
   for (const g of geoms) g.dispose();
   for (const t of texes) t.dispose();
+  // Free the per-instance buffers last (geometry/material already gone above; THREE's
+  // InstancedMesh.dispose only releases instanceMatrix/instanceColor, so order is moot).
+  for (const im of instanced) im.dispose();
 }
 
 /**

--- a/src/mountains/trees.ts
+++ b/src/mountains/trees.ts
@@ -713,6 +713,45 @@ function getTerrainGradient(x: number, z: number): TerrainGradient {
   return sampleTerrainGradient(x, z);
 }
 
+// --- Pool teardown (dispose / dev-HMR; see src/game/teardown.ts) ---
+// The shared geometry/material/normal-map singletons above are built lazily and
+// reused for the page's life — fine while the page IS the game. The teardown path
+// (`disposeGame`) and Vite dev-HMR need to release them so a later rebuild (a fresh
+// `setupScene`, an unmount/remount, the forest re-init) re-creates them cleanly
+// instead of dangling as freed-but-still-referenced handles. This disposes every
+// pooled GPU resource this module owns and nulls the caches so the `get*()` lazy
+// builders re-allocate on the next `addTrees`.
+//
+// Most of these are ALSO reachable from the scene graph (the instanced geometries +
+// instanced bark/foliage materials are attached to the 'forestInstanced' meshes, so
+// the scene sweep in teardown.ts disposes them too); THREE's `dispose()` is
+// safe to call twice. The legacy per-shade palette materials (`trunkMaterials` /
+// `foliageMaterials`, kept only for the Group-returning `createTree` shim) are NOT
+// attached to the scene, so disposing them here is the only place they're freed.
+export function resetTreePools(): void {
+  const free = (r: { dispose?: () => void } | null | undefined): void => {
+    if (r && typeof r.dispose === 'function') r.dispose();
+  };
+  free(trunkGeometry);
+  free(coneGeometry);
+  free(branchGeometry);
+  free(snowCapGeometry);
+  free(snowPatchGeometry);
+  free(snowMaterial);
+  free(barkInstancedMaterial);
+  free(foliageInstancedMaterial);
+  (trunkMaterials || []).forEach(free);
+  (foliageMaterials || []).forEach(free);
+  free(barkNormalTexture);
+  free(foliageNormalTexture);
+
+  trunkGeometry = coneGeometry = branchGeometry = snowCapGeometry = snowPatchGeometry = null;
+  trunkColors = foliageColors = null;
+  trunkMaterials = foliageMaterials = null;
+  snowMaterial = barkInstancedMaterial = foliageInstancedMaterial = null;
+  barkNormalTexture = foliageNormalTexture = null;
+}
+
 // Export all tree-related functions
 export const Trees = {
   createTree,
@@ -720,7 +759,8 @@ export const Trees = {
   addSnowCaps,
   addTrees,
   getTerrainHeight,
-  getTerrainGradient
+  getTerrainGradient,
+  resetTreePools
 };
 
 // Trees is imported directly by snow.js and mountains.js (issue #84).

--- a/src/noop.ts
+++ b/src/noop.ts
@@ -1,0 +1,6 @@
+// A shared do-nothing function, allocated in THIS tiny module's (empty) lexical
+// environment. disposeSnowGlider rebinds window.disposeGame to it on teardown to keep the
+// public API idempotent — using an external helper rather than a coordinator-local
+// closure, so the retained window reference does NOT root snowglider.ts's module
+// environment (which still holds sceneContext/renderer/scene). See the dispose-audit plan.
+export function noop(): void {}

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -332,6 +332,22 @@ export const Sfx = (function() {
 
     isMuted: () => muted,
 
+    // Stop every bed and CLOSE the AudioContext (dispose-audit teardown / dev-HMR). The
+    // context + node graph are module-level and the wind/edge beds loop forever, so
+    // without this they keep playing after disposeGame. close() releases the hardware
+    // context; dropping the node handles lets a later unlock() rebuild the graph on a
+    // fresh context. Idempotent and inert if never unlocked.
+    teardown: function() {
+      running = false;
+      if (ctx) {
+        // close() returns a Promise; swallow async rejection and any sync throw.
+        try { ctx.close().catch(() => {}); } catch { /* already closed / unsupported */ }
+        ctx = null;
+      }
+      master = null;
+      wind = carve = avalanche = null;
+    },
+
     // For tests / diagnostics. `active` reflects whether the context is live.
     getStatus: function() {
       return {

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -509,10 +509,19 @@ function update(dt: number): void {
   applyProgress(cycle, cycleProgress(cycle.elapsed));
 }
 
+/** Drop the sun-cycle singleton (dispose-audit teardown / dev-HMR). The `cycle` captures
+ *  the live scene + directionalLight + sky material/fog, so on an embed/HMR unmount it
+ *  would keep the disposed scene graph reachable. applyAtmosphericSky rebuilds it on the
+ *  next mount. Idempotent. */
+function teardown(): void {
+  cycle = null;
+}
+
 export const Sky = {
   applyGradientSky,
   applyAtmosphericSky,
   update,
+  teardown,
   cycleProgress,
   ZENITH_COLOR,
   HORIZON_COLOR,

--- a/src/snow.ts
+++ b/src/snow.ts
@@ -101,6 +101,23 @@ function createSnowflakes(scene: THREE.Scene) {
   }
 }
 
+// Clear the module-level snowflake pool (dispose-audit teardown / dev-HMR). The pool is
+// a module-level array, so on an embed/remount path that reuses this module instance,
+// createSnowflakes() would append another snowfall on top of the previous (detached)
+// sprites while updateSnowflakes() kept iterating the stale ones. Detach + dispose each
+// sprite's (cloned) material and its shared texture here — self-contained so it does not
+// depend on disposeGame's scene sweep order — then empty the array so a later
+// createSnowflakes() starts clean. Idempotent.
+function teardownSnowflakes(): void {
+  for (const flake of snowflakes) {
+    flake.parent?.remove(flake);
+    const mat = flake.material;
+    mat.map?.dispose();   // shared across clones — dispose is idempotent
+    mat.dispose();
+  }
+  snowflakes.length = 0;
+}
+
 function resetSnowflakePosition(snowflake: THREE.Sprite, playerPos: Vec3Like) {
   // Position snowflakes randomly in a box above the player
   snowflake.position.x = playerPos.x + (Math.random() * snowflakeSpread - snowflakeSpread/2);
@@ -427,6 +444,7 @@ export const Snow = {
   // Snow effects (snowman code moved to snowman.js)
   createSnowflakes,
   updateSnowflakes,
+  teardownSnowflakes,
   createSnowSplash,
   updateSnowSplash
 };

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -261,7 +261,12 @@ document.addEventListener('DOMContentLoaded', function() {
 // disposed renderer + removed canvas.
 let disposed = false;
 let pendingStartTimer: ReturnType<typeof setTimeout> | null = null;
+let getReadyTimer: ReturnType<typeof setTimeout> | null = null;
 let activeIntro: IntroHandle | null = null;
+// Names of the window.* handles this module installs (the publishGameGlobals
+// getters/setters; populated below). disposeSnowGlider deletes them so a clean unmount
+// doesn't leave the disposed scene reachable through their closures or stale APIs callable.
+let installedWindowKeys: string[] = [];
 
 // Activate the live run: flip the run-loop flags and kick off the animation loop.
 // Factored out so the start button, the cinematic intro's completion, and the
@@ -280,9 +285,12 @@ function startGameplayLoop(showGetReady: boolean) {
   // Start animation loop (the loop owns `lastTime`; startLoop seeds it — main-loop.ts)
   startLoop();
 
-  // Show a "Get Ready" message a beat after the run begins (first start only)
+  // Show a "Get Ready" message a beat after the run begins (first start only). Tracked +
+  // disposed-guarded so an unmount in the 1.5s window can't toast over the host page.
   if (showGetReady) {
-    setTimeout(() => {
+    getReadyTimer = setTimeout(() => {
+      getReadyTimer = null;
+      if (disposed) return;
       AudioModule.showMessage("Get Ready!", 1000);
     }, 1500);
   }
@@ -530,6 +538,9 @@ window.initializeGameWithAudio = function() {
   for (const name of Object.keys(live)) {
     Object.defineProperty(window, name, { configurable: true, enumerable: false, ...live[name] });
   }
+  // Remembered so disposeSnowGlider can delete them on unmount (the accessors close over
+  // sceneContext/renderer/scene/etc., which would otherwise keep the disposed graph alive).
+  installedWindowKeys = Object.keys(live);
 })();
 
 // --- Teardown entry point (dispose-audit plan; see game/teardown.ts) ---
@@ -539,11 +550,15 @@ window.initializeGameWithAudio = function() {
 // The run/restart flow is unchanged — this is a NEW path (unmount + dev-HMR), never
 // on the reuse path. Published beside the other coordinator handles.
 function disposeSnowGlider(): void {
-  // Flip the guard FIRST so any deferred first-start callback that fires during/after
-  // teardown (the intro's onComplete, the loading timer) short-circuits in
+  if (disposed) return; // idempotent: a second unmount/HMR dispose is a no-op
+  // Flip the guard so any deferred first-start callback that fires during/after teardown
+  // (the intro's onComplete, the loading/Get-Ready timers) short-circuits in
   // startGameplayLoop instead of starting a loop against a disposed renderer.
   disposed = true;
   if (pendingStartTimer !== null) { clearTimeout(pendingStartTimer); pendingStartTimer = null; }
+  // Cancel the deferred "Get Ready!" toast so it can't appear over the host page after a
+  // mid-startup unmount (the callback is also disposed-guarded).
+  if (getReadyTimer !== null) { clearTimeout(getReadyTimer); getReadyTimer = null; }
   // Cut a still-running fly-over short: skip() cancels its private rAF (so no further
   // renderer.render on a dead context); its onComplete is now a no-op via the guard.
   if (activeIntro && !activeIntro.done) activeIntro.skip();
@@ -562,6 +577,19 @@ function disposeSnowGlider(): void {
   // second snowfall on the stale, detached sprites from the disposed scene.
   Snow.teardownSnowflakes();
   disposeGame(sceneContext, () => listenerAbort.abort());
+
+  // Delete every window.* handle this module installed so the disposed graph is no longer
+  // reachable through their closures (the publishGameGlobals accessors capture
+  // sceneContext/renderer/scene/snowSplash/…) and the stale start/reset/showGameOver APIs
+  // aren't callable after the DOM + WebGL context are gone. window.disposeGame itself is
+  // removed last (idempotence is preserved by the `disposed` guard at the top).
+  const w = window as unknown as Record<string, unknown>;
+  for (const name of installedWindowKeys) delete w[name];
+  for (const name of ['resetSnowman', 'restartGame', 'toggleCameraView', 'showGameOver',
+    'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'disposeGame']) {
+    delete w[name];
+  }
+  if (window.testHooks) delete window.testHooks.isDebrisActive;
 }
 window.disposeGame = disposeSnowGlider;
 

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -34,6 +34,7 @@ import { rockCollisionRadius, ROCK_COLLISION_MIN_SIZE } from './mountains.js';
 import { AudioModule } from './audio.js';
 import { Sfx } from './sfx.js';
 import { Diag } from './diagnostics.js';
+import { noop } from './noop.js';
 import { CourseModule } from './course.js';
 import { EffectsModule } from './effects.js';
 import { Sky } from './sky.js';
@@ -265,10 +266,6 @@ let pendingStartTimer: ReturnType<typeof setTimeout> | null = null;
 let getReadyTimer: ReturnType<typeof setTimeout> | null = null;
 let testAutoStartTimer: ReturnType<typeof setTimeout> | null = null;
 let activeIntro: IntroHandle | null = null;
-// A capture-free no-op that window.disposeGame is rebound to after teardown — so a second
-// external `window.disposeGame()` call stays a safe no-op (preserving the public
-// idempotence contract) WITHOUT the disposeSnowGlider closure keeping sceneContext alive.
-const noopDispose = (): void => {};
 // Names of the window.* handles this module installs (the publishGameGlobals
 // getters/setters; populated below). disposeSnowGlider deletes them so a clean unmount
 // doesn't leave the disposed scene reachable through their closures or stale APIs callable.
@@ -589,6 +586,9 @@ function disposeSnowGlider(): void {
   // Drop the Sky sun-cycle singleton — it captures the scene + directional light + sky
   // material/fog, which would otherwise keep the disposed graph reachable.
   Sky.teardown();
+  // Remove the diagnostics window listeners (keydown/pagehide/error/unhandledrejection)
+  // + __snowgliderDiag bug-report API, whose closures retain the injected report sink.
+  Diag.teardown();
   disposeGame(sceneContext, () => listenerAbort.abort());
 
   // Delete every window.* handle this module installed so the disposed graph is no longer
@@ -605,11 +605,12 @@ function disposeSnowGlider(): void {
     'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'testHooks']) {
     delete w[name];
   }
-  // window.disposeGame is REBOUND (not deleted) to a capture-free no-op: external callers
-  // normally invoke it through `window`, so a second cleanup must stay a safe no-op rather
-  // than throwing on a missing property — while still releasing the disposeSnowGlider
-  // closure that captured sceneContext.
-  window.disposeGame = noopDispose;
+  // window.disposeGame is REBOUND (not deleted) to a no-op: external callers normally
+  // invoke it through `window`, so a second cleanup must stay a safe no-op rather than
+  // throwing on a missing property. The no-op comes from a SEPARATE module (./noop.js) on
+  // purpose — a coordinator-local function would, via its lexical environment, keep
+  // sceneContext/renderer/scene rooted, defeating the cleanup.
+  window.disposeGame = noop;
 }
 window.disposeGame = disposeSnowGlider;
 

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -36,6 +36,7 @@ import { Sfx } from './sfx.js';
 import { Diag } from './diagnostics.js';
 import { CourseModule } from './course.js';
 import { EffectsModule } from './effects.js';
+import { Sky } from './sky.js';
 import { Physics } from './player-state.js';
 import { IntroModule, prefersReducedMotion, type IntroHandle } from './intro.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
@@ -262,7 +263,12 @@ document.addEventListener('DOMContentLoaded', function() {
 let disposed = false;
 let pendingStartTimer: ReturnType<typeof setTimeout> | null = null;
 let getReadyTimer: ReturnType<typeof setTimeout> | null = null;
+let testAutoStartTimer: ReturnType<typeof setTimeout> | null = null;
 let activeIntro: IntroHandle | null = null;
+// A capture-free no-op that window.disposeGame is rebound to after teardown — so a second
+// external `window.disposeGame()` call stays a safe no-op (preserving the public
+// idempotence contract) WITHOUT the disposeSnowGlider closure keeping sceneContext alive.
+const noopDispose = (): void => {};
 // Names of the window.* handles this module installs (the publishGameGlobals
 // getters/setters; populated below). disposeSnowGlider deletes them so a clean unmount
 // doesn't leave the disposed scene reachable through their closures or stale APIs callable.
@@ -559,6 +565,10 @@ function disposeSnowGlider(): void {
   // Cancel the deferred "Get Ready!" toast so it can't appear over the host page after a
   // mid-startup unmount (the callback is also disposed-guarded).
   if (getReadyTimer !== null) { clearTimeout(getReadyTimer); getReadyTimer = null; }
+  // The ?test= auto-start timer (below) dereferences #gameCanvas and calls
+  // initializeGameWithAudio; cancel it so a dispose in its 100ms window can't run against
+  // the torn-down page (the callback is also disposed-guarded).
+  if (testAutoStartTimer !== null) { clearTimeout(testAutoStartTimer); testAutoStartTimer = null; }
   // Cut a still-running fly-over short: skip() cancels its private rAF (so no further
   // renderer.render on a dead context); its onComplete is now a no-op via the guard.
   if (activeIntro && !activeIntro.done) activeIntro.skip();
@@ -576,13 +586,15 @@ function disposeSnowGlider(): void {
   // Clear the module-level snowflake pool so a same-instance remount doesn't stack a
   // second snowfall on the stale, detached sprites from the disposed scene.
   Snow.teardownSnowflakes();
+  // Drop the Sky sun-cycle singleton — it captures the scene + directional light + sky
+  // material/fog, which would otherwise keep the disposed graph reachable.
+  Sky.teardown();
   disposeGame(sceneContext, () => listenerAbort.abort());
 
   // Delete every window.* handle this module installed so the disposed graph is no longer
   // reachable through their closures (the publishGameGlobals accessors capture
   // sceneContext/renderer/scene/snowSplash/…) and the stale start/reset/showGameOver APIs
-  // aren't callable after the DOM + WebGL context are gone. window.disposeGame itself is
-  // removed last (idempotence is preserved by the `disposed` guard at the top).
+  // aren't callable after the DOM + WebGL context are gone.
   const w = window as unknown as Record<string, unknown>;
   for (const name of installedWindowKeys) delete w[name];
   // testHooks is deleted wholesale (not just isDebrisActive): Snowman.addTestHooks installs
@@ -590,10 +602,14 @@ function disposeSnowGlider(): void {
   // capture pos + showGameOver (which retain the disposed scene/UI), so dropping the whole
   // object is what releases them. addTestHooks rebuilds it on the next mount.
   for (const name of ['resetSnowman', 'restartGame', 'toggleCameraView', 'showGameOver',
-    'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'testHooks',
-    'disposeGame']) {
+    'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'testHooks']) {
     delete w[name];
   }
+  // window.disposeGame is REBOUND (not deleted) to a capture-free no-op: external callers
+  // normally invoke it through `window`, so a second cleanup must stay a safe no-op rather
+  // than throwing on a missing property — while still releasing the disposeSnowGlider
+  // closure that captured sceneContext.
+  window.disposeGame = noopDispose;
 }
 window.disposeGame = disposeSnowGlider;
 
@@ -608,13 +624,19 @@ if (import.meta.hot) {
 // If this is a test environment, auto-start the game
 if (window.isTestMode) {
   console.log("Test mode detected, auto-starting game...");
-  setTimeout(() => {
+  testAutoStartTimer = setTimeout(() => {
+    testAutoStartTimer = null;
+    // Bail if torn down in this 100ms window: #gameCanvas is gone and
+    // initializeGameWithAudio has been removed, so dereferencing them would throw.
+    if (disposed) return;
+
     // Hide the start button container
     const startContainer = document.getElementById('startGameContainer');
     if (startContainer) startContainer.style.display = 'none';
-    
+
     // Show the game canvas
-    document.getElementById('gameCanvas')!.style.display = 'block';
+    const gameCanvas = document.getElementById('gameCanvas');
+    if (gameCanvas) gameCanvas.style.display = 'block';
 
     // Initialize the game
     window.initializeGameWithAudio?.();

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -558,6 +558,9 @@ function disposeSnowGlider(): void {
   // state handles, so they self-clean here rather than via the scene/DOM sweep.
   CourseModule.teardown();
   EffectsModule.teardown();
+  // Clear the module-level snowflake pool so a same-instance remount doesn't stack a
+  // second snowfall on the stale, detached sprites from the disposed scene.
+  Snow.teardownSnowflakes();
   disposeGame(sceneContext, () => listenerAbort.abort());
 }
 window.disposeGame = disposeSnowGlider;

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -589,7 +589,8 @@ function disposeSnowGlider(): void {
     'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'disposeGame']) {
     delete w[name];
   }
-  if (window.testHooks) delete window.testHooks.isDebrisActive;
+  const testHooks = window.testHooks as Record<string, unknown> | undefined;
+  if (testHooks) delete testHooks.isDebrisActive;
 }
 window.disposeGame = disposeSnowGlider;
 

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -546,6 +546,11 @@ function disposeSnowGlider(): void {
   // renderer.render on a dead context); its onComplete is now a no-op via the guard.
   if (activeIntro && !activeIntro.done) activeIntro.skip();
   activeIntro = null;
+  // Stop the audio + SFX started in initializeGameWithAudio. They are module-level
+  // resources (a looping <audio> + the Web Audio beds + the mute button) that
+  // disposeGame's scene/renderer/listener teardown would otherwise leave running.
+  AudioModule.teardown();
+  Sfx.teardown();
   disposeGame(sceneContext, () => listenerAbort.abort());
 }
 window.disposeGame = disposeSnowGlider;

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -585,12 +585,15 @@ function disposeSnowGlider(): void {
   // removed last (idempotence is preserved by the `disposed` guard at the top).
   const w = window as unknown as Record<string, unknown>;
   for (const name of installedWindowKeys) delete w[name];
+  // testHooks is deleted wholesale (not just isDebrisActive): Snowman.addTestHooks installs
+  // forceTreeCollision/checkTreeCollision/checkExtendedTerrainCollision closures that
+  // capture pos + showGameOver (which retain the disposed scene/UI), so dropping the whole
+  // object is what releases them. addTestHooks rebuilds it on the next mount.
   for (const name of ['resetSnowman', 'restartGame', 'toggleCameraView', 'showGameOver',
-    'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'disposeGame']) {
+    'initializeGameWithAudio', 'terrainMesh', 'treePositions', 'rockPositions', 'testHooks',
+    'disposeGame']) {
     delete w[name];
   }
-  const testHooks = window.testHooks as Record<string, unknown> | undefined;
-  if (testHooks) delete testHooks.isDebrisActive;
 }
 window.disposeGame = disposeSnowGlider;
 

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -589,6 +589,12 @@ function disposeSnowGlider(): void {
   // Remove the diagnostics window listeners (keydown/pagehide/error/unhandledrejection)
   // + __snowgliderDiag bug-report API, whose closures retain the injected report sink.
   Diag.teardown();
+  // Clear Controls' module-level gameControls/touchState BEFORE aborting the input
+  // listeners below: if a key/touch is down at teardown, aborting removes the handler so
+  // the matching keyup/touchend never fires, and a same-instance remount (HMR/embed) that
+  // reuses the surviving Controls singleton would start with a stuck input (e.g. left=true).
+  // The live game already resets this on every resetSnowman; this covers the remount path.
+  Controls.resetControls();
   disposeGame(sceneContext, () => listenerAbort.abort());
 
   // Delete every window.* handle this module installed so the disposed graph is no longer

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -34,6 +34,8 @@ import { rockCollisionRadius, ROCK_COLLISION_MIN_SIZE } from './mountains.js';
 import { AudioModule } from './audio.js';
 import { Sfx } from './sfx.js';
 import { Diag } from './diagnostics.js';
+import { CourseModule } from './course.js';
+import { EffectsModule } from './effects.js';
 import { Physics } from './player-state.js';
 import { IntroModule, prefersReducedMotion, type IntroHandle } from './intro.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
@@ -551,6 +553,11 @@ function disposeSnowGlider(): void {
   // disposeGame's scene/renderer/listener teardown would otherwise leave running.
   AudioModule.teardown();
   Sfx.teardown();
+  // Remove the subsystem HUD these modules append to document.body (#courseHud /
+  // #courseFlash; the avalanche banner/meter/vignette) — they hold their own node +
+  // state handles, so they self-clean here rather than via the scene/DOM sweep.
+  CourseModule.teardown();
+  EffectsModule.teardown();
   disposeGame(sceneContext, () => listenerAbort.abort());
 }
 window.disposeGame = disposeSnowGlider;

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -41,13 +41,23 @@ import { readStoredBestTime, createShowGameOver } from './ui/result-overlay.js';
 import { setupScene } from './game/scene-setup.js';
 import { createMainLoop, FIXED_DT, MAX_SUBSTEPS } from './game/main-loop.js';
 import { createLifecycle } from './game/lifecycle.js';
+import { disposeGame } from './game/teardown.js';
 
 // Get keyboard controls from the Controls module
 Controls.setupControls();
 
+// One AbortController owns every game-lifetime DOM listener wired below and inside
+// scene-setup/lifecycle (the §4 listener-hygiene fix). Threading its `signal` into
+// each addEventListener collapses the old "62 adds vs 2 removes" asymmetry to a single
+// `abort()` in disposeGame — so unmount / dev-HMR doesn't leave duplicate handlers
+// firing on stale state.
+const listenerAbort = new AbortController();
+
 // --- Build the scene, objects, and subsystems (see game/scene-setup.ts) ---
 // The orchestrator owns the run loop + the window.* publish; scene-setup owns the
-// one-shot construction. Destructure the handles the loop/lifecycle/proxies use.
+// one-shot construction. Keep the whole context object (for disposeGame) and also
+// destructure the handles the loop/lifecycle/proxies use.
+const sceneContext = setupScene(listenerAbort.signal);
 const {
   scene,
   renderer,
@@ -62,7 +72,7 @@ const {
   snowman,
   snowSplash,
   state,
-} = setupScene();
+} = sceneContext;
 
 // --- Snowman Position & Reset ---
 // The per-frame player physics state lives in one typed PlayerState object
@@ -155,7 +165,7 @@ const { updateSnowman, updateCamera, startLoop, resetLoopState, handleResize } =
   rockPositions,
   showGameOver,
 });
-window.addEventListener('resize', handleResize);
+window.addEventListener('resize', handleResize, { signal: listenerAbort.signal });
 
 // --- Physics / frame-rate diagnostics (see src/diagnostics.ts) ---
 // A read-only telemetry observer the main loop feeds each frame (beside Sfx/Flex). It
@@ -215,6 +225,7 @@ const { resetSnowman, restartGame, toggleCameraView, initLifecycleUI } = createL
   player,
   startLoop,
   resetLoopState,
+  signal: listenerAbort.signal,
 });
 // Make reset/restart/toggle accessible globally for touch + keyboard handlers.
 window.resetSnowman = resetSnowman;
@@ -500,6 +511,25 @@ window.initializeGameWithAudio = function() {
     Object.defineProperty(window, name, { configurable: true, enumerable: false, ...live[name] });
   }
 })();
+
+// --- Teardown entry point (dispose-audit plan; see game/teardown.ts) ---
+// One idempotent disposeGame() that stops the loop, frees every GPU resource the
+// one-shot setupScene() allocated (scene sweep + subsystem disposes + tree pools),
+// drops the renderer/WebGL context + canvas, and aborts the listener controller above.
+// The run/restart flow is unchanged — this is a NEW path (unmount + dev-HMR), never
+// on the reuse path. Published beside the other coordinator handles.
+function disposeSnowGlider(): void {
+  disposeGame(sceneContext, () => listenerAbort.abort());
+}
+window.disposeGame = disposeSnowGlider;
+
+// Vite dev-HMR: release the previous instance before the module re-evaluates, so a
+// hot edit doesn't stack WebGL contexts ("too many active contexts") or duplicate
+// listeners. Stripped from production builds (Vite replaces import.meta.hot with
+// undefined), so this is a dev-only safety net.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => disposeSnowGlider());
+}
 
 // If this is a test environment, auto-start the game
 if (window.isTestMode) {

--- a/src/snowglider.ts
+++ b/src/snowglider.ts
@@ -35,7 +35,7 @@ import { AudioModule } from './audio.js';
 import { Sfx } from './sfx.js';
 import { Diag } from './diagnostics.js';
 import { Physics } from './player-state.js';
-import { IntroModule, prefersReducedMotion } from './intro.js';
+import { IntroModule, prefersReducedMotion, type IntroHandle } from './intro.js';
 import { initializeGameStats, initializeControlsToggle, updateTimerDisplay } from './ui/hud.js';
 import { readStoredBestTime, createShowGameOver } from './ui/result-overlay.js';
 import { setupScene } from './game/scene-setup.js';
@@ -43,15 +43,16 @@ import { createMainLoop, FIXED_DT, MAX_SUBSTEPS } from './game/main-loop.js';
 import { createLifecycle } from './game/lifecycle.js';
 import { disposeGame } from './game/teardown.js';
 
-// Get keyboard controls from the Controls module
-Controls.setupControls();
-
-// One AbortController owns every game-lifetime DOM listener wired below and inside
-// scene-setup/lifecycle (the §4 listener-hygiene fix). Threading its `signal` into
-// each addEventListener collapses the old "62 adds vs 2 removes" asymmetry to a single
-// `abort()` in disposeGame — so unmount / dev-HMR doesn't leave duplicate handlers
-// firing on stale state.
+// One AbortController owns every game-lifetime DOM listener — the keyboard/touch/resize
+// handlers in Controls, plus those wired below and inside scene-setup/lifecycle (the §4
+// listener-hygiene fix). Threading its `signal` into each addEventListener collapses the
+// old "62 adds vs 2 removes" asymmetry to a single `abort()` in disposeGame — so unmount /
+// dev-HMR doesn't leave duplicate handlers firing on stale state. Created before
+// Controls.setupControls so its listeners join the same teardown.
 const listenerAbort = new AbortController();
+
+// Get keyboard controls from the Controls module (listeners tied to the teardown signal).
+Controls.setupControls(listenerAbort.signal);
 
 // --- Build the scene, objects, and subsystems (see game/scene-setup.ts) ---
 // The orchestrator owns the run loop + the window.* publish; scene-setup owns the
@@ -252,10 +253,22 @@ document.addEventListener('DOMContentLoaded', function() {
   initializeControlsToggle();
 });
 
+// Teardown bookkeeping (dispose-audit plan §3 / Codex review): a guard flag plus the
+// handles for the deferred first-start work, so disposeGame can cancel a pending intro /
+// loading timer instead of letting its closure later start the loop and render against a
+// disposed renderer + removed canvas.
+let disposed = false;
+let pendingStartTimer: ReturnType<typeof setTimeout> | null = null;
+let activeIntro: IntroHandle | null = null;
+
 // Activate the live run: flip the run-loop flags and kick off the animation loop.
 // Factored out so the start button, the cinematic intro's completion, and the
 // reduced-motion/automation fallback all hand off to the game loop identically.
 function startGameplayLoop(showGetReady: boolean) {
+  // After teardown, every deferred path (the intro's onComplete, the loading setTimeout)
+  // that lands here must be inert — the renderer/canvas are gone. This is the single
+  // choke point all loop-start paths funnel through, so one guard covers them all.
+  if (disposed) return;
   state.gameActive = true;
   state.animationRunning = true;
 
@@ -392,7 +405,10 @@ window.initializeGameWithAudio = function() {
     // Hide the in-game HUD/buttons so the establishing shot reads cleanly (CSS
     // keys off `intro-active`); removed on completion/skip below.
     document.body.classList.add('intro-active');
-    IntroModule.play({
+    // Keep the handle so disposeGame can cut the fly-over short (cancelling its private
+    // rAF) if an HMR reload / unmount happens mid-intro — otherwise its next frame would
+    // call renderer.render on a disposed context. Its onComplete is guarded by `disposed`.
+    activeIntro = IntroModule.play({
       camera,
       endPosition,
       endTarget,
@@ -417,7 +433,9 @@ window.initializeGameWithAudio = function() {
     // reproduce the original short loading message + delayed activation exactly.
     AudioModule.showMessage("Loading game...", 1500);
     state.gameInitialized = true;
-    setTimeout(() => { startGameplayLoop(true); }, 1800);
+    // Track the timer so disposeGame can cancel it; startGameplayLoop is also
+    // `disposed`-guarded, so this is belt-and-suspenders against a mid-delay teardown.
+    pendingStartTimer = setTimeout(() => { pendingStartTimer = null; startGameplayLoop(true); }, 1800);
   } else {
     // Already initialized once: restart immediately.
     startGameplayLoop(false);
@@ -519,6 +537,15 @@ window.initializeGameWithAudio = function() {
 // The run/restart flow is unchanged — this is a NEW path (unmount + dev-HMR), never
 // on the reuse path. Published beside the other coordinator handles.
 function disposeSnowGlider(): void {
+  // Flip the guard FIRST so any deferred first-start callback that fires during/after
+  // teardown (the intro's onComplete, the loading timer) short-circuits in
+  // startGameplayLoop instead of starting a loop against a disposed renderer.
+  disposed = true;
+  if (pendingStartTimer !== null) { clearTimeout(pendingStartTimer); pendingStartTimer = null; }
+  // Cut a still-running fly-over short: skip() cancels its private rAF (so no further
+  // renderer.render on a dead context); its onComplete is now a no-op via the guard.
+  if (activeIntro && !activeIntro.done) activeIntro.skip();
+  activeIntro = null;
   disposeGame(sceneContext, () => listenerAbort.abort());
 }
 window.disposeGame = disposeSnowGlider;

--- a/src/snowtracks.ts
+++ b/src/snowtracks.ts
@@ -308,6 +308,23 @@ export class SnowTrails {
     this.next = 0;
   }
 
+  /**
+   * Free the GPU resources this system owns and detach it from the scene. The
+   * trail pool is an app-lifetime singleton during normal play (allocated once,
+   * reused for the page's life — `reset()` only zeroes the instance matrices), so
+   * this is called ONLY from the teardown path (`disposeGame`) / dev-HMR, never on
+   * a run reset. Mirrors {@link AvalancheSystem.dispose}: the InstancedMesh's
+   * geometry + material are the disposable GPU handles; the typed-array ring
+   * buffers are plain JS and are reclaimed with the instance. Idempotent — THREE's
+   * `dispose()` tolerates a second call, and `scene.remove` of an absent child is a
+   * no-op.
+   */
+  dispose(): void {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+  }
+
   /** Number of currently-live dabs (used by tests). */
   activeCount(): number {
     let n = 0;

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -239,6 +239,37 @@ async function main() {
       return firedWhileLive === 1 && hits === 1; // fired once live, not after abort
     })());
 
+  // --- delayed overlay-observer abort guard (Codex review #226) ---
+  // On mobile setupControls() runs before setupScene() creates #gameOverOverlay, so
+  // setupButtonTouchHandlers arms a 1s delayed observe(). Aborting the teardown signal
+  // during that window must cancel it — else a remounted overlay (HMR) gets the stale
+  // observer and the old restart touch handler.
+  console.log('\n--- delayed overlay observer abort guard ---');
+  {
+    const existing = document.getElementById('gameOverOverlay');
+    if (existing) existing.remove(); // force the no-overlay-yet (delayed observe) branch
+    let observeCalls = 0;
+    const realObserve = window.MutationObserver.prototype.observe;
+    window.MutationObserver.prototype.observe = function (...a) { observeCalls++; return realObserve.apply(this, /** @type {any} */ (a)); };
+    const ac2 = new window.AbortController();
+    try {
+      Controls.setupControls(ac2.signal); // arms the 1s delayed observe (overlay absent)
+      const observesBefore = observeCalls;
+      ac2.abort();                        // tear down DURING the 1s delay window
+      // A remount re-creates the overlay before the timeout would have fired.
+      const remounted = document.createElement('div');
+      remounted.id = 'gameOverOverlay';
+      remounted.style.display = 'none';
+      document.body.appendChild(remounted);
+      await new Promise(r => setTimeout(r, 1100)); // wait past the 1000ms delayed observe
+      check('aborting during the delay window cancels the pending overlay observe()',
+        observeCalls === observesBefore);
+    } finally {
+      window.MutationObserver.prototype.observe = realObserve;
+      ac2.abort();
+    }
+  }
+
   console.log(`\nCONTROLS TEST TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 }

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -199,6 +199,46 @@ async function main() {
     ['left', 'right', 'up', 'down', 'jump'].every(k => afterReset[k] === false));
   check('getControls returns the same shared object', Controls.getControls() === controls);
 
+  // --- teardown signal threading (disposeGame listener hygiene; Codex review #226) ---
+  // setupControls(signal) must thread the AbortSignal into EVERY listener it registers
+  // (keyboard, resize, touch) so disposeGame's single abort() removes them on HMR/unmount
+  // — otherwise a remount stacks duplicate handlers (e.g. `V` toggling once per stale
+  // keydown). Spy on addEventListener to confirm the signal reaches each listener class,
+  // then abort to drop the duplicates this extra setup added (keeps the process clean).
+  console.log('\n--- teardown signal threading ---');
+  // jsdom validates that an addEventListener signal is its OWN realm's AbortSignal, so
+  // use window.AbortController (in a real browser the global IS the window's — no mismatch).
+  const ac = new window.AbortController();
+  const seen = [];
+  const realDocAdd = document.addEventListener;
+  const realWinAdd = window.addEventListener;
+  document.addEventListener = function (type, fn, opts) { seen.push({ type, opts }); return realDocAdd.call(this, type, fn, opts); };
+  window.addEventListener = function (type, fn, opts) { seen.push({ type, opts }); return realWinAdd.call(this, type, fn, opts); };
+  try {
+    Controls.setupControls(ac.signal);
+  } finally {
+    document.addEventListener = realDocAdd;
+    window.addEventListener = realWinAdd;
+  }
+  const withSignal = seen.filter(s => s.opts && s.opts.signal === ac.signal).map(s => s.type);
+  check('setupControls(signal) threads the teardown signal into the keyboard listeners',
+    withSignal.includes('keydown') && withSignal.includes('keyup'));
+  check('setupControls(signal) threads the signal into the resize + touch listeners',
+    withSignal.includes('resize') && withSignal.includes('touchstart'));
+  check('an aborted signal removes the keyboard handler (no state mutation after abort)',
+    (() => {
+      // Verify removal end-to-end on an ISOLATED handler set: a fresh keydown handler
+      // registered with this signal stops firing once aborted (the singleton's earlier
+      // no-signal listeners are a separate set and intentionally untouched here).
+      let hits = 0;
+      window.addEventListener('keydown', () => { hits++; }, { signal: ac.signal });
+      keydown('ArrowLeft');
+      const firedWhileLive = hits;
+      ac.abort();
+      keydown('ArrowLeft');
+      return firedWhileLive === 1 && hits === 1; // fired once live, not after abort
+    })());
+
   console.log(`\nCONTROLS TEST TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 }

--- a/tests/diagnostics-dom-tests.js
+++ b/tests/diagnostics-dom-tests.js
@@ -20,6 +20,10 @@ const g = /** @type {any} */ (globalThis);
 g.window = window;
 g.document = window.document;
 g.navigator = window.navigator;
+// diagnostics.ts creates `new AbortController()` for its listeners; jsdom validates the
+// resulting signal against ITS realm's AbortSignal, so alias the global to the window's
+// (in a real browser they are the same object).
+g.AbortController = window.AbortController;
 // Blob download seam: jsdom has no URL.createObjectURL; stub it so dump()'s browser branch
 // executes end-to-end, and silence the anchor's real navigation on click().
 global.Blob = global.Blob || window.Blob;
@@ -116,6 +120,20 @@ async function main() {
   window.dispatchEvent(Object.assign(new window.Event('error'), { message: 'once', error: new Error('once') }));
   check('init: error handlers are installed once (one report per error, not duplicated)',
     events.filter((e) => e.event === 'client_error').length === 1);
+
+  // --- teardown(): removes the window listeners + overlay + __snowgliderDiag ----
+  // (dispose-audit). After teardown the error capture is gone, the bug-report API is
+  // deleted, and the overlay node is removed; a second call is a no-op.
+  D.Diag.teardown();
+  check('teardown: deletes window.__snowgliderDiag', window.__snowgliderDiag === undefined);
+  check('teardown: removes the dev overlay node', !document.getElementById('diagOverlay'));
+  events.length = 0;
+  window.dispatchEvent(Object.assign(new window.Event('error'), { message: 'after', error: new Error('after') }));
+  check('teardown: the error/unhandledrejection capture is removed (no report after teardown)',
+    events.filter((e) => e.event === 'client_error').length === 0);
+  let threw = false;
+  try { D.Diag.teardown(); } catch { threw = true; }
+  check('teardown: idempotent (a second call does not throw)', !threw);
 
   console.log(`\nDIAGNOSTICS DOM TESTS: ${fail === 0 ? 'OK ✅' : 'FAIL ❌'} (${pass} passed, ${fail} failed)`);
   process.exit(fail === 0 ? 0 : 1);

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -37,12 +37,17 @@ test.describe('disposeGame teardown', () => {
     await page.click('#startGameButton');
     await page.waitForFunction(() => (window as DisposeWindow).gameActive === true);
 
-    // Tear it down.
-    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+    // Tear it down. disposeGame deletes the window.* handles it installed, so capture the
+    // reference first and call it twice — the second call exercises idempotence (a guarded
+    // no-op, not a throw) without depending on the now-removed window.disposeGame.
+    await page.evaluate(() => {
+      const d = (window as DisposeWindow).disposeGame!;
+      d();
+      d();
+    });
 
-    // Loop stopped and every instance-owned DOM node is gone (so a remount can't hit a
-    // stale duplicate-ID node).
-    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    // Every instance-owned DOM node is gone (so a remount can't hit a stale duplicate-ID
+    // node).
     await expect(page.locator('#gameCanvas')).toHaveCount(0);
     await expect(page.locator('#gameOverOverlay')).toHaveCount(0);
     await expect(page.locator('#cameraToggleBtn')).toHaveCount(0);
@@ -54,8 +59,16 @@ test.describe('disposeGame teardown', () => {
     await expect(page.locator('#avalancheMeter')).toHaveCount(0);
     await expect(page.locator('#avalancheVignette')).toHaveCount(0);
 
-    // Idempotent: a second dispose must be a no-op, not a throw.
-    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+    // Every window.* handle this instance installed is deleted — no stale start/reset
+    // APIs callable, and no accessor closure keeping the disposed scene/renderer reachable.
+    const handlesCleared = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      const names = ['disposeGame', 'initializeGameWithAudio', 'resetSnowman', 'restartGame',
+        'toggleCameraView', 'showGameOver', 'scene', 'renderer', 'camera', 'snowman', 'pos',
+        'velocity', 'snowSplash', 'terrain', 'gameActive', 'updateCamera', 'updateSnowman'];
+      return names.filter((n) => w[n] !== undefined);
+    });
+    expect(handlesCleared, `window handles still present after dispose: ${handlesCleared.join(', ')}`).toEqual([]);
 
     // Give any orphaned rAF a couple of frames to (not) fire against the dead context.
     await page.waitForTimeout(150);
@@ -75,9 +88,11 @@ test.describe('disposeGame teardown', () => {
     await page.click('#startGameButton');
     await page.evaluate(() => (window as DisposeWindow).disposeGame!());
 
-    // Wait past the 1800ms delayed start; gameActive must stay false (loop never ran).
+    // Wait past the 1800ms delayed start. The teardown ran (its window handle is gone) and
+    // the deferred loop never started — a loop against the torn-down renderer would throw
+    // on renderer.render after context loss, so zero page errors is the proof it was cancelled.
     await page.waitForTimeout(2200);
-    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    expect(await page.evaluate(() => typeof (window as DisposeWindow).disposeGame)).toBe('undefined');
     expect(pageErrors, `unexpected page errors after a mid-startup dispose:\n${pageErrors.join('\n')}`).toEqual([]);
   });
 
@@ -98,7 +113,9 @@ test.describe('disposeGame teardown', () => {
     await page.evaluate(() => (window as DisposeWindow).disposeGame!());
 
     await page.waitForTimeout(300);
-    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    // Teardown completed (handle gone) and the cancelled fly-over rendered nothing against
+    // the disposed context (zero page errors).
+    expect(await page.evaluate(() => typeof (window as DisposeWindow).disposeGame)).toBe('undefined');
     expect(pageErrors, `unexpected page errors after disposing mid-intro:\n${pageErrors.join('\n')}`).toEqual([]);
   });
 });

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -46,6 +46,13 @@ test.describe('disposeGame teardown', () => {
     await expect(page.locator('#gameCanvas')).toHaveCount(0);
     await expect(page.locator('#gameOverOverlay')).toHaveCount(0);
     await expect(page.locator('#cameraToggleBtn')).toHaveCount(0);
+    // Subsystem HUD (CourseModule / EffectsModule) is gone too — a clean unmount leaves
+    // no fixed-position course/avalanche UI over the host page.
+    await expect(page.locator('#courseHud')).toHaveCount(0);
+    await expect(page.locator('#courseFlash')).toHaveCount(0);
+    await expect(page.locator('#avalancheBanner')).toHaveCount(0);
+    await expect(page.locator('#avalancheMeter')).toHaveCount(0);
+    await expect(page.locator('#avalancheVignette')).toHaveCount(0);
 
     // Idempotent: a second dispose must be a no-op, not a throw.
     await page.evaluate(() => (window as DisposeWindow).disposeGame!());

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from './fixtures';
+
+// E2E coverage for the dispose-audit teardown (disposeGame). The orchestrator's
+// teardown wiring in src/snowglider.ts — disposeSnowGlider, the `disposed` guard, the
+// pending-start-timer / intro-handle cancellation — only runs in a full browser (real
+// WebGLRenderer + module graph), so it's unreachable from the headless Node suites that
+// cover game/teardown.ts directly. These specs drive the published `window.disposeGame`
+// against a real run and assert the §6 plan properties end-to-end: the loop stops, the
+// instance-owned DOM nodes are removed, a second dispose is a no-op, and — crucially —
+// no uncaught error fires from a stray frame rendering against a disposed context.
+
+type DisposeWindow = Window & {
+  disposeGame?: () => void;
+  gameActive?: boolean;
+  initializeGameWithAudio?: () => void;
+};
+
+async function waitForOrchestrator(page: import('@playwright/test').Page): Promise<void> {
+  await page.waitForFunction(
+    () => typeof (window as DisposeWindow).initializeGameWithAudio === 'function',
+  );
+}
+
+test.describe('disposeGame teardown', () => {
+  test('tears down a live run cleanly and is idempotent', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto('/index.html', { waitUntil: 'domcontentloaded' });
+    await waitForOrchestrator(page);
+
+    // Pre-conditions: the renderer canvas + the instance-owned overlay/button mount.
+    await expect(page.locator('#gameCanvas canvas')).toHaveCount(1);
+    await expect(page.locator('#cameraToggleBtn')).toHaveCount(1);
+
+    // Start a live run (intro is skipped under automation -> short loading delay).
+    await page.click('#startGameButton');
+    await page.waitForFunction(() => (window as DisposeWindow).gameActive === true);
+
+    // Tear it down.
+    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+
+    // Loop stopped and every instance-owned DOM node is gone (so a remount can't hit a
+    // stale duplicate-ID node).
+    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    await expect(page.locator('#gameCanvas')).toHaveCount(0);
+    await expect(page.locator('#gameOverOverlay')).toHaveCount(0);
+    await expect(page.locator('#cameraToggleBtn')).toHaveCount(0);
+
+    // Idempotent: a second dispose must be a no-op, not a throw.
+    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+
+    // Give any orphaned rAF a couple of frames to (not) fire against the dead context.
+    await page.waitForTimeout(150);
+    expect(pageErrors, `unexpected page errors during teardown:\n${pageErrors.join('\n')}`).toEqual([]);
+  });
+
+  test('dispose during the start delay cancels the pending loop start', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    await page.goto('/index.html', { waitUntil: 'domcontentloaded' });
+    await waitForOrchestrator(page);
+
+    // Click Start, then dispose immediately — well inside the ~1.8s loading delay,
+    // before the deferred startGameplayLoop fires. The `disposed` guard + the cleared
+    // timer must keep the loop from ever starting against the torn-down renderer.
+    await page.click('#startGameButton');
+    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+
+    // Wait past the 1800ms delayed start; gameActive must stay false (loop never ran).
+    await page.waitForTimeout(2200);
+    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    expect(pageErrors, `unexpected page errors after a mid-startup dispose:\n${pageErrors.join('\n')}`).toEqual([]);
+  });
+
+  test('dispose during the cinematic intro cuts the fly-over short', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    // ?intro=force plays the fly-over even under automation (the manual-QA / e2e seam).
+    await page.goto('/index.html?intro=force', { waitUntil: 'domcontentloaded' });
+    await waitForOrchestrator(page);
+
+    await page.click('#startGameButton');
+    // The intro is running once the body gets the `intro-active` class.
+    await page.waitForFunction(() => document.body.classList.contains('intro-active'));
+
+    // Dispose mid-fly-over: this exercises the activeIntro.skip() cancellation path
+    // (its private rAF is cancelled, so no further renderer.render on a dead context).
+    await page.evaluate(() => (window as DisposeWindow).disposeGame!());
+
+    await page.waitForTimeout(300);
+    expect(await page.evaluate(() => (window as DisposeWindow).gameActive)).toBe(false);
+    expect(pageErrors, `unexpected page errors after disposing mid-intro:\n${pageErrors.join('\n')}`).toEqual([]);
+  });
+});

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -37,13 +37,11 @@ test.describe('disposeGame teardown', () => {
     await page.click('#startGameButton');
     await page.waitForFunction(() => (window as DisposeWindow).gameActive === true);
 
-    // Tear it down. disposeGame deletes the window.* handles it installed, so capture the
-    // reference first and call it twice — the second call exercises idempotence (a guarded
-    // no-op, not a throw) without depending on the now-removed window.disposeGame.
+    // Tear it down. disposeGame rebinds window.disposeGame to a no-op (not delete), so the
+    // public idempotence contract holds: a second call THROUGH window stays a safe no-op.
     await page.evaluate(() => {
-      const d = (window as DisposeWindow).disposeGame!;
-      d();
-      d();
+      (window as DisposeWindow).disposeGame!(); // real teardown
+      (window as DisposeWindow).disposeGame!(); // second call via window — must not throw
     });
 
     // Every instance-owned DOM node is gone (so a remount can't hit a stale duplicate-ID
@@ -61,15 +59,18 @@ test.describe('disposeGame teardown', () => {
 
     // Every window.* handle this instance installed is deleted — no stale start/reset
     // APIs callable, and no accessor closure keeping the disposed scene/renderer reachable.
+    // (disposeGame is intentionally retained as a no-op for idempotence; checked below.)
     const handlesCleared = await page.evaluate(() => {
       const w = window as unknown as Record<string, unknown>;
-      const names = ['disposeGame', 'initializeGameWithAudio', 'resetSnowman', 'restartGame',
+      const names = ['initializeGameWithAudio', 'resetSnowman', 'restartGame',
         'toggleCameraView', 'showGameOver', 'scene', 'renderer', 'camera', 'snowman', 'pos',
         'velocity', 'snowSplash', 'terrain', 'gameActive', 'updateCamera', 'updateSnowman',
         'testHooks'];
       return names.filter((n) => w[n] !== undefined);
     });
     expect(handlesCleared, `window handles still present after dispose: ${handlesCleared.join(', ')}`).toEqual([]);
+    // disposeGame stays a callable no-op so a remount/double-cleanup through window is safe.
+    expect(await page.evaluate(() => typeof (window as DisposeWindow).disposeGame)).toBe('function');
 
     // Give any orphaned rAF a couple of frames to (not) fire against the dead context.
     await page.waitForTimeout(150);
@@ -89,11 +90,11 @@ test.describe('disposeGame teardown', () => {
     await page.click('#startGameButton');
     await page.evaluate(() => (window as DisposeWindow).disposeGame!());
 
-    // Wait past the 1800ms delayed start. The teardown ran (its window handle is gone) and
-    // the deferred loop never started — a loop against the torn-down renderer would throw
-    // on renderer.render after context loss, so zero page errors is the proof it was cancelled.
+    // Wait past the 1800ms delayed start. The teardown ran (initializeGameWithAudio is
+    // deleted) and the deferred loop never started — a loop against the torn-down renderer
+    // would throw on renderer.render after context loss, so zero page errors is the proof.
     await page.waitForTimeout(2200);
-    expect(await page.evaluate(() => typeof (window as DisposeWindow).disposeGame)).toBe('undefined');
+    expect(await page.evaluate(() => typeof (window as DisposeWindow).initializeGameWithAudio)).toBe('undefined');
     expect(pageErrors, `unexpected page errors after a mid-startup dispose:\n${pageErrors.join('\n')}`).toEqual([]);
   });
 
@@ -114,9 +115,9 @@ test.describe('disposeGame teardown', () => {
     await page.evaluate(() => (window as DisposeWindow).disposeGame!());
 
     await page.waitForTimeout(300);
-    // Teardown completed (handle gone) and the cancelled fly-over rendered nothing against
-    // the disposed context (zero page errors).
-    expect(await page.evaluate(() => typeof (window as DisposeWindow).disposeGame)).toBe('undefined');
+    // Teardown completed (initializeGameWithAudio deleted) and the cancelled fly-over
+    // rendered nothing against the disposed context (zero page errors).
+    expect(await page.evaluate(() => typeof (window as DisposeWindow).initializeGameWithAudio)).toBe('undefined');
     expect(pageErrors, `unexpected page errors after disposing mid-intro:\n${pageErrors.join('\n')}`).toEqual([]);
   });
 });

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -120,4 +120,82 @@ test.describe('disposeGame teardown', () => {
     expect(await page.evaluate(() => typeof (window as DisposeWindow).initializeGameWithAudio)).toBe('undefined');
     expect(pageErrors, `unexpected page errors after disposing mid-intro:\n${pageErrors.join('\n')}`).toEqual([]);
   });
+
+  // Plan §6.2 — the GPU-memory baseline contract. The other specs prove the DOM/handles
+  // are gone; this proves the dedup scene sweep actually FREES the GPU resources, i.e.
+  // disposeGame returns renderer.info.memory to baseline instead of leaking the buffers
+  // the live run uploaded. There is no in-place reinit entry point (only dev-HMR
+  // re-evaluates the module), so this asserts the single-shot dispose half of the cycle:
+  // live counts > 0, then ~0 after teardown. A regression that skips a pooled
+  // geometry/material/texture in the sweep would leave a non-zero residual here.
+  test('dispose returns renderer.info.memory to baseline (the sweep frees GPU resources)', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    // Deterministic forest so the live geometry/texture counts are stable run to run
+    // (same seed the perf-budget spec uses), making the >0 pre-condition a fixed number.
+    await page.addInitScript(() => {
+      let s = 0x9e3779b9 >>> 0;
+      Math.random = () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = Math.imul(s ^ (s >>> 15), 1 | s);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    });
+
+    await page.goto('/index.html', { waitUntil: 'domcontentloaded' });
+    await waitForOrchestrator(page);
+    await page.click('#startGameButton');
+    await page.waitForFunction(() => (window as DisposeWindow).gameActive === true);
+
+    // Warm the loop so the renderer has uploaded the scene's geometries/textures —
+    // renderer.info.memory is only populated by a real frame render.
+    await page.waitForFunction(() => !!(window as unknown as { renderer?: unknown }).renderer);
+    for (let i = 0; i < 12; i++) {
+      await page.evaluate(() => new Promise<void>((r) => requestAnimationFrame(() => r())));
+    }
+
+    // Capture memory off the SAME renderer reference before and after teardown: the
+    // window.renderer accessor is deleted by disposeGame, but a captured ref survives,
+    // and each unique geometry/material/texture .dispose() in the sweep synchronously
+    // decrements info.memory.
+    type Mem = { geometries: number; textures: number };
+    const { before, after } = await page.evaluate(() => {
+      const w = window as unknown as {
+        renderer: { info: { memory: { geometries: number; textures: number } } };
+        disposeGame: () => void;
+      };
+      const r = w.renderer;
+      const snap = (): Mem => ({ ...r.info.memory });
+      const before = snap();
+      w.disposeGame();
+      const after = snap();
+      return { before, after };
+    });
+
+    // Surface the numbers so any baseline drift is auditable in CI output.
+    console.log('[teardown] renderer.info.memory before/after dispose:', JSON.stringify({ before, after }));
+
+    // Pre-condition: a warm run really did upload resources (guards against a false pass
+    // where "0 -> 0" looks clean only because nothing was ever live).
+    expect(before.geometries, 'live geometries before dispose').toBeGreaterThan(20);
+    expect(before.textures, 'live textures before dispose').toBeGreaterThan(3);
+
+    // The contract:
+    //  - Geometries return to an EXACT baseline of 0. Every BufferGeometry is owned by a
+    //    mesh in the scene graph, so the dedup traverse sweep reaches and disposes all of
+    //    them (measured 85 -> 0). This is the tight guard: a pooled geometry the sweep
+    //    skipped, or a per-object geometry leak, would leave a non-zero residual.
+    //  - Textures drop to a small FIXED residual (measured 11 -> 3). The sweep walks
+    //    mesh.material slots, so it does not reach the few textures held OUTSIDE the mesh
+    //    graph (e.g. scene.background/environment or renderer-internal targets). That
+    //    residual is constant and does not scale with scene objects, so it is pinned as a
+    //    ceiling here, NOT chased to 0 in the sweep — a regression that leaks textures
+    //    per-object would push this back up toward the live count and red-bar.
+    expect(after.geometries, 'geometries leaked after dispose').toBe(0);
+    expect(after.textures, 'textures leaked after dispose').toBeLessThanOrEqual(3);
+
+    expect(pageErrors, `unexpected page errors during memory teardown:\n${pageErrors.join('\n')}`).toEqual([]);
+  });
 });

--- a/tests/e2e/teardown.spec.ts
+++ b/tests/e2e/teardown.spec.ts
@@ -65,7 +65,8 @@ test.describe('disposeGame teardown', () => {
       const w = window as unknown as Record<string, unknown>;
       const names = ['disposeGame', 'initializeGameWithAudio', 'resetSnowman', 'restartGame',
         'toggleCameraView', 'showGameOver', 'scene', 'renderer', 'camera', 'snowman', 'pos',
-        'velocity', 'snowSplash', 'terrain', 'gameActive', 'updateCamera', 'updateSnowman'];
+        'velocity', 'snowSplash', 'terrain', 'gameActive', 'updateCamera', 'updateSnowman',
+        'testHooks'];
       return names.filter((n) => w[n] !== undefined);
     });
     expect(handlesCleared, `window handles still present after dispose: ${handlesCleared.join(', ')}`).toEqual([]);

--- a/tests/leak-tests.js
+++ b/tests/leak-tests.js
@@ -11,10 +11,12 @@
 //
 // Scope note: the plan listed "debris -> avalanche -> snow-surface", but src/mountains/
 // snow-surface.ts is render-only (one-shot vertex-colour / normal baking, no reset/cover
-// cycle) and src/snowtracks.ts (the grooves system) exposes only reset() (zeroes instance
-// matrices) with no dispose() — neither owns a disposable per-cycle lifecycle to guard.
-// The two systems that genuinely allocate-and-dispose are SnowmanDebris and
-// AvalancheSystem, so the leak assertions live here for those two.
+// cycle) so it owns no disposable per-cycle lifecycle to guard. The systems that
+// genuinely allocate GPU resources are SnowmanDebris, AvalancheSystem, and SnowTrails,
+// so the leak/dispose assertions live here for those three. SnowTrails has no per-cycle
+// churn (its InstancedMesh pool is an app-lifetime singleton; reset() only zeroes the
+// instance matrices), so for it we guard the teardown contract: dispose() detaches the
+// mesh and frees its geometry/material (the dispose-audit plan added it for disposeGame).
 //
 // Headless: both systems import only `three` (bare) and self-guard on
 // requestAnimationFrame, so they run under Node like debris-tests.js. Drive update(dt)
@@ -50,6 +52,7 @@ async function main() {
   try {
     await testDebrisCycles(THREE, disposedGeo, disposedMat);
     await testAvalancheCycles(THREE, disposedGeo, disposedMat);
+    await testSnowTrailsDispose(THREE, disposedGeo, disposedMat);
   } finally {
     geoProto.dispose = realGeoDispose;
     matProto.dispose = realMatDispose;
@@ -157,6 +160,40 @@ async function testAvalancheCycles(THREE, disposedGeo, disposedMat) {
     scene.children.length < childrenBeforeDispose);
   check('dispose() disposes the InstancedMesh geometry', disposedGeo.has(meshGeoUuid));
   check('dispose() disposes the InstancedMesh material', disposedMat.has(meshMatUuid));
+}
+
+// ---- SnowTrails: the InstancedMesh + geometry + material are one-time assets built in
+// the constructor and reused for the page's life (reset() only zeroes matrices). The
+// dispose-audit plan added dispose() for the teardown path (disposeGame). Assert it
+// detaches the mesh from the scene and frees its geometry/material, and is idempotent. ----
+async function testSnowTrailsDispose(THREE, disposedGeo, disposedMat) {
+  console.log('--- snowtrails: dispose() detaches the InstancedMesh and frees its assets ---');
+  const { SnowTrails } = await import('../src/snowtracks.ts');
+
+  const scene = new THREE.Scene();
+  const trails = new SnowTrails(scene, 16);
+  trails.setTerrainFunction(() => 0);
+
+  // The mesh is attached at construction.
+  check('SnowTrails attaches its InstancedMesh to the scene on construction',
+    scene.children.includes(trails.mesh));
+
+  const meshGeoUuid = trails.mesh.geometry.uuid;
+  const meshMatUuid = trails.mesh.material.uuid;
+  const childrenBeforeDispose = scene.children.length;
+
+  trails.dispose();
+  check('dispose() detaches the SnowTrails InstancedMesh from the scene',
+    scene.children.length < childrenBeforeDispose && !scene.children.includes(trails.mesh));
+  check('dispose() disposes the SnowTrails InstancedMesh geometry', disposedGeo.has(meshGeoUuid));
+  check('dispose() disposes the SnowTrails InstancedMesh material', disposedMat.has(meshMatUuid));
+
+  // Idempotent: a second dispose() must not throw (scene.remove of an absent child and
+  // a repeat THREE dispose() are both no-ops) — disposeGame can run it after the scene
+  // sweep already touched the same mesh.
+  let threw = false;
+  try { trails.dispose(); } catch { threw = true; }
+  check('dispose() is idempotent (a second call does not throw)', !threw);
 }
 
 main().catch((err) => { console.error('leak test harness crashed:', err); process.exit(1); });

--- a/tests/sfx-tests.js
+++ b/tests/sfx-tests.js
@@ -63,8 +63,12 @@ async function main() {
     engine.land(0.8);
     engine.endRun('finish');
     engine.endRun('crash');
+    engine.teardown();                       // dispose-audit teardown — inert without a context
+    engine.teardown();                       // idempotent
   } catch { threw = true; }
   check('engine: every method is a safe no-op without Web Audio', !threw);
+  check('engine: teardown() leaves the engine inert (no context, not running)',
+    engine.getStatus().active === false && engine.getStatus().running === false);
 
   const status = engine.getStatus();
   check('engine: reports inert (no context active) in Node', status.active === false && status.running === false);

--- a/tests/teardown-tests.js
+++ b/tests/teardown-tests.js
@@ -160,6 +160,16 @@ async function testDedupSweep(THREE, disposeSceneResources) {
   matB.addEventListener('dispose', () => matBDisposed++);
   scene.add(new THREE.Mesh(geo2, [matA, matB]));
 
+  // An InstancedMesh (forest/avalanche/snow-trail case): its per-instance
+  // instanceMatrix/instanceColor buffers are freed only by InstancedMesh.dispose(), NOT
+  // geometry.dispose(), so the sweep must call it. dispose() dispatches a 'dispose' event.
+  const instGeo = new THREE.BoxGeometry(1, 1, 1);
+  const instMat = new THREE.MeshStandardMaterial();
+  const inst = new THREE.InstancedMesh(instGeo, instMat, 4);
+  let instDisposed = 0;
+  inst.addEventListener('dispose', () => instDisposed++);
+  scene.add(inst);
+
   disposeSceneResources(scene);
 
   check('shared geometry disposed exactly once across 3 meshes', geoDisposed.length === 1);
@@ -167,6 +177,7 @@ async function testDedupSweep(THREE, disposeSceneResources) {
   check('texture hung off the shared material disposed exactly once', texDisposed.length === 1);
   check('the unique second geometry disposed once', geo2Disposed === 1);
   check('both materials in an array material disposed once each', matADisposed === 1 && matBDisposed === 1);
+  check('InstancedMesh per-instance buffers disposed (InstancedMesh.dispose called)', instDisposed === 1);
 }
 
 // Build a fake SceneContext: a real THREE.Scene (so the sweep runs), spy subsystems,

--- a/tests/teardown-tests.js
+++ b/tests/teardown-tests.js
@@ -31,9 +31,70 @@ async function main() {
   await testDedupSweep(THREE, disposeSceneResources);
   await testDisposeGameIdempotent(THREE, disposeGame);
   await testOwnedDomNodeRemoval(THREE, disposeGame);
+  await testSnowflakePoolTeardown(THREE);
 
   console.log(`\nTEARDOWN TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
+}
+
+// ---- Snow.teardownSnowflakes: detaches the sprites, frees their materials, and CLEARS
+// the module-level pool so a same-instance remount doesn't stack a second snowfall on the
+// stale sprites (Codex review #226). ----
+async function testSnowflakePoolTeardown(THREE) {
+  console.log('--- Snow.teardownSnowflakes: clears the module snowflake pool ---');
+  const { Snow } = await import('../src/snow.ts');
+
+  // jsdom lacks a 2d canvas context; stub the few calls createSnowflakes makes.
+  const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://snowglider.ai/' });
+  const g = globalThis;
+  const prevDoc = g.document, prevWin = g.window;
+  g.window = dom.window;
+  g.document = dom.window.document;
+  const realCreate = dom.window.document.createElement.bind(dom.window.document);
+  dom.window.document.createElement = (tag) => {
+    const el = realCreate(tag);
+    if (tag === 'canvas') {
+      el.getContext = () => ({
+        createRadialGradient: () => ({ addColorStop() {} }),
+        fillRect() {}, fillStyle: '',
+      });
+    }
+    return el;
+  };
+
+  // Count SpriteMaterial disposals so we can prove the pool was emptied (a stale pool
+  // would re-dispose its old sprites on the next teardown -> double the count).
+  let matDisposed = 0;
+  const realMatDispose = THREE.SpriteMaterial.prototype.dispose;
+  THREE.SpriteMaterial.prototype.dispose = function (...a) { matDisposed++; return realMatDispose.apply(this, a); };
+
+  try {
+    const scene = new THREE.Scene();
+    const before = scene.children.length;
+
+    Snow.createSnowflakes(scene);
+    const added = scene.children.length - before;
+    check('createSnowflakes adds the snowflake sprites to the scene', added > 0);
+
+    matDisposed = 0;
+    Snow.teardownSnowflakes();
+    check('teardownSnowflakes detaches every snowflake from the scene', scene.children.length === before);
+    check('teardownSnowflakes disposes the snowflake sprite materials', matDisposed >= added);
+
+    // Second cycle: if teardown cleared the pool, this disposes the SAME count again; a
+    // stale pool would re-dispose the old sprites too (~2x).
+    Snow.createSnowflakes(scene);
+    check('a second createSnowflakes adds the same count (pool was cleared, not stacked)',
+      scene.children.length - before === added);
+    matDisposed = 0;
+    Snow.teardownSnowflakes();
+    check('the second teardown disposes only the fresh sprites (no stale-pool re-dispose)',
+      matDisposed >= added && matDisposed < added * 2);
+  } finally {
+    THREE.SpriteMaterial.prototype.dispose = realMatDispose;
+    g.document = prevDoc;
+    g.window = prevWin;
+  }
 }
 
 // ---- disposeSceneResources: each unique resource freed exactly once, even when shared. ----

--- a/tests/teardown-tests.js
+++ b/tests/teardown-tests.js
@@ -19,6 +19,8 @@
 //   node --import ./tests/loaders/register-ts-resolve.mjs tests/teardown-tests.js
 'use strict';
 
+const { JSDOM } = require('jsdom');
+
 let pass = 0, fail = 0;
 function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
 
@@ -28,6 +30,7 @@ async function main() {
 
   await testDedupSweep(THREE, disposeSceneResources);
   await testDisposeGameIdempotent(THREE, disposeGame);
+  await testOwnedDomNodeRemoval(THREE, disposeGame);
 
   console.log(`\nTEARDOWN TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
@@ -81,7 +84,13 @@ function makeFakeContext(THREE) {
 
   const calls = { debrisReset: 0, trailsDispose: 0, avalancheDispose: 0, rendererDispose: 0, forceContextLoss: 0, canvasRemoved: 0, listenersTorndown: 0 };
 
-  const canvas = { parentNode: { removeChild: (c) => { if (c === canvas) calls.canvasRemoved++; } } };
+  // Model the real ownership: the canvas sits inside a #gameCanvas wrapper, which sits in
+  // the body. disposeGame removes the WRAPPER (canvas.parentNode), taking the canvas with
+  // it — so the spy lives on the wrapper's parent. (No global `document` here, so the
+  // getElementById('cameraToggleBtn') branch is correctly skipped.)
+  const body = { removeChild: (c) => { if (c === wrapper) calls.canvasRemoved++; } };
+  const wrapper = { parentNode: body };
+  const canvas = { parentNode: wrapper };
   const renderer = {
     domElement: canvas,
     dispose: () => { calls.rendererDispose++; },
@@ -119,7 +128,7 @@ async function testDisposeGameIdempotent(THREE, disposeGame) {
   check('avalanche dispose() called once', calls.avalancheDispose === 1);
   check('renderer dispose() called once', calls.rendererDispose === 1);
   check('renderer forceContextLoss() called once', calls.forceContextLoss === 1);
-  check('canvas detached from its parent once', calls.canvasRemoved === 1);
+  check('owned #gameCanvas wrapper detached from the body once', calls.canvasRemoved === 1);
   check('listeners torn down once', calls.listenersTorndown === 1);
 
   // Second call: every side effect must stay at its first-call count (no-op).
@@ -144,6 +153,67 @@ async function testDisposeGameIdempotent(THREE, disposeGame) {
   let threw2 = false;
   try { disposeGame(ctx3); } catch { threw2 = true; }
   check('disposeGame works without a teardownListeners callback', !threw2);
+}
+
+// ---- disposeGame removes the instance-owned DOM nodes, not just the canvas (Codex
+// review #226). setupScene() appends the #gameCanvas wrapper + #gameOverOverlay, and
+// initLifecycleUI() appends #cameraToggleBtn; leaving them in the document on teardown
+// would create duplicate IDs / stale UI on a remount. ----
+async function testOwnedDomNodeRemoval(THREE, disposeGame) {
+  console.log('--- disposeGame: removes #gameCanvas wrapper, #gameOverOverlay, #cameraToggleBtn ---');
+
+  const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://snowglider.ai/' });
+  const { document } = dom.window;
+  const g = globalThis;
+  const prevDoc = g.document;
+  g.document = document; // teardown.ts reads the global `document` for getElementById
+
+  try {
+    // Mirror setupScene()/initLifecycleUI() DOM ownership: the canvas lives inside the
+    // #gameCanvas wrapper, the overlay + toggle button are appended to the body.
+    const wrapper = document.createElement('div');
+    wrapper.id = 'gameCanvas';
+    const canvas = document.createElement('canvas');
+    wrapper.appendChild(canvas);
+    document.body.appendChild(wrapper);
+
+    const overlay = document.createElement('div');
+    overlay.id = 'gameOverOverlay';
+    document.body.appendChild(overlay);
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.id = 'cameraToggleBtn';
+    document.body.appendChild(toggleBtn);
+
+    // A reset button authored in index.html (NOT instance-owned) must survive teardown.
+    const resetBtn = document.createElement('button');
+    resetBtn.id = 'resetBtn';
+    document.body.appendChild(resetBtn);
+
+    let rendererDisposed = 0;
+    const ctx = {
+      scene: new THREE.Scene(),
+      renderer: {
+        domElement: canvas,
+        dispose: () => { rendererDisposed++; },
+        forceContextLoss: () => {},
+      },
+      gameOverOverlay: overlay,
+      state: { gameActive: true, animationRunning: true, debris: null, snowTrails: null, avalanche: null },
+    };
+
+    disposeGame(ctx);
+
+    check('renderer disposed', rendererDisposed === 1);
+    check('#gameCanvas wrapper (and its canvas) removed from the document',
+      document.getElementById('gameCanvas') === null && !document.body.contains(canvas));
+    check('#gameOverOverlay removed from the document', document.getElementById('gameOverOverlay') === null);
+    check('#cameraToggleBtn removed from the document', document.getElementById('cameraToggleBtn') === null);
+    check('index.html-authored #resetBtn is NOT removed (not instance-owned)',
+      document.getElementById('resetBtn') !== null);
+  } finally {
+    g.document = prevDoc;
+  }
 }
 
 main().catch((err) => { console.error('teardown test harness crashed:', err); process.exit(1); });

--- a/tests/teardown-tests.js
+++ b/tests/teardown-tests.js
@@ -1,0 +1,149 @@
+// teardown-tests.js — headless coverage for the dispose-audit teardown path
+// (src/game/teardown.ts): the dedup-safe scene-resource sweep and the idempotent
+// disposeGame() entry point.
+//
+// There is NO production leak — the run/restart flow reuses the scene (see the plan
+// §1). disposeGame() is the NEW path used by unmount + dev-HMR, so these tests guard
+// its two load-bearing properties:
+//   1. disposeSceneResources disposes each UNIQUE geometry/material/texture exactly
+//      once even when many meshes share a pooled singleton (a naive per-mesh traverse
+//      would double-free).
+//   2. disposeGame is idempotent: a second call is a no-op (the §6 double-dispose
+//      safety requirement), and the first call stops the loop, disposes every
+//      subsystem once, drops the renderer + canvas, and aborts the listeners.
+//
+// A real WebGLRenderer needs a GL context (unreachable in Node), so the renderer is a
+// spy double; the scene is a real THREE.Scene so the traverse/dedup logic runs for
+// real. Run via the register-ts-resolve loader so teardown.ts's `./*.js` sibling
+// imports (the trees facade) resolve to their `.ts` sources:
+//   node --import ./tests/loaders/register-ts-resolve.mjs tests/teardown-tests.js
+'use strict';
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+
+async function main() {
+  const THREE = await import('three');
+  const { disposeSceneResources, disposeGame } = await import('../src/game/teardown.ts');
+
+  await testDedupSweep(THREE, disposeSceneResources);
+  await testDisposeGameIdempotent(THREE, disposeGame);
+
+  console.log(`\nTEARDOWN TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+// ---- disposeSceneResources: each unique resource freed exactly once, even when shared. ----
+async function testDedupSweep(THREE, disposeSceneResources) {
+  console.log('--- disposeSceneResources: dedups shared geometry/material/texture ---');
+
+  // One geometry, one material (with a texture map) shared across THREE meshes — the
+  // pooled-singleton case the dedup Set must collapse.
+  const geo = new THREE.BoxGeometry(1, 1, 1);
+  const tex = new THREE.Texture();
+  const mat = new THREE.MeshStandardMaterial({ map: tex });
+
+  const geoDisposed = [];
+  const matDisposed = [];
+  const texDisposed = [];
+  geo.addEventListener('dispose', () => geoDisposed.push(1));
+  mat.addEventListener('dispose', () => matDisposed.push(1));
+  tex.addEventListener('dispose', () => texDisposed.push(1));
+
+  const scene = new THREE.Scene();
+  for (let i = 0; i < 3; i++) scene.add(new THREE.Mesh(geo, mat));
+
+  // A mesh with an ARRAY material (multi-material) plus a fresh unique geometry, to
+  // exercise the Array.isArray branch and confirm distinct resources are each freed.
+  const geo2 = new THREE.PlaneGeometry(1, 1);
+  const matA = new THREE.MeshBasicMaterial();
+  const matB = new THREE.MeshBasicMaterial();
+  let geo2Disposed = 0, matADisposed = 0, matBDisposed = 0;
+  geo2.addEventListener('dispose', () => geo2Disposed++);
+  matA.addEventListener('dispose', () => matADisposed++);
+  matB.addEventListener('dispose', () => matBDisposed++);
+  scene.add(new THREE.Mesh(geo2, [matA, matB]));
+
+  disposeSceneResources(scene);
+
+  check('shared geometry disposed exactly once across 3 meshes', geoDisposed.length === 1);
+  check('shared material disposed exactly once across 3 meshes', matDisposed.length === 1);
+  check('texture hung off the shared material disposed exactly once', texDisposed.length === 1);
+  check('the unique second geometry disposed once', geo2Disposed === 1);
+  check('both materials in an array material disposed once each', matADisposed === 1 && matBDisposed === 1);
+}
+
+// Build a fake SceneContext: a real THREE.Scene (so the sweep runs), spy subsystems,
+// and a spy renderer double (a real WebGLRenderer needs a GL context).
+function makeFakeContext(THREE) {
+  const scene = new THREE.Scene();
+  scene.add(new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshStandardMaterial()));
+
+  const calls = { debrisReset: 0, trailsDispose: 0, avalancheDispose: 0, rendererDispose: 0, forceContextLoss: 0, canvasRemoved: 0, listenersTorndown: 0 };
+
+  const canvas = { parentNode: { removeChild: (c) => { if (c === canvas) calls.canvasRemoved++; } } };
+  const renderer = {
+    domElement: canvas,
+    dispose: () => { calls.rendererDispose++; },
+    forceContextLoss: () => { calls.forceContextLoss++; },
+  };
+
+  const ctx = {
+    scene,
+    renderer,
+    state: {
+      gameActive: true,
+      animationRunning: true,
+      debris: { reset: () => { calls.debrisReset++; } },
+      snowTrails: { dispose: () => { calls.trailsDispose++; } },
+      avalanche: { dispose: () => { calls.avalancheDispose++; } },
+    },
+  };
+  const teardownListeners = () => { calls.listenersTorndown++; };
+  return { ctx, calls, teardownListeners };
+}
+
+// ---- disposeGame: stops the loop, disposes each subsystem once, drops renderer +
+// canvas, aborts listeners — and a SECOND call is a no-op (idempotence). ----
+async function testDisposeGameIdempotent(THREE, disposeGame) {
+  console.log('--- disposeGame: full teardown, then idempotent on a second call ---');
+
+  const { ctx, calls, teardownListeners } = makeFakeContext(THREE);
+
+  disposeGame(ctx, teardownListeners);
+
+  check('stops the loop (gameActive=false)', ctx.state.gameActive === false);
+  check('stops the loop (animationRunning=false)', ctx.state.animationRunning === false);
+  check('debris reset() called once', calls.debrisReset === 1);
+  check('snowTrails dispose() called once', calls.trailsDispose === 1);
+  check('avalanche dispose() called once', calls.avalancheDispose === 1);
+  check('renderer dispose() called once', calls.rendererDispose === 1);
+  check('renderer forceContextLoss() called once', calls.forceContextLoss === 1);
+  check('canvas detached from its parent once', calls.canvasRemoved === 1);
+  check('listeners torn down once', calls.listenersTorndown === 1);
+
+  // Second call: every side effect must stay at its first-call count (no-op).
+  disposeGame(ctx, teardownListeners);
+  check('second disposeGame() does not re-reset debris', calls.debrisReset === 1);
+  check('second disposeGame() does not re-dispose snowTrails', calls.trailsDispose === 1);
+  check('second disposeGame() does not re-dispose avalanche', calls.avalancheDispose === 1);
+  check('second disposeGame() does not re-dispose the renderer', calls.rendererDispose === 1);
+  check('second disposeGame() does not re-abort listeners', calls.listenersTorndown === 1);
+
+  // A renderer whose forceContextLoss throws (headless / lost context) must not crash
+  // disposeGame — the renderer block is wrapped — and the rest of teardown still runs.
+  const { ctx: ctx2, calls: calls2, teardownListeners: tl2 } = makeFakeContext(THREE);
+  ctx2.renderer.forceContextLoss = () => { throw new Error('no GL context'); };
+  let threw = false;
+  try { disposeGame(ctx2, tl2); } catch { threw = true; }
+  check('disposeGame swallows a renderer teardown error', !threw);
+  check('listeners still torn down despite the renderer throw', calls2.listenersTorndown === 1);
+
+  // disposeGame must tolerate a missing teardownListeners arg.
+  const { ctx: ctx3 } = makeFakeContext(THREE);
+  let threw2 = false;
+  try { disposeGame(ctx3); } catch { threw2 = true; }
+  check('disposeGame works without a teardownListeners callback', !threw2);
+}
+
+main().catch((err) => { console.error('teardown test harness crashed:', err); process.exit(1); });

--- a/tests/teardown-tests.js
+++ b/tests/teardown-tests.js
@@ -32,9 +32,41 @@ async function main() {
   await testDisposeGameIdempotent(THREE, disposeGame);
   await testOwnedDomNodeRemoval(THREE, disposeGame);
   await testSnowflakePoolTeardown(THREE);
+  await testAudioToastTeardown();
 
   console.log(`\nTEARDOWN TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
+}
+
+// ---- AudioModule.teardown(): clears on-screen showMessage() toasts + their timers so a
+// fixed z-index:3000 div doesn't linger over the host page after unmount (Codex review #226). ----
+async function testAudioToastTeardown() {
+  console.log('--- AudioModule.teardown: clears lingering showMessage toasts ---');
+  const { AudioModule } = await import('../src/audio.ts');
+
+  const dom = new JSDOM('<!doctype html><body></body>', { url: 'https://snowglider.ai/' });
+  const g = globalThis;
+  const prevDoc = g.document, prevWin = g.window;
+  g.window = dom.window;
+  g.document = dom.window.document;
+  try {
+    AudioModule.showMessage('Loading game...', 100000); // long duration so it can't self-remove
+    AudioModule.showMessage('Get Ready!', 100000);
+    const toasts = () => [...dom.window.document.body.children].filter((el) => el.textContent === 'Loading game...' || el.textContent === 'Get Ready!');
+    check('showMessage appends the toast nodes to the body', toasts().length === 2);
+
+    AudioModule.teardown();
+    check('teardown removes every on-screen toast node', toasts().length === 0);
+
+    // Idempotent + a fresh toast after teardown is independent of the cleared ones.
+    let threw = false;
+    try { AudioModule.teardown(); } catch { threw = true; }
+    check('teardown is idempotent (no throw when no toasts remain)', !threw);
+  } finally {
+    AudioModule.teardown();
+    g.document = prevDoc;
+    g.window = prevWin;
+  }
 }
 
 // ---- Snow.teardownSnowflakes: detaches the sprites, frees their materials, and CLEARS

--- a/tests/trees-tests.js
+++ b/tests/trees-tests.js
@@ -152,6 +152,46 @@ async function main() {
       `${forestB.length} meshes`);
   }
 
+  // --- resetTreePools: dispose + null the shared geometry/material/texture pools -----
+  // Added for the dispose-audit teardown (disposeGame): the pools are app-lifetime
+  // singletons, so resetTreePools must free them AND null the caches so a later rebuild
+  // re-creates fresh handles instead of dangling on freed ones.
+  {
+    const disposedGeo = new Set();
+    const geoProto = THREE.BufferGeometry.prototype;
+    const realDispose = geoProto.dispose;
+    geoProto.dispose = function (...a) { disposedGeo.add(this.uuid); return realDispose.apply(this, a); };
+    try {
+      // Build a tree so the lazy geometry pools are populated, and capture the exact
+      // pooled geometries it drew from.
+      const treeA = Trees.createTree(1.0);
+      const geomsA = new Set();
+      treeA.traverse((o) => { const m = /** @type {any} */ (o); if (m.geometry) geomsA.add(m.geometry); });
+
+      Trees.resetTreePools();
+
+      const allDisposed = [...geomsA].every(g => disposedGeo.has(/** @type {any} */ (g).uuid));
+      assert(geomsA.size > 0 && allDisposed,
+        'resetTreePools disposes every pooled geometry the forest used');
+
+      // A rebuild after the reset must allocate fresh geometries — none shared with the
+      // pre-reset (now-disposed) pool — proving the singleton caches were nulled.
+      const treeB = Trees.createTree(1.0);
+      const geomsB = new Set();
+      treeB.traverse((o) => { const m = /** @type {any} */ (o); if (m.geometry) geomsB.add(m.geometry); });
+      const shared = [...geomsB].filter(g => geomsA.has(g));
+      assert(geomsB.size > 0 && shared.length === 0,
+        'a rebuild after resetTreePools allocates fresh geometries (no freed pool handles reused)');
+
+      // Idempotent: a second reset with the caches already null must not throw.
+      let threw = false;
+      try { Trees.resetTreePools(); } catch { threw = true; }
+      assert(!threw, 'resetTreePools is idempotent (safe when the pools are already null)');
+    } finally {
+      geoProto.dispose = realDispose;
+    }
+  }
+
   console.log(`\n=================================`);
   console.log(`Trees tests completed: ${passed} passed, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -80,6 +80,10 @@ declare global {
     toggleCameraView?: () => unknown;
     resetSnowman?: (...args: any[]) => unknown;
     restartGame?: () => unknown;
+    // Idempotent teardown for the whole game instance (dispose-audit plan): frees the
+    // WebGL context + GPU resources and removes game-lifetime listeners. Used by
+    // embedders/unmount and the dev-HMR hook; see src/game/teardown.ts.
+    disposeGame?: () => void;
     showGameOver?: (...args: any[]) => unknown;
     initializeGameWithAudio?: (...args: any[]) => unknown;
     // Test-only handles read/written by snowman.js test hooks + browser suites.
@@ -98,6 +102,17 @@ declare global {
       dump: () => unknown;
       reset: () => void;
       overlay: (on?: boolean) => void;
+    };
+  }
+
+  // Minimal Vite HMR typing for the coordinator's dev-only `import.meta.hot.dispose`
+  // teardown hook (src/snowglider.ts). The project doesn't pull in `vite/client`
+  // (its broad ambient module declarations would leak into every file), so declare
+  // just the slice we use. `hot` is undefined in production builds.
+  interface ImportMeta {
+    readonly hot?: {
+      dispose(cb: (data: unknown) => void): void;
+      accept(cb?: (mod: unknown) => void): void;
     };
   }
 }


### PR DESCRIPTION
Add a single idempotent teardown entry point so the game can be unmounted cleanly. There is no production leak — the run/restart flow correctly reuses the scene — but the page-IS-the-game model never released the WebGL context, GPU buffers, or DOM listeners, which bites under Vite dev-HMR (stacked contexts), embedding/unmount (leaked context on navigation), and a future forest rebuild.

- src/game/teardown.ts (new): disposeGame(ctx) stops the loop, runs a dedup-safe scene sweep (each unique geometry/material/texture disposed once, since the tree/avalanche/trail pools are shared singletons), disposes the subsystems, nulls the tree pools, drops the renderer + WebGL context + canvas, and aborts the listener controller. Idempotent via a per-context WeakSet.
- Listener hygiene: one AbortController in the coordinator threads its signal into every game-lifetime addEventListener (resize, restart hover, reset / camera-toggle / restart buttons) across snowglider.ts, scene-setup.ts, and lifecycle.ts — collapsing the add/remove asymmetry to a single abort().
- SnowTrails.dispose() + Trees.resetTreePools() added to mirror the existing AvalancheSystem.dispose()/SnowmanDebris.reset() patterns.
- Dev-HMR hook (import.meta.hot.dispose) releases the prior instance before the module re-evaluates; stripped from production builds.
- Tests: teardown-tests.js covers the dedup sweep + idempotence + error/missing -arg paths; leak-tests.js gains SnowTrails.dispose() coverage.

The run/restart reuse path is unchanged; this only adds a new teardown path.

## Scope: in this PR vs. deferred

The review surfaced a long tail of additional teardown findings. To keep this PR proportionate to its goal — and because, as noted above, **there is no production leak** (the run/restart path reuses the scene and never calls disposeGame; the only consumers of the new path are dev-HMR and tests) — the remaining items are split as follows.

**Added in this PR (beyond the original teardown):**
- **GPU-memory baseline contract** (`tests/e2e/teardown.spec.ts`): captures `renderer.info.memory` before/after `disposeGame()` on a real WebGL context and asserts the dedup sweep frees what the live run uploaded — geometries 85 → **0 (exact)**, textures 11 → **≤3** (see deferred note). This is the missing proof that the sweep actually reclaims GPU resources, not just removes DOM.
- **Controls state reset in teardown**: `disposeSnowGlider` now calls `Controls.resetControls()` before aborting the input listeners, so a key/touch held at teardown can't leave `gameControls`/`touchState` stuck for a same-instance remount. One line into an already-tested method the live game runs on every reset.
- **InstancedMesh per-instance buffer disposal**: the scene sweep now calls `InstancedMesh.dispose()` for the forest / avalanche / snow-trail instanced meshes. `geometry.dispose()` does not free the per-instance `instanceMatrix`/`instanceColor` buffers — only `InstancedMesh.dispose()` does — so this closes a real gap in the sweep's "frees every GPU resource" contract (one the `renderer.info.memory` baseline can't observe, since instance attributes aren't counted under `memory.geometries`). Covered by a dispose-spy assertion in teardown-tests.js.

**Deferred to a follow-up — [#227](https://github.com/den-run-ai/snowglider/issues/227)** (gated on a real embed / forest-rebuild consumer): these are all reachable *only* via a same-instance HMR/embed remount, which has no shipped consumer, so they are tracked rather than chased here:
- **Null the `Diag` report sink in `Diag.teardown()`** — a GC-reachability nicety: the retained `report` closure keeps the disposed module env reachable after unmount. No functional effect; matters only for full-heap collectability on a surviving-singleton remount.
- **Reset the `Diag` recorder state in `teardown()`** — `teardown()` disables `active` but doesn't call `reset()`, so stale `summary`/ring-buffer/`prev`/anomaly flags could carry into a singleton-reusing remount and skew the first new frame's tunnel-risk sample. The live reset path already calls `Diag.reset()` on every run, so this only matters on a constructor-level remount.
- **The ~3-texture residual after `disposeGame()`** — the mesh-only `scene.traverse` sweep doesn't reach textures held outside material slots (`scene.background`/`scene.environment` / renderer-internal targets). It's a small fixed count that doesn't scale with scene objects, so the baseline test pins it as a `≤3` ceiling (which still catches any per-object texture leak) instead of expanding the sweep.
- **A true dispose → reinit → baseline *cycle* test** — production exposes no in-place reinit entry point (only dev-HMR re-evaluates the module), so the contract above covers the single-shot dispose half. A multi-cycle test would land with a real reinit consumer.


Claude-Session: https://claude.ai/code/session_01HVh6EgkVy3WoRmax51V8PA