### PR TITLE
Fix the mobile dead-button class at the source (controls.ts) + logout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,33 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Fix: systemic mobile dead-button class (Start-menu About/Close, logout, …)
+- **Root cause, finally fixed at the source.** `controls.ts` installs document-level
+  `touchstart`/`touchmove`/`touchend` handlers that `preventDefault()` *every* touch (for
+  ski steering). `preventDefault()` on a touch suppresses the browser's synthesized
+  `click`, so **any click-bound button drawn over the canvas was dead on mobile** unless
+  individually rescued. The tree had accumulated ~6 one-off workarounds for this single
+  cause: the restart-button defuse (#173), the controls-guide scroll exemption, the auth
+  sign-in `touchend`, the audio-button `touchstart`, and two share-control defuses. New
+  buttons (the start-menu **About Game** / **Close**, the account **logout**) kept falling
+  into the same trap.
+- **Systemic fix:** the gameplay touch handlers now bail (no `preventDefault`, no steering)
+  whenever the touch lands on an **interactive control** — `button, a, input, select,
+  textarea, label, [role="button"]` (via `closest()`, so nested icons count) — in addition
+  to the existing scrollable-guide exemption. Steering touches land on the canvas and are
+  unaffected; buttons with their own touch handlers (audio/reset/camera/restart) keep
+  working (they call their own `preventDefault`). This covers every current **and future**
+  click-bound button without per-button wiring.
+- **Logout was a self-inflicted variant:** its only touch handler was a `touchstart` that
+  called `preventDefault()` and nothing else — suppressing the click *and* never signing
+  out. Rebound to `click` + `touchend` (mirroring the sign-in buttons), guarded against
+  double-fire by the in-flight `disabled` check.
+- **Tests:** `tests/controls-node-tests.js` asserts a tap on a button (and on an element
+  nested in one) is never `preventDefault`ed nor read as steering; `tests/auth-tests.js`
+  covers logout via `touchend`; `tests/e2e/mobile.spec.ts` adds a real-tap WebKit check
+  that **About Game / Close** open and dismiss the panel. Verified the e2e fails without
+  the fix.
+
 ### Fix: finish-screen share buttons dead on mobile
 - **Every "Share Result" / per-platform / "Save image" / "Copy link" button on the
   finish result panel did nothing when tapped on a phone.** The buttons are bound to

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -78,9 +78,15 @@ physics. Details and the edge-engagement equations:
 - **Keyboard and touch are one contract.** Both only write the shared `controls`
   state; never branch physics on input source. Add a binding in
   [`controls.ts`](../src/controls.ts), not in the game loop.
-- **Touch buttons need their own `touchstart` handler.** The document-level
-  `touchstart` `preventDefault()` swallows synthesized clicks, so every on-screen
-  button wires its own handler (see the mute-button fix, #173).
+- **Click-bound buttons just work on touch now.** The document-level touch handlers
+  in [`controls.ts`](../src/controls.ts) `preventDefault()` steering touches, which
+  used to swallow the synthesized `click` on any on-screen button (hence the long
+  trail of per-button workarounds: #173, the auth `touchend`, the mute-button
+  `touchstart`, the share defuses). The handlers now **bail on touches that land on an
+  interactive control** (`button, a, input, select, textarea, label, [role="button"]`),
+  so a plain `click` listener is enough — no per-button touch wiring required.
+  Buttons that need to act on `touchstart`/`touchend` for other reasons (audio unlock,
+  popup user-activation) still may, but it's no longer mandatory.
 - **Reduced motion / automation.** Cosmetic layers (intro fly-over, snowman flex)
   are disabled under `reduced-motion` / test / automation so the deterministic path
   is unchanged — see [`ARCHITECTURE.md` §8](ARCHITECTURE.md#8-testing--deployment-seams).

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -605,23 +605,24 @@ function setupAuthButtons() {
     profileChip.addEventListener('touchend', toggleGuestUpgrade, { passive: false });
   }
 
-  // Logout button
+  // Logout button. Bind click + touchend, mirroring bindAuthButton. The OLD code
+  // bound a touchstart handler that ONLY called preventDefault() (no logout) plus a
+  // click handler — so on mobile the tap's touchstart preventDefault suppressed the
+  // synthesized click and logout never ran (the button was dead on touch). touchend
+  // is the tap-complete gesture; its preventDefault() stops the duplicate click, and
+  // the `disabled` guard means the click/touchend pair can't sign out twice.
   const logoutBtn = document.getElementById('logoutBtn') as HTMLButtonElement;
   if (logoutBtn) {
-    // Prevent default touch behavior if needed
-    logoutBtn.addEventListener('touchstart', (e) => {
-      e.preventDefault();
-    }, { passive: false });
-
-    logoutBtn.addEventListener('click', (e) => {
-      e.preventDefault();
+    const onLogout = (e: Event) => {
+      if (e) e.preventDefault();
 
       // Check if auth is available before attempting logout
       if (!auth) {
-          console.error("Auth service not available. Cannot sign out.");
-          // UI should already reflect signed-out state if auth failed init
-          return;
+        console.error("Auth service not available. Cannot sign out.");
+        // UI should already reflect signed-out state if auth failed init
+        return;
       }
+      if (logoutBtn.disabled) return; // a sign-out is already in flight
 
       // Update button state during sign-out
       logoutBtn.textContent = 'Signing Out...';
@@ -631,7 +632,7 @@ function setupAuthButtons() {
       firebaseSignOut(auth)
         .then(() => {
             // Success is primarily handled by onAuthStateChanged listener
-            console.log("Successfully signed out via button click.");
+            console.log("Successfully signed out via button.");
         })
         .catch(error => {
             console.error("Logout error:", error);
@@ -643,7 +644,10 @@ function setupAuthButtons() {
           logoutBtn.disabled = false;
           logoutBtn.textContent = 'Logout';
         });
-    });
+    };
+
+    logoutBtn.addEventListener('click', onLogout);
+    logoutBtn.addEventListener('touchend', onLogout, { passive: false });
   }
 }
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -243,9 +243,35 @@ function setupTouchControls(signal?: AbortSignal) {
       target.closest('#controlsGuide, #controlsContent'));
   };
 
+  // Touches that land on an interactive control (any button/link/form field, or an
+  // element explicitly marked interactive) must NOT be treated as gameplay steering.
+  // The handlers below preventDefault() every steering touch, and on mobile a
+  // preventDefault() on touchstart/touchmove/touchend suppresses the browser's
+  // synthesized click — which silently kills every click-bound UI button drawn over
+  // the canvas (Start/About/Close, the finish-screen share controls, the account
+  // chip/logout, …). Historically each such button was rescued one at a time (the
+  // restart-button defuse in #173, the auth touchend, the audio-button touchstart,
+  // the share defuseTouch); keying off the element role fixes the whole class at the
+  // source and covers buttons added later. Steering touches land on the canvas /
+  // background, which matches none of these. Buttons that run their OWN touch handler
+  // (audio/reset/camera/restart) keep working unchanged — they call their own
+  // preventDefault, so bailing here only drops the now-redundant document-level
+  // suppression and never double-fires.
+  const isInteractiveUiTouch = (event: TouchEvent): boolean => {
+    const target = event.target as Element | null;
+    return !!(target && typeof target.closest === 'function' &&
+      target.closest('button, a, input, select, textarea, label, [role="button"]'));
+  };
+
+  // A touch the gameplay layer must leave entirely alone: a scroll inside a guide
+  // panel or a tap on an interactive control. Both skip preventDefault() and steering
+  // so the browser delivers the native scroll / click.
+  const isNonGameplayTouch = (event: TouchEvent): boolean =>
+    isScrollableUiTouch(event) || isInteractiveUiTouch(event);
+
   // Handle touch start
   const handleTouchStart = (event: TouchEvent) => {
-    if (isScrollableUiTouch(event)) return; // let the controls guide scroll natively
+    if (isNonGameplayTouch(event)) return; // let UI controls + scrollable guides own their touch
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();
@@ -265,7 +291,7 @@ function setupTouchControls(signal?: AbortSignal) {
 
   // Handle touch move
   const handleTouchMove = (event: TouchEvent) => {
-    if (isScrollableUiTouch(event)) return; // let the controls guide scroll natively
+    if (isNonGameplayTouch(event)) return; // let UI controls + scrollable guides own their touch
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();
@@ -285,7 +311,7 @@ function setupTouchControls(signal?: AbortSignal) {
 
   // Handle touch end
   const handleTouchEnd = (event: TouchEvent) => {
-    if (isScrollableUiTouch(event)) return; // matches the start/move early-out above
+    if (isNonGameplayTouch(event)) return; // matches the start/move early-out above
     // Skip preventDefault during tests to avoid interfering with test automation
     if (!window.location.search.includes('test=')) {
       event.preventDefault();

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -169,6 +169,27 @@ async function main() {
     authUI.style.display === 'flex' && profileUI.style.display === 'none');
   check('signed-out: getCurrentUser() is null', AuthModule.getCurrentUser() === null);
 
+  console.log('\n--- Sign-out via touch (mobile tap) ---');
+  // The logout button previously bound only a touchstart handler that called
+  // preventDefault() and nothing else — which suppressed the synthesized click AND
+  // never signed out, so logout was dead on mobile. It must now sign out from
+  // 'touchend' (the tap-complete gesture) too, and not double-fire with the click.
+  fb.emitAuthState({ uid: 'u1', email: 'snow@glider.ai', displayName: 'Snow' });
+  await flush();
+  const signOutsBeforeTouch = calls.signOut;
+  const logoutTouch = new window.Event('touchend', { cancelable: true });
+  logoutBtn.dispatchEvent(logoutTouch);
+  check('logout touchend signs out even when the click is suppressed',
+    calls.signOut === signOutsBeforeTouch + 1 && logoutBtn.disabled === true);
+  check('logout touchend is preventDefaulted (suppresses the duplicate click)',
+    logoutTouch.defaultPrevented === true);
+  // A trailing synthetic click (before the async sign-out settles) must not sign out twice.
+  logoutBtn.dispatchEvent(new window.Event('click'));
+  check('trailing click after logout touchend does not sign out twice',
+    calls.signOut === signOutsBeforeTouch + 1);
+  await flush();
+  fb.emitAuthState(null);
+
   console.log('\n--- Sign-in via touch (game-page click-suppression scenario) ---');
   // On the game page, controls.js installs a document-level touchstart
   // preventDefault that suppresses this button's synthetic click — so sign-in must

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -157,7 +157,7 @@ async function main() {
   fb.emitAuthState({ uid: 'u1', email: 'snow@glider.ai', displayName: 'Snow', photoURL: 'http://p/x.png' });
 
   console.log('\n--- Sign-out ---');
-  const logoutBtn = window.document.getElementById('logoutBtn');
+  const logoutBtn = /** @type {HTMLButtonElement} */ (window.document.getElementById('logoutBtn'));
   logoutBtn.dispatchEvent(new window.Event('click'));
   check('firebaseSignOut was invoked', calls.signOut === 1);
   await flush();

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -190,6 +190,19 @@ async function main() {
   await flush();
   fb.emitAuthState(null);
 
+  console.log('\n--- Sign-out failure surfaces an alert + re-enables the button ---');
+  fb.emitAuthState({ uid: 'u1', email: 'snow@glider.ai', displayName: 'Snow' });
+  await flush();
+  alerts.length = 0;
+  fb.setNextSignOutError(new Error('network down'));
+  logoutBtn.dispatchEvent(new window.Event('click'));
+  await flush();
+  await flush();
+  check('sign-out failure alerts the user', alerts.some(a => /network down/.test(a)));
+  check('sign-out failure re-enables the logout button',
+    logoutBtn.disabled === false && logoutBtn.textContent === 'Logout');
+  fb.emitAuthState(null);
+
   console.log('\n--- Sign-in via touch (game-page click-suppression scenario) ---');
   // On the game page, controls.js installs a document-level touchstart
   // preventDefault that suppresses this button's synthetic click — so sign-in must

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -146,6 +146,38 @@ async function main() {
   check('a drag inside #controlsContent is never read as ski steering', controls.left === false);
   document.body.removeChild(guide);
 
+  console.log('\n--- interactive UI controls: touch passthrough (mobile) ---');
+  // A tap on any interactive control (button/link/form field) drawn over the canvas
+  // must be left to the browser: NOT preventDefaulted, so the synthesized click still
+  // fires on mobile (else every click-bound UI button — Start/About/Close, the share
+  // controls, the account chip — is silently dead), and NOT read as ski steering even
+  // when the tap lands in a control region. Regression guard for the systemic fix that
+  // retired the per-button workarounds.
+  const uiBtn = document.createElement('button');
+  uiBtn.id = 'aboutGameButton';
+  uiBtn.textContent = 'About Game';
+  document.body.appendChild(uiBtn);
+  controls.left = false;
+  // Left-region coordinates, but the gesture starts on the button.
+  const btnPoint = [{ identifier: 9, clientX: W / 6, clientY: H / 2 }];
+  for (const type of ['touchstart', 'touchmove', 'touchend']) {
+    const evt = /** @type {any} */ (new window.Event(type, { bubbles: true, cancelable: true }));
+    evt.changedTouches = btnPoint;
+    uiBtn.dispatchEvent(evt);
+    check(`${type} on a button is NOT preventDefaulted (synthesized click survives)`,
+      evt.defaultPrevented === false);
+  }
+  check('a tap on a button is never read as ski steering', controls.left === false);
+  // A nested element inside a button (e.g. an icon span) is still treated as the button.
+  const icon = document.createElement('span');
+  uiBtn.appendChild(icon);
+  const nestedEvt = /** @type {any} */ (new window.Event('touchstart', { bubbles: true, cancelable: true }));
+  nestedEvt.changedTouches = [{ identifier: 10, clientX: W / 6, clientY: H / 2 }];
+  icon.dispatchEvent(nestedEvt);
+  check('a touch on an element nested in a button is NOT preventDefaulted',
+    nestedEvt.defaultPrevented === false);
+  document.body.removeChild(uiBtn);
+
   console.log('\n--- visual touch controls (mobile) ---');
   check('mobile setup creates the 5 visual touch-control overlays',
     document.querySelectorAll('.touch-control').length === 5);

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -66,6 +66,26 @@ test.describe('mobile touch', () => {
   });
 });
 
+// Regression for the start-menu "About Game" / "Close" buttons on mobile. These are
+// plain click-bound <button>s shown while controls.ts's document-level touch handlers
+// are already live (setupControls runs at module load, before any run), so before the
+// systemic fix their synthesized click was suppressed and the buttons were dead. A
+// real page.tap() routes through the genuine WebKit touch->click pipeline.
+test.describe('mobile start-menu buttons', () => {
+  test('About Game / Close open and dismiss the About panel via tap', async ({ page }) => {
+    await gotoGame(page);
+    // Still on the start screen (do NOT start the game): the About controls live here.
+    const aboutPanel = page.locator('#aboutGamePanel');
+    await expect(aboutPanel).toBeHidden();
+
+    await page.locator('#aboutGameButton').tap();
+    await expect(aboutPanel).toBeVisible();
+
+    await page.locator('#closeAboutButton').tap();
+    await expect(aboutPanel).toBeHidden();
+  });
+});
+
 // Regression for the dead finish-screen share buttons on mobile. controls.ts
 // attaches document-level touchstart/touchmove/touchend handlers that
 // preventDefault() every touch outside the scrollable guides; on a touch engine a

--- a/tests/mocks/firebase.mjs
+++ b/tests/mocks/firebase.mjs
@@ -84,6 +84,7 @@ export const calls = {
 let authStateCallback = null; // the onAuthStateChanged listener auth.ts registers
 /** @type {PopupResult} */
 let nextPopupResult = null;   // controls how the next signInWithPopup/signInAnonymously resolves/rejects
+let nextSignOutError = null;  // when set, the next signOut() rejects with this (one-shot)
 /** @type {PopupResult} */
 let nextLinkResult = null;    // controls how the next linkWithPopup resolves/rejects (guest upgrade)
 
@@ -161,6 +162,7 @@ export function reset() {
   timestampCounter = 0;
   authStateCallback = null;
   nextPopupResult = null;
+  nextSignOutError = null;
   nextLinkResult = null;
   authInstance.currentUser = null;
 }
@@ -474,6 +476,11 @@ export function linkWithPopup(user, _provider) {
 // auth.ts imports this as `signOut as firebaseSignOut`.
 export function signOut() {
   calls.signOut++;
+  if (nextSignOutError) {
+    const err = nextSignOutError;
+    nextSignOutError = null; // one-shot
+    return Promise.reject(err);
+  }
   return Promise.resolve();
 }
 
@@ -508,6 +515,15 @@ export function setNextPopupResult(result) {
  */
 export function setNextLinkResult(result) {
   nextLinkResult = result;
+}
+
+/**
+ * Make the next signOut() reject with the given error (one-shot), so the logout
+ * failure path (alert + button re-enable) can be exercised.
+ * @param {unknown} error
+ */
+export function setNextSignOutError(error) {
+  nextSignOutError = error;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #230. That PR fixed the finish-screen share buttons one-by-one; this PR fixes the **whole class** at the source and clears two more casualties (start-menu **About Game** / **Close**, account **logout**).

## The class

`controls.ts` installs **document-level** `touchstart`/`touchmove`/`touchend` handlers that `preventDefault()` *every* touch (for ski steering). `preventDefault()` on a touch suppresses the browser's synthesized `click`, so **any click-bound button drawn over the canvas is dead on mobile** unless individually rescued. These handlers are live even on the start screen (`setupControls()` runs at module load).

The tree had accumulated ~6 one-off workarounds for this single cause:

| Fix | Button | Technique |
|---|---|---|
| #173 | Restart | `stopPropagation` on touchstart |
| controls-guide | Ski guides | container scroll exemption |
| auth `touchend` | Sign-in buttons | extra explicit handler |
| audio | Mute | explicit touchstart |
| #230 (×2) | Share controls | `defuseTouch` |

New buttons kept falling into the trap — hence **About Game** / **Close** (reported) and **logout**.

## Fix

1. **Systemic (`controls.ts`):** the gameplay touch handlers now bail (no `preventDefault`, no steering) when the touch lands on an **interactive control** — `button, a, input, select, textarea, label, [role="button"]` via `closest()` (so nested icons count) — alongside the existing scrollable-guide exemption. Steering touches land on the canvas and are unaffected; buttons with their own touch handlers (audio/reset/camera/restart) keep working (they call their own `preventDefault`). Covers every current **and future** click-bound button without per-button wiring.

2. **Logout (`auth.ts`) — a self-inflicted variant:** its only touch handler was a `touchstart` that called `preventDefault()` and nothing else — suppressing the click *and* never signing out. Rebound to `click` + `touchend` (mirroring the sign-in buttons), guarded against double-fire by the in-flight `disabled` check.

## Tests

- `tests/controls-node-tests.js` — a tap on a button (and on an element nested in one) is never `preventDefault`ed nor read as steering.
- `tests/auth-tests.js` — logout fires from `touchend` when the click is suppressed, and doesn't double sign-out.
- `tests/e2e/mobile.spec.ts` — real-tap WebKit check that **About Game / Close** open and dismiss the About panel. **Verified it fails without the fix.**
- `npm run lint`, `tsc --noEmit`, and the controls/start-menu/result-overlay/contract/teardown/auth/share suites all pass; the e2e validated on Chromium mobile emulation locally (WebKit runs in CI's Playwright image).

## Caveat

Verified headlessly + emulated touch only — not on physical iOS/Android hardware, which remains the real bar per the project's mobile guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaCVacwVcuMrH5U2vm1GL5)_