### PR TITLE
fix(scores): enforce the measured plausibility floor + purge migration (#229 item 2, PR C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ dist/
 
 # Local-only security notes (not for publication)
 SECURITY.md
+
+# Firebase emulator debug logs (produced by `npm run test:firebase`)
+firestore-debug.log
+firebase-debug.log
+ui-debug.log

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,8 +10,14 @@ service cloud.firestore {
       return isSignedIn() && request.auth.uid == userId;
     }
 
+    // Plausibility floor + upper cap. These two literals MUST equal
+    // MIN_VALID_SCORE_TIME / MAX_VALID_SCORE_TIME in src/score-limits.ts — Firestore
+    // rules cannot import JS, so the values are duplicated and kept in lockstep by the
+    // drift test in tests/score-limits-sync-tests.js. The floor (18 s) was measured
+    // empirically (issue #229, PR A): the shipped engine cannot produce a faster run, so
+    // a sub-floor write is forged and the server rejects it even from a patched client.
     function isValidScoreTime(time) {
-      return time is number && time >= 4 && time <= 600;
+      return time is number && time >= 18 && time <= 600;
     }
 
     function userDocPath(userId) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -16,6 +16,7 @@
     "test:auth": "node --import ./tests/loaders/register-firebase-mock.mjs tests/auth-tests.js && node tests/firebase-bootstrap-tests.js",
     "test:local-auth": "node tests/local-auth-tests.js",
     "test:scores": "node --import ./tests/loaders/register-firebase-mock.mjs tests/scores-tests.js",
+    "test:limits-sync": "node --import ./tests/loaders/register-ts-resolve.mjs tests/score-limits-sync-tests.js",
     "test:start-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/start-menu-tests.js",
     "test:collapsible": "node --import ./tests/loaders/register-ts-resolve.mjs tests/collapsible-panel-tests.js",
     "test:result-overlay": "node --import ./tests/loaders/register-ts-resolve.mjs tests/result-overlay-tests.js",

--- a/scripts/purge-implausible-scores.mjs
+++ b/scripts/purge-implausible-scores.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// purge-implausible-scores.mjs
+//
+// One-time admin migration for issue #229 (PR C): remove leaderboard entries and user
+// best times that sit BELOW the plausibility floor (MIN_VALID_SCORE_TIME in
+// src/score-limits.ts). The shipped engine cannot produce a sub-floor time (measured by
+// tests/verification/plausibility_floor_harness.js), so any such record is forged. Client
+// deletes are forbidden by firestore.rules (`allow delete: if false`), so this must run
+// with elevated Admin SDK credentials.
+//
+// The floor is parsed from src/score-limits.ts (the single source of truth) — never
+// hard-coded here — so this script always purges to whatever the shipped floor is.
+//
+// SAFETY: dry-run by default. It only mutates Firestore when invoked with --apply.
+//
+// Deploy ordering (see PR C plan): deploy the new firestore.rules FIRST (so no client can
+// re-write a sub-floor value mid-purge), THEN run this with --apply, THEN ship the client
+// with the raised constant.
+//
+// Usage:
+//   # Auth: set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON, or run in a
+//   # Google environment with application-default credentials. Optionally set
+//   # FIREBASE_PROJECT_ID / GCLOUD_PROJECT to pin the project.
+//   npm i firebase-admin           # if not already available
+//   node scripts/purge-implausible-scores.mjs            # dry run: lists what would change
+//   node scripts/purge-implausible-scores.mjs --apply    # performs the deletes + repairs
+//
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APPLY = process.argv.includes('--apply');
+
+// --- Read the floor from the single source of truth (no hard-coded literal). ----------
+function readFloor() {
+  const src = readFileSync(join(__dirname, '..', 'src', 'score-limits.ts'), 'utf8');
+  const m = src.match(/MIN_VALID_SCORE_TIME\s*=\s*([\d.]+)/);
+  if (!m) throw new Error('Could not parse MIN_VALID_SCORE_TIME from src/score-limits.ts');
+  return Number(m[1]);
+}
+
+async function main() {
+  const FLOOR = readFloor();
+  console.log(`Plausibility floor (MIN_VALID_SCORE_TIME) = ${FLOOR} s`);
+  console.log(APPLY ? 'MODE: --apply (live; will mutate Firestore)\n' : 'MODE: dry-run (no writes; pass --apply to perform changes)\n');
+
+  let admin;
+  try {
+    admin = (await import('firebase-admin')).default;
+  } catch {
+    console.error('firebase-admin is not installed. Run `npm i firebase-admin` first (it is intentionally not an app dependency).');
+    process.exit(2);
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID || process.env.GCLOUD_PROJECT || undefined;
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+    ...(projectId ? { projectId } : {})
+  });
+  const db = admin.firestore();
+
+  // --- 1. Purge sub-floor leaderboard entries, collecting affected users. --------------
+  const affectedUsers = new Set();
+  let deleted = 0;
+  const lbSnap = await db.collection('leaderboard').get();
+  console.log(`Scanning ${lbSnap.size} leaderboard entries...`);
+  for (const docSnap of lbSnap.docs) {
+    const time = docSnap.get('time');
+    if (typeof time === 'number' && time < FLOOR) {
+      console.log(`  [leaderboard/${docSnap.id}] time=${time} < ${FLOOR} -> DELETE`);
+      affectedUsers.add(docSnap.id);
+      deleted++;
+      if (APPLY) await docSnap.ref.delete();
+    }
+  }
+
+  // --- 2. Repair user best times that are themselves sub-floor (the bogus best). --------
+  // The leaderboard doc id is the uid, so the affected users are exactly those we purged;
+  // also sweep every users/{uid} whose stored bestTime is sub-floor, in case a user doc
+  // holds a forged best with no matching leaderboard row.
+  let repaired = 0;
+  const userSnap = await db.collection('users').get();
+  console.log(`\nScanning ${userSnap.size} user docs for sub-floor best times...`);
+  for (const docSnap of userSnap.docs) {
+    const bestTime = docSnap.get('bestTime');
+    if (typeof bestTime === 'number' && bestTime < FLOOR) {
+      console.log(`  [users/${docSnap.id}] bestTime=${bestTime} < ${FLOOR} -> CLEAR bestTime`);
+      affectedUsers.add(docSnap.id);
+      repaired++;
+      if (APPLY) {
+        await docSnap.ref.update({
+          bestTime: admin.firestore.FieldValue.delete(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp()
+        });
+      }
+    }
+  }
+
+  console.log(`\nSummary: ${deleted} leaderboard entr${deleted === 1 ? 'y' : 'ies'} ${APPLY ? 'deleted' : 'would be deleted'}, ` +
+    `${repaired} user best time${repaired === 1 ? '' : 's'} ${APPLY ? 'cleared' : 'would be cleared'}; ` +
+    `${affectedUsers.size} user(s) affected.`);
+  if (!APPLY) console.log('Dry run only — re-run with --apply to perform these changes.');
+  process.exit(0);
+}
+
+main().catch((e) => { console.error('purge failed:', e); process.exit(1); });

--- a/src/boot/local-auth.js
+++ b/src/boot/local-auth.js
@@ -1,6 +1,10 @@
 // @ts-check
 (function () {
-  const MIN_VALID_SCORE_TIME = 4;
+  // Plausibility floor + cap. This classic bootstrap script can't import ES modules, so
+  // the two literals are duplicated from src/score-limits.ts (the single source of truth);
+  // tests/score-limits-sync-tests.js asserts they stay equal. Floor measured in issue #229
+  // (PR A); see score-limits.ts for the derivation.
+  const MIN_VALID_SCORE_TIME = 18;
   const MAX_VALID_SCORE_TIME = 600;
 
   /** @param {number} time */

--- a/src/score-limits.ts
+++ b/src/score-limits.ts
@@ -1,0 +1,23 @@
+/**
+ * score-limits.ts — single source of truth for the leaderboard score-time bounds.
+ *
+ * MIN_VALID_SCORE_TIME is the leaderboard PLAUSIBILITY FLOOR. It was measured
+ * empirically by tests/verification/plausibility_floor_harness.js (issue #229, PR A),
+ * which drives the real Snowman physics over the real 180 m course: the shipped engine's
+ * fastest clean descent is ~26 s, and the hard theoretical minimum is ~21.8 s (the
+ * COURSE_LENGTH ÷ the ~8.2 m/s friction-capped terminal speed). Chaining the clean-landing
+ * jump boost is NET-SLOWER, so there is no exploit that beats the cruise — any sub-floor
+ * time is therefore forged, not engine-producible.
+ *
+ * 18 s sits ~15% under the theoretical minimum: low enough that a legitimate engine run is
+ * never rejected, high enough to reject the implausible ~14 s records issue #229 flagged.
+ * (The previous value, 4 s, was a placeholder that let forged times through.)
+ *
+ * MAX_VALID_SCORE_TIME is a generous upper bound for a completed run.
+ *
+ * IMPORTANT: firestore.rules duplicates these two literals because Firestore security
+ * rules cannot import JavaScript. tests/score-limits-sync-tests.js asserts the rules
+ * literals equal these constants, so the client and server floors can never drift.
+ */
+export const MIN_VALID_SCORE_TIME = 18;
+export const MAX_VALID_SCORE_TIME = 600;

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -40,18 +40,15 @@ import {
 } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore.js";
 import { logEvent, type Analytics } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-analytics.js";
 import type { User } from "https://www.gstatic.com/firebasejs/11.5.0/firebase-auth.js";
+// Plausibility floor + upper cap: single source of truth (see score-limits.ts). The
+// floor was measured empirically (issue #229, PR A); firestore.rules duplicates the same
+// literals because rules can't import JS, and a drift test keeps them in lockstep.
+import { MIN_VALID_SCORE_TIME, MAX_VALID_SCORE_TIME } from './score-limits.js';
 
 // Module state
 let firestore: Firestore | null = null; // Local cache of firestore instance, updated by initializeScores
 let analytics: Analytics | null = null;
 let currentUser: User | null = null;
-
-// The timed course runs from z=-15 to z=-195 (180 world metres). Four seconds is
-// deliberately loose: it rejects timer/startup artifacts like 0.01s while allowing
-// any physically plausible descent the current game can produce. Ten minutes is
-// a generous upper bound for completed runs and matches the Firestore rules cap.
-const MIN_VALID_SCORE_TIME = 4;
-const MAX_VALID_SCORE_TIME = 600;
 
 function isValidScoreTime(time: number) {
   return typeof time === 'number' &&

--- a/src/ui/result-overlay.ts
+++ b/src/ui/result-overlay.ts
@@ -9,10 +9,10 @@ import { Sfx } from '../sfx.js';
 import { Diag } from '../diagnostics.js';
 import { CourseModule } from '../course.js';
 import { EffectsModule } from '../effects.js';
-
-// Add timer and best time tracking (state.startTime / state.bestTime)
-const MIN_VALID_SCORE_TIME = 4;
-const MAX_VALID_SCORE_TIME = 600;
+// Plausibility floor + cap from the single source (see score-limits.ts) — used as the
+// local fallback when ScoresModule isn't present, so the client finish gate matches the
+// scores module and the Firestore rules (issue #229, PR C).
+import { MIN_VALID_SCORE_TIME, MAX_VALID_SCORE_TIME } from '../score-limits.js';
 
 export function isValidScoreTime(time: number): boolean {
   if (window.ScoresModule && typeof window.ScoresModule.isValidScoreTime === 'function') {

--- a/tests/auth-tests.js
+++ b/tests/auth-tests.js
@@ -323,7 +323,7 @@ async function main() {
     authUI.style.display === 'flex' && profileUI.classList.contains('expanded'));
   check('anonymous guest: AuthModule still reports signed-in (for UI/onboarding)',
     AuthModule.isUserSignedIn() === true);
-  AuthModule.recordScore(12.34); // guest finishes a run
+  AuthModule.recordScore(22.34); // guest finishes a run (valid time; only the guest guard should block it)
   await flush();
   check('anonymous guest: recordScore writes NO leaderboard entry for the guest',
     fb.read('leaderboard', 'guest1') === undefined &&
@@ -373,7 +373,7 @@ async function main() {
   // (see scores.ts: "the on-login syncUserData reconciliation re-applies it").
   // Write through the injected global store auth.ts reads (jsdom's window.localStorage
   // is read-only, so the harness's window.localStorage = global alias did not take).
-  localStorage.setItem('snowgliderBestTime', '17.5');
+  localStorage.setItem('snowgliderBestTime', '19.5');
   fb.setNextPopupResult(null);
   fb.emitAuthState({ uid: 'sync1', email: 's@g.ai', displayName: 'Sync', photoURL: null });
   // syncUserData is scheduled 100ms after sign-in; wait past it with margin, then let
@@ -385,7 +385,7 @@ async function main() {
   check('syncUserData writes the user profile doc on sign-in',
     !!fb.read('users', 'sync1') && fb.read('users', 'sync1').displayName === 'Sync');
   check('syncUserData backfills a valid local best to the leaderboard',
-    !!fb.read('leaderboard', 'sync1') && fb.read('leaderboard', 'sync1').time === 17.5);
+    !!fb.read('leaderboard', 'sync1') && fb.read('leaderboard', 'sync1').time === 19.5);
 
   // getUserIdToken delegates to the signed-in user's getIdToken (with forceRefresh).
   fb.emitAuthState({ uid: 'tok1', email: 't@g.ai', displayName: 'Tok', photoURL: null,

--- a/tests/browser-tests.js
+++ b/tests/browser-tests.js
@@ -632,13 +632,14 @@ import { Snowman } from '../src/snowman.js';
       gameActive = true;
       bestTimeUpdated = false;
       
-      // Make sure bestTime has a value that can be beaten
-      if (bestTime === Infinity) {
-        bestTime = 10; // Set a beatable best time
-      }
-      
-      // Set time to be better than current best time
-      startTime = performance.now() - (bestTime * 500); // Half the current best time
+      // A beatable best ABOVE the 18s plausibility floor (src/score-limits.ts), so a
+      // faster finish is still a valid score. Forced unconditionally (not just when
+      // Infinity) so a small best left by an earlier test can't push the synthesized
+      // finish below the floor and make the real showGameOver drop it.
+      bestTime = 40;
+
+      // Finish in half the best time (20s): faster than the best AND above the floor.
+      startTime = performance.now() - (bestTime * 500);
       
       // Simulate reaching the end of the slope
       pos.x = 0; // Stay on the ski path

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -101,12 +101,13 @@ test.describe('mobile share buttons', () => {
     await startGame(page);
 
     // Surface the finish result panel (which owns the share controls) without
-    // skiing the whole course: backdate the run clock past the 4s minimum-valid-
-    // time guard, then drive the real game-over finish path. This builds
-    // #courseResult inside the (z-index 1000, full-screen) game-over overlay.
+    // skiing the whole course: backdate the run clock past the 18s minimum-valid-
+    // time plausibility floor (src/score-limits.ts), then drive the real game-over
+    // finish path. This builds #courseResult inside the (z-index 1000, full-screen)
+    // game-over overlay.
     await page.evaluate(() => {
       const w = window as unknown as { startTime: number; showGameOver: (r: string) => void };
-      w.startTime = performance.now() - 5000;
+      w.startTime = performance.now() - 20000;
       w.showGameOver('You reached the end of the slope!');
     });
 

--- a/tests/firestore-rules-tests.js
+++ b/tests/firestore-rules-tests.js
@@ -122,19 +122,23 @@ async function main() {
   await runTest('user best times must be plausible score values', async () => {
     const alice = dbFor('alice');
 
-    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(14.67), { merge: true }));
+    // Sub-floor and over-cap writes are rejected first (no doc is created), then a
+    // plausible at-the-floor time is accepted as a fresh create. 17.99 specifically
+    // guards the 18 s plausibility floor (PR C, issue #229).
     await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(3.99), { merge: true }));
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(17.99), { merge: true }));
     await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(601), { merge: true }));
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(18), { merge: true }));
   });
 
   await runTest('user best times cannot be downgraded to a slower time', async () => {
     const alice = dbFor('alice');
     await seed(async admin => {
-      await setDoc(doc(admin, 'users', 'alice'), bestTime(14));
+      await setDoc(doc(admin, 'users', 'alice'), bestTime(20)); // a valid (>= floor) existing best
     });
 
-    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(19), { merge: true }));
-    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(13.5), { merge: true }));
+    await assertFails(setDoc(doc(alice, 'users', 'alice'), bestTime(25), { merge: true }));     // slower
+    await assertSucceeds(setDoc(doc(alice, 'users', 'alice'), bestTime(19), { merge: true }));  // faster, plausible
   });
 
   await runTest('valid user best times can repair a corrupt stored best', async () => {
@@ -162,7 +166,7 @@ async function main() {
 
     await assertSucceeds(setDoc(
       doc(alice, 'leaderboard', 'alice'),
-      leaderboardEntry(alice, 'alice', 14.67)
+      leaderboardEntry(alice, 'alice', 25.43)
     ));
   });
 
@@ -170,12 +174,12 @@ async function main() {
     const alice = dbFor('alice');
     await seed(async admin => {
       await setDoc(doc(admin, 'users', 'alice'), profile());
-      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 14.67));
+      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 25.43));
     });
 
     await assertSucceeds(getDocs(query(
       collection(alice, 'leaderboard'),
-      where('time', '>=', 4),
+      where('time', '>=', 18),
       orderBy('time', 'asc'),
       limit(10)
     )));
@@ -186,13 +190,13 @@ async function main() {
 
     await assertFails(getDocs(query(
       collection(anon, 'leaderboard'),
-      where('time', '>=', 4),
+      where('time', '>=', 18),
       orderBy('time', 'asc'),
       limit(10)
     )));
     await assertFails(setDoc(
       doc(anon, 'leaderboard', 'alice'),
-      leaderboardEntry(anon, 'alice', 14.67)
+      leaderboardEntry(anon, 'alice', 25.43)
     ));
   });
 
@@ -205,11 +209,11 @@ async function main() {
 
     await assertFails(setDoc(
       doc(alice, 'leaderboard', 'alice'),
-      leaderboardEntry(alice, 'bob', 14.67)
+      leaderboardEntry(alice, 'bob', 25.43)
     ));
     await assertFails(setDoc(
       doc(alice, 'leaderboard', 'bob'),
-      leaderboardEntry(alice, 'bob', 14.67)
+      leaderboardEntry(alice, 'bob', 25.43)
     ));
   });
 
@@ -223,9 +227,23 @@ async function main() {
       doc(alice, 'leaderboard', 'alice'),
       leaderboardEntry(alice, 'alice', 0.01)
     ));
+    // A forged sub-floor time (faster than the engine can produce) is rejected server-side
+    // even from a patched client — the core PR C guard for issue #229.
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 14)
+    ));
+    await assertFails(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 17.99)
+    ));
     await assertFails(setDoc(
       doc(alice, 'leaderboard', 'alice'),
       leaderboardEntry(alice, 'alice', 601)
+    ));
+    await assertSucceeds(setDoc(
+      doc(alice, 'leaderboard', 'alice'),
+      leaderboardEntry(alice, 'alice', 18)
     ));
   });
 
@@ -233,16 +251,16 @@ async function main() {
     const alice = dbFor('alice');
     await seed(async admin => {
       await setDoc(doc(admin, 'users', 'alice'), profile());
-      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 14));
+      await setDoc(doc(admin, 'leaderboard', 'alice'), leaderboardEntry(admin, 'alice', 20)); // valid existing best
     });
 
     await assertFails(setDoc(
       doc(alice, 'leaderboard', 'alice'),
-      leaderboardEntry(alice, 'alice', 19)
+      leaderboardEntry(alice, 'alice', 25)
     ));
     await assertSucceeds(setDoc(
       doc(alice, 'leaderboard', 'alice'),
-      leaderboardEntry(alice, 'alice', 13.5)
+      leaderboardEntry(alice, 'alice', 19)
     ));
   });
 

--- a/tests/local-auth-tests.js
+++ b/tests/local-auth-tests.js
@@ -145,9 +145,9 @@ function main() {
 
   // --- AuthModule.recordScore: localStorage fallback when ScoresModule is absent ---
   delete a.window.ScoresModule;
-  Auth.recordScore(10);
+  Auth.recordScore(25);
   check('AuthModule.recordScore falls back to localStorage without ScoresModule',
-    a.localStorage.getItem('snowgliderBestTime') === '10');
+    a.localStorage.getItem('snowgliderBestTime') === '25');
 
   // --- AuthModule.displayLeaderboard: no ScoresModule, #leaderboard present ---
   Auth.displayLeaderboard();

--- a/tests/result-overlay-tests.js
+++ b/tests/result-overlay-tests.js
@@ -38,7 +38,7 @@ function makeDeps(/** @type {{ bestTime?: number, startTime?: number, onCrash?: 
     </div>`;
   document.body.classList.add('game-active');
   return {
-    state: { gameActive: true, bestTime, startTime: startTime ?? (performance.now() - 10000) },
+    state: { gameActive: true, bestTime, startTime: startTime ?? (performance.now() - 20000) },
     gameOverOverlay: document.getElementById('gameOverOverlay'),
     gameOverDetail: document.getElementById('gameOverDetail'),
     restartButton: document.getElementById('restartButton'),
@@ -60,17 +60,17 @@ async function main() {
 
   // --- isValidScoreTime: fallback computation + delegation to ScoresModule ---
   delete window.ScoresModule;
-  check('isValidScoreTime fallback accepts a sane time', isValidScoreTime(10) === true);
-  check('isValidScoreTime fallback rejects a tiny time', isValidScoreTime(1) === false);
+  check('isValidScoreTime fallback accepts a sane time', isValidScoreTime(20) === true);
+  check('isValidScoreTime fallback rejects a sub-floor time', isValidScoreTime(1) === false);
   window.ScoresModule = { isValidScoreTime: (t) => t === 42 };
-  check('isValidScoreTime delegates to ScoresModule', isValidScoreTime(42) === true && isValidScoreTime(10) === false);
+  check('isValidScoreTime delegates to ScoresModule', isValidScoreTime(42) === true && isValidScoreTime(20) === false);
   delete window.ScoresModule;
 
   // --- readStoredBestTime: empty / valid / invalid stored values ---
   local.clear();
   check('readStoredBestTime returns Infinity with no stored time', readStoredBestTime() === Infinity);
-  local.clear(); local.setItem('snowgliderBestTime', '12.5');
-  check('readStoredBestTime parses a valid stored time', readStoredBestTime() === 12.5);
+  local.clear(); local.setItem('snowgliderBestTime', '22.5');
+  check('readStoredBestTime parses a valid stored time', readStoredBestTime() === 22.5);
   local.clear(); local.setItem('snowgliderBestTime', '0.1');
   check('readStoredBestTime drops an invalid stored time', readStoredBestTime() === Infinity && local.getItem('snowgliderBestTime') === null);
 
@@ -106,7 +106,7 @@ async function main() {
   {
     leaderboardShown = 0;
     window.AuthModule.getCurrentUser = () => ({ uid: 'u1' });
-    const deps = makeDeps({ bestTime: 1 }); // existing best (1s) faster than the ~10s finish
+    const deps = makeDeps({ bestTime: 1 }); // existing best (1s) faster than the ~20s finish
     createShowGameOver(deps)(FINISH);
     check('finish that is not a new best shows "Your Time"', /Your Time/.test(deps.bestTimeDisplay.textContent));
     check('signed-in finish inserts + displays the leaderboard',
@@ -125,7 +125,7 @@ async function main() {
   // --- Finish with an INVALID elapsed time -> warn branch, no score ---
   {
     window.AuthModule = { recordScore: () => { throw new Error('should not be called'); }, getCurrentUser: () => null };
-    const deps = makeDeps({ bestTime: 5, startTime: performance.now() - 1000 }); // ~1s < MIN 4
+    const deps = makeDeps({ bestTime: 5, startTime: performance.now() - 1000 }); // ~1s < MIN 18
     createShowGameOver(deps)(FINISH);
     check('invalid finish time shows the existing best, records nothing', /Best Time/.test(deps.bestTimeDisplay.textContent));
   }

--- a/tests/score-limits-sync-tests.js
+++ b/tests/score-limits-sync-tests.js
@@ -1,0 +1,61 @@
+// @ts-check
+// score-limits-sync-tests.js
+// Lockstep guard: the leaderboard plausibility floor + upper cap live in src/score-limits.ts
+// as the single source of truth, but firestore.rules has to duplicate the two literals
+// because Firestore security rules cannot import JavaScript. This test parses the
+// isValidScoreTime() bounds out of firestore.rules and asserts they exactly equal the
+// exported JS constants, so the client-side gate (scores.ts / result-overlay.ts) and the
+// server-side gate (the rules) can never silently drift apart (issue #229, PR C).
+//
+// Run: node --import ./tests/loaders/register-ts-resolve.mjs tests/score-limits-sync-tests.js
+const fs = require('fs');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function check(name, ok) {
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}: ${name} ${ok ? '✅' : '❌'}`);
+  if (ok) pass++; else fail++;
+}
+
+(async () => {
+  const { MIN_VALID_SCORE_TIME, MAX_VALID_SCORE_TIME } = await import('../src/score-limits.ts');
+
+  const rulesPath = path.join(__dirname, '..', 'firestore.rules');
+  const rules = fs.readFileSync(rulesPath, 'utf8');
+
+  // Pull the bounds straight out of the isValidScoreTime() body:
+  //   return time is number && time >= <MIN> && time <= <MAX>;
+  const m = rules.match(/time\s+is\s+number\s*&&\s*time\s*>=\s*([\d.]+)\s*&&\s*time\s*<=\s*([\d.]+)/);
+
+  console.log('--- score-limits.ts <-> firestore.rules lockstep ---');
+  check('firestore.rules exposes an isValidScoreTime() numeric range', !!m);
+
+  if (m) {
+    const rulesMin = Number(m[1]);
+    const rulesMax = Number(m[2]);
+    console.log(`  score-limits.ts: MIN=${MIN_VALID_SCORE_TIME} MAX=${MAX_VALID_SCORE_TIME} | firestore.rules: MIN=${rulesMin} MAX=${rulesMax}`);
+    check('rules floor equals MIN_VALID_SCORE_TIME', rulesMin === MIN_VALID_SCORE_TIME);
+    check('rules cap equals MAX_VALID_SCORE_TIME', rulesMax === MAX_VALID_SCORE_TIME);
+  }
+
+  // The classic-script local-auth fallback (src/boot/local-auth.js) can't import ES
+  // modules, so it duplicates the same two literals — assert they match too.
+  const localAuthPath = path.join(__dirname, '..', 'src', 'boot', 'local-auth.js');
+  const localAuth = fs.readFileSync(localAuthPath, 'utf8');
+  const laMin = localAuth.match(/MIN_VALID_SCORE_TIME\s*=\s*([\d.]+)/);
+  const laMax = localAuth.match(/MAX_VALID_SCORE_TIME\s*=\s*([\d.]+)/);
+  check('local-auth.js declares MIN/MAX literals', !!laMin && !!laMax);
+  if (laMin && laMax) {
+    check('local-auth.js floor equals MIN_VALID_SCORE_TIME', Number(laMin[1]) === MIN_VALID_SCORE_TIME);
+    check('local-auth.js cap equals MAX_VALID_SCORE_TIME', Number(laMax[1]) === MAX_VALID_SCORE_TIME);
+  }
+
+  // Sanity on the constants themselves so a typo (e.g. min > max, non-finite) is caught.
+  check('MIN_VALID_SCORE_TIME is a positive finite number',
+    Number.isFinite(MIN_VALID_SCORE_TIME) && MIN_VALID_SCORE_TIME > 0);
+  check('MAX_VALID_SCORE_TIME is greater than the floor',
+    Number.isFinite(MAX_VALID_SCORE_TIME) && MAX_VALID_SCORE_TIME > MIN_VALID_SCORE_TIME);
+
+  console.log(`\nSCORE-LIMITS SYNC TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/scores-tests.js
+++ b/tests/scores-tests.js
@@ -105,15 +105,17 @@ async function main() {
     !!ScoresModule && ['initializeScores', 'setCurrentUser', 'recordScore',
       'getLeaderboard', 'updateUserBestTime', 'updateLeaderboard',
       'isFirestoreAvailable', 'isValidScoreTime'].every(key => typeof ScoresModule[key] === 'function'));
-  check('score validation rejects impossible and non-finite times',
+  check('score validation rejects impossible, sub-floor and non-finite times',
     ScoresModule.isValidScoreTime(0.01) === false &&
+    ScoresModule.isValidScoreTime(14) === false &&     // below the 18 s plausibility floor (PR C)
+    ScoresModule.isValidScoreTime(17.99) === false &&  // just under the floor
     ScoresModule.isValidScoreTime(600.01) === false &&
     ScoresModule.isValidScoreTime(Infinity) === false &&
-    ScoresModule.isValidScoreTime(/** @type {any} */ ('14')) === false);
-  check('score validation accepts plausible numeric times',
-    ScoresModule.isValidScoreTime(4) === true &&
+    ScoresModule.isValidScoreTime(/** @type {any} */ ('20')) === false);
+  check('score validation accepts plausible numeric times at/above the floor',
+    ScoresModule.isValidScoreTime(18) === true &&
     ScoresModule.isValidScoreTime(600) === true &&
-    ScoresModule.isValidScoreTime(14.67) === true);
+    ScoresModule.isValidScoreTime(25.43) === true);
 
   console.log('\n--- Local score recording ---');
   resetState(ScoresModule);
@@ -153,32 +155,32 @@ async function main() {
   console.log('\n--- Authoritative best reconciliation ---');
   resetState(ScoresModule);
   ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
-  seed('users', 'u2', { bestTime: 14, updatedAt: { old: true } });
-  ScoresModule.updateUserBestTime('u2', 19.43);
+  seed('users', 'u2', { bestTime: 20, updatedAt: { old: true } });
+  ScoresModule.updateUserBestTime('u2', 25.43);
   await flushAll();
   check('slower run does not overwrite a faster Firestore user best',
-    read('users', 'u2')?.bestTime === 14);
+    read('users', 'u2')?.bestTime === 20);
   check('missing leaderboard entry is backfilled with the authoritative best',
-    read('leaderboard', 'u2')?.time === 14);
+    read('leaderboard', 'u2')?.time === 20);
   check('raw slower run never reaches the leaderboard',
-    calls.setDoc.every(call => call.path !== 'leaderboard/u2' || call.data.time !== 19.43));
+    calls.setDoc.every(call => call.path !== 'leaderboard/u2' || call.data.time !== 25.43));
 
   console.log('\n--- Leaderboard compare/write behavior ---');
   resetState(ScoresModule);
   ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
   seed('leaderboard', 'u3', {
     user: doc(firestoreInstance, 'users', 'u3'),
-    time: 17,
+    time: 25,
     achievedAt: { old: true }
   });
-  ScoresModule.updateLeaderboard('u3', 19);
+  ScoresModule.updateLeaderboard('u3', 28);
   await flushAll();
   check('leaderboard update does not downgrade a faster existing entry',
-    read('leaderboard', 'u3')?.time === 17);
-  ScoresModule.updateLeaderboard('u3', 16);
+    read('leaderboard', 'u3')?.time === 25);
+  ScoresModule.updateLeaderboard('u3', 22);
   await flushAll();
   check('leaderboard update accepts a faster time',
-    read('leaderboard', 'u3')?.time === 16);
+    read('leaderboard', 'u3')?.time === 22);
 
   console.log('\n--- Leaderboard fetch filtering ---');
   resetState(ScoresModule);
@@ -187,24 +189,28 @@ async function main() {
     user: doc(firestoreInstance, 'users', 'bad-fast'),
     time: 0.01
   });
+  seed('leaderboard', 'sub-floor', {              // forged sub-18s entry: must be filtered (PR C)
+    user: doc(firestoreInstance, 'users', 'sub-floor'),
+    time: 14
+  });
   seed('leaderboard', 'missing-user', {
-    time: 8
+    time: 24
   });
   seed('leaderboard', 'fast', {
     user: doc(firestoreInstance, 'users', 'fast'),
-    time: 14.67
+    time: 24.67
   });
   seed('leaderboard', 'slow', {
     user: doc(firestoreInstance, 'users', 'slow'),
     time: 58.64
   });
   const leaderboard = await ScoresModule.getLeaderboard();
-  check('getLeaderboard returns only valid entries with user refs',
+  check('getLeaderboard returns only valid (>= floor) entries with user refs',
     leaderboard.length === 2 &&
     leaderboard[0].userId === 'fast' &&
     leaderboard[1].userId === 'slow');
   check('getLeaderboard orders valid entries by ascending time',
-    leaderboard[0].time === 14.67 && leaderboard[1].time === 58.64);
+    leaderboard[0].time === 24.67 && leaderboard[1].time === 58.64);
 
   console.log('\n--- Offline write ordering ---');
   resetState(ScoresModule);
@@ -226,12 +232,12 @@ async function main() {
   ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
   currentAuthUser = { uid: 'hs', displayName: 'HS' };
   ScoresModule.setCurrentUser(currentAuthUser);
-  ScoresModule.recordScore(15); // first finish, no stored best => a new personal best
+  ScoresModule.recordScore(19); // first finish, no stored best => a new personal best
   await flushAll();
   check('a new authenticated personal best logs new_high_score',
-    calls.logEvent.some(event => event.name === 'new_high_score' && event.params.time === 15));
+    calls.logEvent.some(event => event.name === 'new_high_score' && event.params.time === 19));
   check('new personal best is also synced to the user doc',
-    read('users', 'hs')?.bestTime === 15);
+    read('users', 'hs')?.bestTime === 19);
 
   console.log('\n--- getActiveUser falls back to AuthModule ---');
   resetState(ScoresModule);
@@ -239,10 +245,10 @@ async function main() {
   // No setCurrentUser() call: recordScore must resolve the signed-in user via the
   // AuthModule.getAuthState()/getCurrentUser() fallback path.
   currentAuthUser = { uid: 'fallback', displayName: 'Fallback' };
-  ScoresModule.recordScore(16);
+  ScoresModule.recordScore(19);
   await flushAll();
   check('getActiveUser pulls the user from AuthModule when none was set',
-    read('users', 'fallback')?.bestTime === 16);
+    read('users', 'fallback')?.bestTime === 19);
 
   console.log('\n--- isFirestoreAvailable reflects AuthModule + local instance ---');
   resetState(ScoresModule);
@@ -268,7 +274,7 @@ async function main() {
   ScoresModule.initializeScores(firestoreInstance, analyticsInstance);
   currentAuthUser = { uid: 'me', displayName: 'Me' };
   ScoresModule.setCurrentUser(currentAuthUser);
-  seed('leaderboard', 'me', { user: doc(firestoreInstance, 'users', 'me'), time: 12.34 });
+  seed('leaderboard', 'me', { user: doc(firestoreInstance, 'users', 'me'), time: 19.34 });
   seed('leaderboard', 'other', { user: doc(firestoreInstance, 'users', 'other'), time: 20 });
   ScoresModule.displayLeaderboard();
   await flushAll();
@@ -276,8 +282,8 @@ async function main() {
   check('displayLeaderboard renders the Top 10 Times table',
     lbHtml.includes('Top 10 Times') && lbHtml.includes('<table>'));
   check('displayLeaderboard renders rows ascending with formatted times',
-    lbHtml.includes('12.34s') && lbHtml.includes('20.00s') &&
-    lbHtml.indexOf('12.34s') < lbHtml.indexOf('20.00s'));
+    lbHtml.includes('19.34s') && lbHtml.includes('20.00s') &&
+    lbHtml.indexOf('19.34s') < lbHtml.indexOf('20.00s'));
   check('displayLeaderboard highlights and names the current user row',
     lbHtml.includes('current-user-score') && lbHtml.includes('Me'));
 


### PR DESCRIPTION
## Summary

Second stage of the leaderboard cleanup (issue #229, follows PR #232/PR A). PR A measured that the shipped engine's fastest descent is **~26 s** (hard theoretical minimum **~21.8 s** at the ~8.2 m/s friction-capped terminal) and that chaining the clean-landing jump boost is **net-slower** — so any sub-cruise record (e.g. the ~14 s entries #229 flagged) is **forged, not engine-producible**. This PR turns that finding into enforcement: it replaces the placeholder `MIN_VALID_SCORE_TIME = 4` with the measured **18 s** floor, makes the floor a single source of truth, and ships an admin purge for existing bad entries.

`isValidScoreTime()` already flows through every write path (`recordScore → updateUserBestTime → updateLeaderboard`), the read query (`where('time','>=',MIN_VALID_SCORE_TIME)`), and the client finish gate (`result-overlay.ts`), so raising the constant fixes them all at once. The server-side rules now reject a forged sub-floor write even from a patched client.

## Single source of truth

- **New `src/score-limits.ts`** owns `MIN_VALID_SCORE_TIME = 18` and `MAX_VALID_SCORE_TIME = 600` (with the PR-A derivation documented). `scores.ts` and `ui/result-overlay.ts` now **import** it instead of redeclaring the literals.
- `firestore.rules` and the classic-script fallback `src/boot/local-auth.js` **cannot import JS**, so they duplicate the two literals. **New `tests/score-limits-sync-tests.js`** (`test:limits-sync`, wired into `npm test`) parses both files and asserts every copy equals the exported constant — so the client and server floors can never silently drift.

## Purge migration

- **New `scripts/purge-implausible-scores.mjs`** (Firebase Admin SDK; client deletes are forbidden by the rules). Deletes sub-floor leaderboard entries and clears sub-floor user best times. **Dry-run by default**; `--apply` performs changes. Reads the floor from `score-limits.ts` (no hard-coded literal). Intentionally **not** an app dependency.
- **Deploy order (critical):** deploy `firestore.rules` first → run the purge with `--apply` → ship the client with the raised constant.

## Tests

- `firestore-rules-tests.js`: added a **sub-floor leaderboard-write rejection** case (the core PR C guard); the downgrade tests now seed valid (≥ floor) bests so they exercise monotonicity rather than the corrupt-best repair path. Emulator suite **13 passed, 0 failed** locally.
- `scores` / `result-overlay` / `auth` / `local-auth` fixtures updated off the old 4 s floor.
- `.gitignore`: ignore the emulator debug logs `npm run test:firebase` produces.

## Acceptance criteria (PR C)

- [x] `scores.ts` and `firestore.rules` both use the PR-A floor; a test asserts they're equal (also covers `local-auth.js`).
- [x] `npm run test:scores` green (fixtures updated).
- [x] `npm run test:firebase` green, incl. a new sub-floor leaderboard-write-rejected case.
- [x] Purge dry-run lists implausible entries; `--apply` removes them + clears `bestTime`.
- [x] Leaderboard renders with no sub-floor rows (the `getLeaderboard` filter + the `>= 18` query).

## Verification

`npm test` (full aggregate), `npm run test:firebase`, `npm run lint`, `npm run typecheck`, `npm run typecheck:tests` all green locally.

Closes #229 item 2 (both checkboxes; confirms the impossible-score rejection from #78 now covers this regime). No gameplay change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01492k3ZUUCp6NyL3AY1iMWK)_