### PR TITLE
feat(snow): cavity/AO vertex shading + single-sourced slope tiers (#17)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,27 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Feature: cavity / ambient-occlusion snow shading + single-sourced slope tiers (#17)
+- **Readability gap.** The shipped per-vertex slope tint (`applySnowVertexColors`) keyed
+  off slope *magnitude* only, so it darkened steep faces but left concave hollows — the
+  rolls and gullies between moguls — as flat white, exactly where real snow self-shadows
+  (the "occluded concavity" the rendering doc's core principle calls for).
+- **Cavity/AO term.** `applySnowVertexColors` now also bakes an ambient-occlusion term
+  when handed the terrain grid: each vertex is compared to its 4 grid-neighbours' mean
+  height; vertices below the local mean (concave) take a subtle darken + cool blue-shift,
+  a little stronger on steeper ground. Convex peaks stay bright. Build-time, deterministic,
+  zero per-frame cost; reads vertex heights but never writes them, so the physics height
+  field / authoritative geometry are untouched.
+- **Single-sourced slope thresholds.** The HUD's `SLOPE_MODERATE` / `SLOPE_STEEP` tier
+  edges moved into a shared `src/slope-tiers.ts`, consumed by both the HUD (no behaviour
+  change) and the new cavity term's steep-slope gating, so the on-snow shading and the
+  on-screen difficulty mark can't drift apart.
+- Covered by `tests/snow-surface-tests.js` (`npm run test:snow-surface`); terrain /
+  regression / physics-invariant suites unchanged (no height-field touch). See
+  [`SNOW_RENDERING.md`](SNOW_RENDERING.md). The obstacle-silhouette half of the original
+  readability proposal is deferred to its own perf-aware PR (per-object contact decals
+  interact with the instanced-forest draw-call budget).
+
 ### Feature: player-following sun shadow + frustum fix (#18)
 - **Latent bug.** Everything in the scene set `castShadow` and the terrain set
   `receiveShadow`, but nothing configured the directional (sun) light's shadow

--- a/docs/SNOW_RENDERING.md
+++ b/docs/SNOW_RENDERING.md
@@ -101,6 +101,26 @@ pure rendering change: it never touches `pos`/`velocity` or the physics height f
 so the no-input invariant is unaffected, and it adds no new per-frame shadow cost (the
 sun cycle already re-rendered the shadow map every frame).
 
+## Cavity / ambient-occlusion shading (#17)
+
+The "Core visual principle" above asks for troughs and lee sides to get their form
+from **occluded concavity**, not a grey tint. The shipped slope tint
+(`applySnowVertexColors`) only keyed off slope *magnitude* (normal tilt), so it
+darkened steep faces but left concave hollows — the rolls and gullies between moguls —
+as flat white, exactly where snow self-shadows. `applySnowVertexColors` now also bakes a
+**cavity/AO term** when handed the terrain grid (`cols`/`rows`):
+
+- For each vertex it compares the height to its 4 grid neighbours' mean. A vertex that
+  sits *below* the local mean is concave (a hollow) and takes a subtle darken + cool
+  blue-shift toward an occluded-pocket tint; convex peaks go negative and stay bright.
+- The term is a little stronger on steeper ground, gated by the **shared** `SLOPE_STEEP`
+  boundary from `src/slope-tiers.ts` — the same constant the HUD's difficulty mark uses,
+  so the on-snow shading and the on-screen tier never drift.
+- It reads vertex *heights* but never writes them, so the physics height field and the
+  authoritative terrain geometry are untouched (same render-only contract as the slope
+  tint and smoothed shading normals). It is build-time and deterministic — zero per-frame
+  cost. Covered by `tests/snow-surface-tests.js` (`npm run test:snow-surface`).
+
 ## Ownership boundaries
 
 Keeping each layer in its lane is what prevents the whiteout / grey / muddy
@@ -110,7 +130,7 @@ regressions from creeping back when one piece is retuned:
 |---|---|---|
 | Static snow-lighting (`scene-setup.ts`, `mountains.ts`) | albedo, normal-map de-striping, smoothed render normals, static light balance, near-white slope tint | sun-cycle animation |
 | Terrain (`mountains.ts` height field) | the slope geometry; replacing the periodic ridge that bands under low sun | lighting rebalance |
-| AO / curvature readability (if added) | concavity shading from the smoothed-normal clone | terrain physics changes |
+| Cavity / AO readability (`mountains/snow-surface.ts`, #17) | per-vertex concavity darken + cool-shift baked into the slope tint | terrain physics changes / height field |
 | Sun cycle (`src/sky.ts`, #163) | directional sun position/color/intensity, Preetham `sunPosition`/`exposure`, bounded fog/background tint | snow albedo, vertex tint, smoothed normals, terrain, **hemisphere fill** |
 
 ## The sun cycle is an atmospheric layer, not a readability fix

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:difficulty": "node --import ./tests/loaders/register-ts-resolve.mjs tests/difficulty-tests.js",
@@ -39,6 +39,7 @@
     "test:audio-asset": "node tests/audio-asset-tests.js",
     "test:sky": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sky-cycle-tests.js",
     "test:sun-shadow": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sun-shadow-tests.js",
+    "test:snow-surface": "node --import ./tests/loaders/register-ts-resolve.mjs tests/snow-surface-tests.js",
     "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",

--- a/src/mountains/snow-surface.ts
+++ b/src/mountains/snow-surface.ts
@@ -8,6 +8,18 @@
 // deterministic forestDensityField so the ground ties to the tree stands.
 import * as THREE from 'three';
 import { forestDensityField } from './noise.js';
+import { SLOPE_MODERATE, SLOPE_STEEP } from '../slope-tiers.js';
+
+// Cavity / ambient-occlusion shading (issue #17 follow-up). The shipped slope tint
+// keys off slope *magnitude* (normal tilt), so it darkens steep faces but leaves
+// concave hollows — the rolls and gullies between moguls — as flat white, which is
+// exactly where real snow self-shadows and pools cool light. These constants bake a
+// subtle darken + blue-shift into vertices that sit BELOW their neighbours (concave),
+// added on top of the slope tint. Build-time and deterministic, so zero per-frame cost.
+const CAVITY_SCALE = 1.2;        // metres of concavity (neighbour-mean minus vertex) that reaches full occlusion
+const CAVITY_MAX_AMT = 0.30;     // max lerp toward the occluded colour (kept subtle — powder must stay bright)
+const CAVITY_COLOR = { r: 0.80, g: 0.84, b: 0.93 }; // cool, slightly-dark occluded-pocket tint (palette #93A9CC, softened)
+
 
 // --- Procedural snow surface textures (issue #17) ---
 // Authored for the project's legacy colour pipeline (`ColorManagement.enabled =
@@ -145,12 +157,26 @@ export function createSnowNormalTexture(): THREE.CanvasTexture {
  * blue cast for depth, the way real powder shadows do. Applied via `vertexColors`,
  * so it adds slope-dependent depth without touching the height field — physics is
  * unaffected. Mutates `geometry` in place; call after `computeVertexNormals()`.
+ *
+ * When `cols`/`rows` (the PlaneGeometry grid vertex counts) are supplied, a curvature
+ * /ambient-occlusion term is added on top of the slope tint: vertices that sit below
+ * their grid neighbours (concave hollows) take a subtle darken + cool blue-shift, a
+ * little stronger on steeper ground (gated by the shared {@link SLOPE_STEEP} boundary).
+ * This is the cue the slope-magnitude tint misses — hollows read as shaded depressions
+ * instead of flat white. Reads vertex *heights* but never modifies them, so the physics
+ * height field / authoritative geometry are untouched.
  */
-export function applySnowVertexColors(geometry: THREE.BufferGeometry): void {
+export function applySnowVertexColors(
+  geometry: THREE.BufferGeometry, cols?: number, rows?: number
+): void {
   const normals = geometry.attributes.normal!.array as Float32Array;
   const positions = geometry.attributes.position!.array as Float32Array;
   const count = geometry.attributes.position!.count;
   const colors = new Float32Array(count * 3);
+  // The cavity/AO term needs the grid topology to find each vertex's neighbours; only
+  // engage it when a matching grid is passed (the live terrain), else fall back to the
+  // pure slope tint (keeps the function usable from tests / other callers unchanged).
+  const cavity = !!cols && !!rows && cols * rows === count;
   const snow = { r: 1.0, g: 1.0, b: 1.0 };
   const shade = { r: 0.93, g: 0.95, b: 0.99 }; // barely-cool powder shadow (almost white)
   // Where conifer stands grow — gentle slopes inside the forest-density bands — the
@@ -176,6 +202,30 @@ export function applySnowVertexColors(geometry: THREE.BufferGeometry): void {
     r += (forestTint.r - r) * amt;
     g += (forestTint.g - g) * amt;
     b += (forestTint.b - b) * amt;
+    // Cavity / AO: darken + cool-shift vertices that dip below their neighbours.
+    if (cavity) {
+      const c = i % cols;
+      const row = (i / cols) | 0;
+      const yC = positions[i * 3 + 1]!;
+      // 4-neighbour heights, edge-clamped (matches applySmoothShadingNormals' clamping).
+      const yl = positions[(row * cols + Math.max(0, c - 1)) * 3 + 1]!;
+      const yr = positions[(row * cols + Math.min(cols - 1, c + 1)) * 3 + 1]!;
+      const yu = positions[(Math.max(0, row - 1) * cols + c) * 3 + 1]!;
+      const yd = positions[(Math.min(rows - 1, row + 1) * cols + c) * 3 + 1]!;
+      // Concavity > 0 when the vertex sits below the local mean (a hollow); convex peaks
+      // go negative and are left bright. Normalise to an occlusion amount in [0, 1].
+      const concavity = (yl + yr + yu + yd) / 4 - yC;
+      let occ = Math.min(1, Math.max(0, concavity / CAVITY_SCALE));
+      // Self-shadowing reads stronger on steeper ground: scale the term from ~0.7 on
+      // gentle slopes up to ~1.3 past the black-diamond pitch (shared SLOPE_* edges).
+      const slopeMag = Math.sqrt(Math.max(0, 1 - ny * ny)) / Math.max(ny, 1e-3);
+      const steep = Math.min(1, Math.max(0, (slopeMag - SLOPE_MODERATE) / (SLOPE_STEEP - SLOPE_MODERATE)));
+      occ *= 0.7 + 0.6 * steep;
+      const occAmt = Math.min(1, occ) * CAVITY_MAX_AMT;
+      r += (CAVITY_COLOR.r - r) * occAmt;
+      g += (CAVITY_COLOR.g - g) * occAmt;
+      b += (CAVITY_COLOR.b - b) * occAmt;
+    }
     colors[i * 3] = r;
     colors[i * 3 + 1] = g;
     colors[i * 3 + 2] = b;

--- a/src/mountains/terrain-mesh.ts
+++ b/src/mountains/terrain-mesh.ts
@@ -94,7 +94,9 @@ export function createTerrain(scene: THREE.Scene) {
   // matte like real powder; the gentle normalScale avoids harsh corrugation.
   const albedo = createSnowAlbedoTexture();
   const normalMap = createSnowNormalTexture();
-  applySnowVertexColors(geometry);
+  // Pass the 151x201 grid so the slope tint also bakes the cavity/AO term (hollows
+  // read as shaded depressions, not flat white). Same grid as applySmoothShadingNormals.
+  applySnowVertexColors(geometry, 151, 201);
 
   const material = new THREE.MeshStandardMaterial({
     color: 0xffffff,

--- a/src/slope-tiers.ts
+++ b/src/slope-tiers.ts
@@ -1,0 +1,13 @@
+// Shared ski-slope steepness thresholds, in gradient magnitude (rise/run = tan θ).
+//
+// Single source of truth for BOTH the HUD's difficulty tiers (src/ui/hud.ts — the
+// ● green / ■ blue / ◆ black-diamond readout) AND the terrain's slope-aware snow
+// shading (src/mountains/snow-surface.ts — the cavity/AO darkening leans harder on
+// steeper ground). Before this module each side carried its own copy of the numbers,
+// so a retune of one would silently drift from the other; importing the same
+// constants keeps the on-snow shading and the on-screen difficulty mark in agreement.
+//
+// Dependency-free constants (no THREE), so the physics kernel or any UI module can
+// import them without pulling in the render stack.
+export const SLOPE_MODERATE = 0.32; // ≈18° / 32% — green (●) → blue (■)
+export const SLOPE_STEEP = 0.58;    // ≈30° / 58% — blue (■) → black diamond (◆)

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5,6 +5,7 @@
 
 import type { PlayerPos, UpdateResult } from '../snowman.js';
 import { setupCollapsiblePanel } from './collapsible-panel.js';
+import { SLOPE_MODERATE, SLOPE_STEEP } from '../slope-tiers.js';
 
 // --- Real-world units for the Game Stats readout ---
 // The simulation runs in metric world units where 1 unit ≈ 1 metre (the same
@@ -25,8 +26,8 @@ const RAD_TO_DEG = 180 / Math.PI;
 // ~24°, which is steep in absolute terms), and the boundaries double as the
 // snowplow's "can I stop here?" cue — the wedge can fully stop you up to the black
 // line and only checks speed beyond it (PHYSICS.md §3.4, issue #54).
-const SLOPE_MODERATE = 0.32;     // ≈18° / 32% — green (●) → blue (■)
-const SLOPE_STEEP = 0.58;        // ≈30° / 58% — blue (■) → black diamond (◆)
+// SLOPE_MODERATE / SLOPE_STEEP are single-sourced in ../slope-tiers.js so the terrain's
+// slope-aware snow shading (mountains/snow-surface.ts) keys off the same boundaries.
 // The raw per-frame gradient is noisy (high-frequency terrain detail makes it jump
 // several degrees frame-to-frame as the snowman moves), which made the readout — and
 // its difficulty tier — flicker. Smooth the *display* value with an exponential

--- a/tests/snow-surface-tests.js
+++ b/tests/snow-surface-tests.js
@@ -1,0 +1,86 @@
+// @ts-check
+// Headless coverage for the snow-surface cavity/AO vertex shading (issue #17 follow-up)
+// and the single-sourced slope thresholds (src/slope-tiers.ts).
+//
+// applySnowVertexColors bakes a per-vertex snow tint into the terrain geometry. The
+// shipped tint keys off slope magnitude only, so concave hollows stayed flat white; the
+// new cavity term darkens + cool-shifts vertices that dip below their grid neighbours.
+// These assertions build a tiny grid with a known hollow / peak / flat and verify the
+// term darkens hollows, leaves convex peaks and flats untouched, and never modifies the
+// vertex heights. Pure + WebGL-free (only THREE math + the function under test). CommonJS
+// + dynamic import so the register-ts-resolve loader resolves the `.ts` sources + 'three'.
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+const sum3 = (a, i) => a[i * 3] + a[i * 3 + 1] + a[i * 3 + 2];
+
+async function main() {
+  const THREE = await import('three');
+  const { applySnowVertexColors } = await import('../src/mountains/snow-surface.ts');
+  const { SLOPE_MODERATE, SLOPE_STEEP } = await import('../src/slope-tiers.ts');
+
+  // --- Build a 7x7 grid (PlaneGeometry 6x6 segments), rotated so y is height. ---
+  const COLS = 7, ROWS = 7;
+  function freshGeo() {
+    const g = new THREE.PlaneGeometry(12, 12, COLS - 1, ROWS - 1);
+    g.rotateX(-Math.PI / 2); // now position.y is terrain height
+    const p = g.attributes.position.array;
+    // Flat field at y=0, with one concave hollow and one convex peak whose
+    // 4-neighbourhoods don't overlap.
+    const HOLLOW = 3 * COLS + 3; // (r=3,c=3) centre
+    const PEAK = 1 * COLS + 1;   // (r=1,c=1)
+    p[HOLLOW * 3 + 1] = -2;      // dips below neighbours -> concave
+    p[PEAK * 3 + 1] = 2;         // rises above neighbours -> convex
+    g.computeVertexNormals();
+    return { g, HOLLOW, PEAK, FLAT: 5 * COLS + 5 };
+  }
+
+  console.log('--- snow-surface: cavity/AO term ---');
+  const { g, HOLLOW, PEAK, FLAT } = freshGeo();
+  const heightsBefore = Float32Array.from(g.attributes.position.array);
+
+  // Slope tint only (no grid) — the baseline the cavity term adds onto.
+  applySnowVertexColors(g);
+  const base = Float32Array.from(g.attributes.color.array);
+
+  // Same geometry, now with the grid so the cavity term engages.
+  applySnowVertexColors(g, COLS, ROWS);
+  const cav = Float32Array.from(g.attributes.color.array);
+
+  check('hollow is darkened by the cavity term (sum drops vs slope-tint-only)',
+    sum3(cav, HOLLOW) < sum3(base, HOLLOW) - 1e-4);
+  check('hollow is cool/blue-shifted (b-r grows)',
+    (cav[HOLLOW * 3 + 2] - cav[HOLLOW * 3]) > (base[HOLLOW * 3 + 2] - base[HOLLOW * 3]) + 1e-4);
+  check('convex peak is left bright (cavity occ = 0, unchanged)',
+    Math.abs(sum3(cav, PEAK) - sum3(base, PEAK)) < 1e-6);
+  check('flat vertex unchanged by the cavity term',
+    Math.abs(sum3(cav, FLAT) - sum3(base, FLAT)) < 1e-6);
+
+  let inRange = true;
+  for (let k = 0; k < cav.length; k++) if (cav[k] < 0 || cav[k] > 1) inRange = false;
+  check('all cavity colour components stay within [0,1]', inRange);
+
+  // The height field must be untouched — this is a render-only colour pass.
+  const heightsAfter = g.attributes.position.array;
+  let heightsIdentical = true;
+  for (let k = 0; k < heightsAfter.length; k++) if (heightsAfter[k] !== heightsBefore[k]) heightsIdentical = false;
+  check('vertex heights are NOT modified (physics height field untouched)', heightsIdentical);
+
+  // Back-compat / guard: a mismatched grid size skips the cavity term entirely.
+  const { g: g2, HOLLOW: H2 } = freshGeo();
+  applySnowVertexColors(g2);
+  const noGrid = Float32Array.from(g2.attributes.color.array);
+  applySnowVertexColors(g2, 999, 999); // wrong dims -> cavity disabled
+  const badGrid = Float32Array.from(g2.attributes.color.array);
+  check('mismatched grid dims disable the cavity term (back-compat)',
+    Math.abs(sum3(badGrid, H2) - sum3(noGrid, H2)) < 1e-6);
+
+  console.log('\n--- slope-tiers: single source ---');
+  check('SLOPE_MODERATE / SLOPE_STEEP are the documented edges', SLOPE_MODERATE === 0.32 && SLOPE_STEEP === 0.58);
+  check('moderate edge is below the steep edge', SLOPE_MODERATE < SLOPE_STEEP);
+
+  console.log(`\nsnow-surface: ${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch(err => { console.error('❌ SNOW-SURFACE TESTS FAILED:', err); process.exit(1); });


### PR DESCRIPTION
## Summary

Implements the **AO/cavity** half of plan improvement **#2** (the readability pass). The rendering doc's core principle already says troughs and lee sides should get their form from **occluded concavity, not a grey tint** — but the shipped per-vertex slope tint (`applySnowVertexColors`) keyed off slope *magnitude* only. It darkened steep faces yet left concave hollows — the rolls and gullies between moguls — as flat white, which is exactly where real snow self-shadows and pools cool light.

## Before / after

The hollows now read as faint, cool shaded depressions instead of flat white (subtle by design — powder must stay bright).

| Before (flat-white hollows) | After (cavity/AO shading) |
|---|---|
| ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/snow-ao-17/ao-before.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/snow-ao-17/ao-after.png) |

## What's in this PR

- **Cavity/AO term (`src/mountains/snow-surface.ts`).** `applySnowVertexColors` now also bakes an ambient-occlusion term when handed the terrain grid (`cols`/`rows`): each vertex is compared to its 4 grid-neighbours' mean height; vertices that sit *below* the local mean (concave hollows) take a subtle darken + cool blue-shift toward an occluded-pocket tint, scaled up a little on steeper ground. Convex peaks go negative and stay bright. Build-time and deterministic — **zero per-frame cost**.
- **Single-sourced slope thresholds (`src/slope-tiers.ts`, new).** The HUD's `SLOPE_MODERATE` / `SLOPE_STEEP` tier edges moved into a dependency-free shared module, consumed by both the HUD (no behaviour change) and the cavity term's steep-slope gating — so the on-snow shading and the on-screen difficulty mark (● / ■ / ◆) can't drift apart.

## Why it's safe

Render-only: the cavity term **reads** vertex heights but never writes them, so the **physics height field and authoritative terrain geometry are untouched** — same contract as the existing slope tint and smoothed shading normals. The terrain, regression, and physics-invariant suites are unaffected (verified locally).

## Tests (all green)

- **New `tests/snow-surface-tests.js`** (`npm run test:snow-surface`, wired into `npm test`): 9 headless, WebGL-free assertions — a known hollow is darkened + cool-shifted, a convex peak and a flat vertex are left untouched, all colours stay in [0,1], **vertex heights are byte-identical before/after** (no height-field touch), a mismatched grid disables the term (back-compat), and the shared `SLOPE_*` edges hold.
- `npm test` (exit 0), `test:verify` (physics invariant IDENTICAL), `lint` (0 errors), `typecheck`, `typecheck:tests`, `vite build` — all green.

## Docs

`docs/SNOW_RENDERING.md` (new "Cavity / ambient-occlusion shading" section + ownership-table row), `docs/CHANGELOG.md`.

## Deferred (out of scope)

The **obstacle-silhouette** half of the original #2 proposal (contact-darkening rings/rims at tree/rock bases) is intentionally left for its own follow-up: per-object contact decals interact with the instanced-forest draw-call / geometry budget (`tests/e2e/perf-budget.spec.ts`), so it deserves a perf-aware PR of its own rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPKke9qBQGD75TnasMAJ63)_