### PR TITLE
Fix dead share buttons on the mobile finish screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,21 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Fix: finish-screen share buttons dead on mobile
+- **Every "Share Result" / per-platform / "Save image" / "Copy link" button on the
+  finish result panel did nothing when tapped on a phone.** The buttons are bound to
+  `click`, and `controls.ts` attaches document-level `touchstart`/`touchmove`/`touchend`
+  handlers that `preventDefault()` every touch outside the scrollable guides. On mobile,
+  a `preventDefault()` on the first `touchmove` **or** on `touchend` suppresses the
+  synthesized `click` — so the tap never reached the handler. The earlier fix (#173)
+  defused only `touchstart`, which left the other half live: a clean tap still bubbles a
+  `touchend`, and a slightly-moving finger a `touchmove`.
+- **Fix:** `defuseTouch` in `src/ui/share-menu.ts` now `stopPropagation()`s the whole
+  touch sequence (`touchstart`/`touchmove`/`touchend`/`touchcancel`) so none of it reaches
+  the document handlers; the button's own `click` fires normally. Added a regression guard
+  in `tests/share-menu-tests.js` that dispatches a tap sequence on each share button and
+  asserts no touch event reaches `document`.
+
 ### Fixed-timestep accumulator: frame-rate-independent physics (no tunneling)
 - **The live run loop (`src/game/main-loop.ts`) now steps physics on a fixed grid.**
   The old loop advanced the kernel once per render frame with a variable `delta`

--- a/src/ui/share-menu.ts
+++ b/src/ui/share-menu.ts
@@ -35,11 +35,21 @@ export interface ShareControlsOptions {
 
 const PRIMARY_LABEL = '🔗 Share Result';
 
-/** Stop in-overlay button taps from reaching controls.ts's document-level
- *  touchstart handler, which preventDefaults and would kill the synthesized
- *  click on mobile (see fix #173). */
+/** Stop in-overlay button taps from reaching controls.ts's document-level touch
+ *  handlers. Those listen on `document` for touchstart/touchmove/touchend and
+ *  preventDefault() every touch outside the scrollable guides — and on mobile a
+ *  preventDefault() on EITHER the first touchmove OR touchend suppresses the
+ *  synthesized click, killing a button that's bound to 'click'. Fix #173 defused
+ *  only touchstart, which left the buttons dead on real devices (a clean tap still
+ *  bubbles a touchend, and a slightly-moving finger a touchmove). So we stop the
+ *  whole touch sequence from reaching those document handlers; the button's own
+ *  click fires normally. passive:true is fine — we only need stopPropagation, not
+ *  preventDefault. */
 function defuseTouch(el: HTMLElement): void {
-  el.addEventListener('touchstart', (e) => { e.stopPropagation(); }, { passive: true });
+  const swallow = (e: Event): void => { e.stopPropagation(); };
+  for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+    el.addEventListener(type, swallow, { passive: true });
+  }
 }
 
 function styleButton(btn: HTMLElement, primary: boolean): void {

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -65,3 +65,54 @@ test.describe('mobile touch', () => {
     expect(await page.locator('.touch-control').count()).toBeGreaterThan(0);
   });
 });
+
+// Regression for the dead finish-screen share buttons on mobile. controls.ts
+// attaches document-level touchstart/touchmove/touchend handlers that
+// preventDefault() every touch outside the scrollable guides; on a touch engine a
+// preventDefault() on the first touchmove OR on touchend suppresses the synthesized
+// click. The share buttons (bound to `click`) therefore did nothing on a phone
+// unless share-menu.ts keeps their whole touch sequence off `document`. A real
+// page.tap() routes through that exact WebKit pipeline, so this fails (the click
+// never lands) if the defuse ever regresses — which the .click()-driven unit tests
+// cannot catch.
+test.describe('mobile share buttons', () => {
+  test('tapping a share button fires its click (gameplay touch handlers do not eat it)', async ({ page }) => {
+    await gotoGame(page);
+    await startGame(page);
+
+    // Surface the finish result panel (which owns the share controls) without
+    // skiing the whole course: backdate the run clock past the 4s minimum-valid-
+    // time guard, then drive the real game-over finish path. This builds
+    // #courseResult inside the (z-index 1000, full-screen) game-over overlay.
+    await page.evaluate(() => {
+      const w = window as unknown as { startTime: number; showGameOver: (r: string) => void };
+      w.startTime = performance.now() - 5000;
+      w.showGameOver('You reached the end of the slope!');
+    });
+
+    const shareBtn = page.locator('#shareResultBtn');
+    const imageBtn = page.locator('#shareImageBtn');
+    await expect(shareBtn).toBeVisible();
+    await expect(imageBtn).toBeVisible();
+
+    // Count real click events on each visible share button. The listeners fire
+    // synchronously during click dispatch, so a tap that produces a click bumps the
+    // counter regardless of what the button's own handler then does.
+    await page.evaluate(() => {
+      const w = window as unknown as { __shareClicks: { primary: number; image: number } };
+      w.__shareClicks = { primary: 0, image: 0 };
+      document.getElementById('shareResultBtn')!
+        .addEventListener('click', () => { w.__shareClicks.primary++; });
+      document.getElementById('shareImageBtn')!
+        .addEventListener('click', () => { w.__shareClicks.image++; });
+    });
+
+    await shareBtn.tap();
+    await imageBtn.tap();
+
+    await page.waitForFunction(() => {
+      const c = (window as unknown as { __shareClicks: { primary: number; image: number } }).__shareClicks;
+      return c.primary > 0 && c.image > 0;
+    });
+  });
+});

--- a/tests/share-menu-tests.js
+++ b/tests/share-menu-tests.js
@@ -163,6 +163,33 @@ async function main() {
   check('mobile primary falls back to a text+link share when files are unsupported',
     !!textShared && /snowglider\.ai/.test(textShared.url));
 
+  // ---- Touch defusing: button taps must NOT reach controls.ts's document-level
+  // touch handlers. Those preventDefault() every touch, and on mobile a
+  // preventDefault() on the first touchmove OR touchend suppresses the synthesized
+  // click — so a share button bound to 'click' is dead unless its whole touch
+  // sequence is kept off `document`. Regression guard for the mobile-dead-button bug. ----
+  console.log('\n--- touch events are kept off document (mobile click survival) ---');
+  setNavigator({});
+  root = mount({ time: 42.13, isBest: true });
+  const seenAtDocument = [];
+  const docListener = (e) => { seenAtDocument.push(e.type); };
+  for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+    document.addEventListener(type, docListener);
+  }
+  // Dispatch a realistic tap sequence (bubbling, cancelable) on each share button.
+  const touchTargets = ['#shareResultBtn', '#shareImageBtn', '#share-x-btn', '#shareCopyBtn'];
+  for (const sel of touchTargets) {
+    const btn = root.querySelector(sel);
+    for (const type of ['touchstart', 'touchmove', 'touchend']) {
+      btn.dispatchEvent(new window.Event(type, { bubbles: true, cancelable: true }));
+    }
+  }
+  for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+    document.removeEventListener(type, docListener);
+  }
+  check('no share-button touch event reaches the document (would kill the click on mobile)',
+    seenAtDocument.length === 0);
+
   console.log(`\nSHARE-MENU TOTAL: ${pass} passed, ${fail} failed`);
   process.exit(fail ? 1 : 0);
 }


### PR DESCRIPTION
## Problem

Every share control on the finish result panel — **🔗 Share Result**, the per-platform buttons, **📸 Save image**, **🔗 Copy link** — did nothing when tapped on a phone. (Reported with a mobile screenshot of the result screen.)

## Root cause

The share buttons are bound to `click`. But `controls.ts` registers **document-level** `touchstart` / `touchmove` / `touchend` handlers that call `preventDefault()` on every touch outside the scrollable guides (to drive ski steering). On a touch engine, a `preventDefault()` on the **first `touchmove`** *or* on **`touchend`** suppresses the synthesized `click` — so the tap never reached the button's handler.

The earlier fix (#173) added `defuseTouch`, but it only `stopPropagation()`'d **`touchstart`**. That left the other half live: a clean tap still bubbles a `touchend` to `document`, and a slightly-moving finger a `touchmove` — either one killed the click. The existing unit tests pass because they invoke `.click()` directly, bypassing the real touch→click pipeline.

## Fix

`defuseTouch` in `src/ui/share-menu.ts` now `stopPropagation()`s the **whole** touch sequence (`touchstart` / `touchmove` / `touchend` / `touchcancel`), so none of it reaches the document handlers and the button's own `click` fires normally. `passive: true` is kept — we only need `stopPropagation`, not `preventDefault`.

## Why CI missed it (and the new coverage)

There *is* a mobile CI target — the Playwright `e2e` job runs a **Mobile Safari (WebKit, iPhone 13)** project — but it only exercised in-game touch *regions* via synthetic dispatched `Event`s and **never reached the finish result screen**, so the share buttons were never tapped on a touch device in CI. Synthetic `document.dispatchEvent` also can't reproduce the browser's real "preventDefault on touchend suppresses the click" semantics.

This PR closes that gap with a **real-tap** regression test:

- `tests/share-menu-tests.js` (headless): dispatches a tap sequence on each share button and asserts no touch event reaches `document` (the propagation contract).
- `tests/e2e/mobile.spec.ts` (WebKit, real `page.tap()`): surfaces the result panel via the `window.startTime` / `window.showGameOver` seams (backdating past the 4 s valid-time guard) and asserts each tap produces a `click`. **Verified it fails with the old touchstart-only defuse and passes with the full-sequence fix.**

## Testing

- `npm run lint`, `npm run build` — clean.
- `npm run test:share-menu` (19/19), `test:share`, `test:result-overlay`, `test:controls` — pass.
- New `mobile.spec.ts` share-tap test validated on Chromium mobile emulation locally (WebKit runs in CI's Playwright image): fails without the fix, passes with it.

## Caveat

Per the project's mobile guidance, this is verified headlessly + via emulated touch in CI — it has **not** been exercised on a physical iOS/Android device. The change is sound for WebKit/Blink synthesized-click semantics, but a real-device tap-through before release would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaCVacwVcuMrH5U2vm1GL5)_