### PR TITLE
feat(snow): obstacle contact shadows under trees & rocks (#17)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,8 +314,10 @@ snowman.position = curState                       // restore authoritative physi
 > mesh-vertex formula (the *two-formula terrain contract*); **`snow-surface.ts`**
 > holds the snow albedo/normal CanvasTextures and the vertex-colour / smoothed-normal
 > passes; **`terrain-mesh.ts`** holds `createTerrain` (which pre-populates `heightMap`
-> and scatters rocks + trees); and **`rocks.ts`** holds rock meshes/colours/placement
-> plus the collision-hazard subset. `src/mountains/index.ts` is the assembly hub that
+> and scatters rocks + trees); **`rocks.ts`** holds rock meshes/colours/placement
+> plus the collision-hazard subset; and **`contact-shadows.ts`** (#17) bakes the soft
+> AO blob under each tree/large rock as one InstancedMesh (render-only grounding cue, no
+> physics). `src/mountains/index.ts` is the assembly hub that
 > builds the `Mountains` object and re-exports the named/type surface
 > (`terrainRidgeField`, `forestDensityField`, `rockCollisionRadius`, `TerrainVec2`,
 > `RockPosition`). The terrain/regression suites and the physics-invariant harness pin

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,21 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Feature: obstacle contact shadows (#17)
+- **Readability gap.** Trees and rocks sat on the bright snow with no grounding cue, so a
+  tree could read as floating / pasted-on. The slope/cavity shading darkens the terrain
+  itself, but nothing darkened the snow where an obstacle meets it.
+- **Contact-AO decals (`src/mountains/contact-shadows.ts`, new).** A soft baked AO blob is
+  placed under each tree and large rock as a **single `InstancedMesh`** (one shared quad +
+  one shared radial-alpha texture → one extra draw call, one geometry, one texture — the
+  same perf discipline as the instanced forest; stays inside the `perf-budget.spec.ts`
+  ceilings). The blobs never cast/receive shadows, so they add no shadow-pass cost.
+- Reuses the tree/rock positions the placement code already produces (no duplicated
+  placement logic); only reads the terrain height to sit each blob on the surface — never
+  touches the height field or any physics path. Headless-safe (radial texture is
+  `document`-guarded). Covered by `tests/contact-shadows-tests.js`
+  (`npm run test:contact-shadows`). See [`SNOW_RENDERING.md`](SNOW_RENDERING.md).
+
 ### Feature: cavity / ambient-occlusion snow shading + single-sourced slope tiers (#17)
 - **Readability gap.** The shipped per-vertex slope tint (`applySnowVertexColors`) keyed
   off slope *magnitude* only, so it darkened steep faces but left concave hollows — the
@@ -125,7 +140,6 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   later stacked PRs. `tests/difficulty-tests.js` guards the config integrity, the frozen
   Blue constants, the omit-vs-Blue byte-identity, and that the param is live (Black ends
   faster / Bunny slower on a tuck descent).
-
 ### Fix: systemic mobile dead-button class (Start-menu About/Close, logout, …)
 - **Root cause, finally fixed at the source.** `controls.ts` installs document-level
   `touchstart`/`touchmove`/`touchend` handlers that `preventDefault()` *every* touch (for

--- a/docs/SNOW_RENDERING.md
+++ b/docs/SNOW_RENDERING.md
@@ -121,6 +121,27 @@ as flat white, exactly where snow self-shadows. `applySnowVertexColors` now also
   tint and smoothed shading normals). It is build-time and deterministic — zero per-frame
   cost. Covered by `tests/snow-surface-tests.js` (`npm run test:snow-surface`).
 
+## Obstacle contact shadows (#17)
+
+Trees and rocks sat ON the bright snow with no grounding cue, so on an all-white slope
+a tree could read as floating / pasted-on. The slope tint and lighting shade the terrain
+itself, but nothing darkened the snow right where an obstacle meets it.
+`mountains/contact-shadows.ts` adds a soft baked **contact shadow** (ambient-occlusion
+blob) under each tree and large rock:
+
+- One `InstancedMesh` of a single shared horizontal quad + one shared radial-alpha
+  texture — so the whole forest's grounding cue is **one extra draw call, one geometry,
+  one texture** (the same perf discipline as the instanced forest; it stays well inside
+  the `perf-budget.spec.ts` ceilings). The blobs never cast or receive shadows — they ARE
+  the (fake) shadow — so they add no shadow-pass cost.
+- It reuses the tree/rock positions the placement code already computed (no duplicated
+  placement logic) and only READS the terrain height to sit each blob on the surface;
+  it never touches the height field or any physics path. Headless-safe (the radial
+  texture is `document`-guarded). Covered by `tests/contact-shadows-tests.js`
+  (`npm run test:contact-shadows`).
+
+This complements, rather than duplicates, the player-following directional shadow: the
+contact blob is a tight AO darkening right at the base, independent of sun direction.
 ## Ownership boundaries
 
 Keeping each layer in its lane is what prevents the whiteout / grey / muddy
@@ -131,6 +152,7 @@ regressions from creeping back when one piece is retuned:
 | Static snow-lighting (`scene-setup.ts`, `mountains.ts`) | albedo, normal-map de-striping, smoothed render normals, static light balance, near-white slope tint | sun-cycle animation |
 | Terrain (`mountains.ts` height field) | the slope geometry; replacing the periodic ridge that bands under low sun | lighting rebalance |
 | Cavity / AO readability (`mountains/snow-surface.ts`, #17) | per-vertex concavity darken + cool-shift baked into the slope tint | terrain physics changes / height field |
+| Obstacle contact shadows (`mountains/contact-shadows.ts`, #17) | baked AO blobs under trees/rocks (one InstancedMesh) | casting real shadows / physics |
 | Sun cycle (`src/sky.ts`, #163) | directional sun position/color/intensity, Preetham `sunPosition`/`exposure`, bounded fog/background tint | snow albedo, vertex tint, smoothed normals, terrain, **hemisphere fill** |
 
 ## The sun cycle is an atmospheric layer, not a readability fix

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
-    "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:contact-shadows && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",    "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:difficulty": "node --import ./tests/loaders/register-ts-resolve.mjs tests/difficulty-tests.js",
     "test:regression": "node --import ./tests/loaders/register-ts-resolve.mjs tests/regression-tests.js",
@@ -40,7 +39,7 @@
     "test:sky": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sky-cycle-tests.js",
     "test:sun-shadow": "node --import ./tests/loaders/register-ts-resolve.mjs tests/sun-shadow-tests.js",
     "test:snow-surface": "node --import ./tests/loaders/register-ts-resolve.mjs tests/snow-surface-tests.js",
-    "test:coverage-merge": "node tests/coverage-merge-tests.js",
+    "test:contact-shadows": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contact-shadows-tests.js",    "test:coverage-merge": "node tests/coverage-merge-tests.js",
     "test:verify": "node tests/verification/physics_invariant_harness.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/dom_smoke_test.js",
     "test:turn-styles": "node tests/verification/turn_styles_compare.js",
     "test:winnable": "node --import ./tests/loaders/register-ts-resolve.mjs tests/verification/winnability_harness.js",

--- a/src/mountains/contact-shadows.ts
+++ b/src/mountains/contact-shadows.ts
@@ -1,0 +1,130 @@
+// mountains/contact-shadows.ts - Baked contact-AO decals under obstacles (issue #17).
+//
+// THE READABILITY GAP. Trees and rocks sit ON the bright snow with no grounding cue,
+// so on an all-white slope a tree can read as floating / pasted-on. The slope tint and
+// cavity/AO shade the terrain itself, but nothing darkens the snow right where an
+// obstacle meets it. This adds a soft, baked **contact shadow** (ambient-occlusion blob)
+// under each tree and large rock so hazards visually "sit in" the snow and pop against it.
+//
+// Why a single InstancedMesh (perf). The forest is a few hundred obstacles; a per-object
+// decal mesh would blow the draw-call / geometry budget the perf-budget e2e guards
+// (tests/e2e/perf-budget.spec.ts), exactly the trap the instanced forest itself avoids.
+// So every blob is one instance of ONE shared horizontal quad with ONE shared material
+// and ONE shared radial-alpha texture — a single extra draw call, one geometry, one
+// texture. The blobs never cast or receive shadows (they ARE the shadow), so they add no
+// shadow-pass cost either.
+//
+// Contract & safety. Purely cosmetic scenery, like rocks/trees/snowtracks: it only READS
+// the injected terrain height + the obstacle positions the placement code already
+// computed (no duplicated placement logic), and never touches pos/velocity, the physics
+// kernel, or the height field — the determinism/physics-invariant harness is unaffected.
+// Headless-safe: the radial texture is guarded on `document` (null in Node), and the rest
+// is geometry + a colour material, so the Node tests build it exactly like the avalanche /
+// snowtrails systems. Disposed by the generic scene sweep in game/teardown.ts (the mesh,
+// its material, and the texture hung off `material.map` are all collected there).
+import * as THREE from 'three';
+import type { TreePosition } from './trees.js';
+import type { RockPosition } from './rocks.js';
+
+/** Terrain height sampler injected by the caller (same shape the other scenery uses). */
+export type TerrainHeightFn = (x: number, z: number) => number;
+
+// --- Tunables ---
+const BLOB_OPACITY = 0.34;     // global strength of the contact darkening (kept soft)
+const TREE_RADIUS_K = 1.6;     // blob radius = tree.scale * this (foliage footprint, world units)
+const ROCK_RADIUS_K = 1.15;    // blob radius = rock.size * this
+const MIN_RADIUS = 0.8;        // floor so the smallest obstacles still read as grounded
+const SURFACE_LIFT = 0.05;     // sit just above the snow to avoid z-fighting
+
+/**
+ * A radial alpha disc: opaque-black at the centre fading smoothly to transparent at the
+ * rim, so the instanced quad reads as a soft round AO blob rather than a hard disc.
+ * Guarded on `document` (returns null in Node) like the snow/rock/tree normal maps.
+ */
+function createContactShadowTexture(): THREE.CanvasTexture | null {
+  if (typeof document === 'undefined') return null;
+  const SIZE = 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = SIZE;
+  const ctx = canvas.getContext('2d')!;
+  const image = ctx.createImageData(SIZE, SIZE);
+  const data = image.data;
+  const c = (SIZE - 1) / 2;
+  for (let y = 0; y < SIZE; y++) {
+    for (let x = 0; x < SIZE; x++) {
+      const dx = (x - c) / c, dy = (y - c) / c;
+      const r = Math.min(1, Math.sqrt(dx * dx + dy * dy));
+      // Soft falloff: full in the core, easing to 0 at the rim (smootherstep-ish).
+      const a = 1 - r * r * (3 - 2 * r); // smoothstep(0,1,r) inverted -> dense centre
+      const idx = (y * SIZE + x) * 4;
+      data[idx] = 0; data[idx + 1] = 0; data[idx + 2] = 0; // black AO
+      data[idx + 3] = Math.max(0, Math.min(255, a * 255));
+    }
+  }
+  ctx.putImageData(image, 0, 0);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.NoColorSpace; // alpha/AO data, not authored colour
+  return tex;
+}
+
+/** Per-obstacle blob descriptor (world centre + radius). */
+interface Blob { x: number; z: number; radius: number; }
+
+/**
+ * Build the contact-shadow blobs for the given trees + rocks and add them to the scene
+ * as one InstancedMesh. Each blob is a horizontal quad centred on the obstacle, sized to
+ * its footprint, and lifted just above the terrain. Returns the mesh (named
+ * `contactShadows` for the scene-cleanup sweep + tests), or null when there is nothing
+ * to place. Reuses the positions the placement code already produced — no duplicated
+ * tree/rock placement logic.
+ */
+export function addContactShadows(
+  scene: THREE.Scene,
+  trees: TreePosition[],
+  rocks: RockPosition[],
+  getTerrainHeight: TerrainHeightFn
+): THREE.InstancedMesh | null {
+  const blobs: Blob[] = [];
+  for (const t of trees) {
+    blobs.push({ x: t.x, z: t.z, radius: Math.max(MIN_RADIUS, (t.scale || 1) * TREE_RADIUS_K) });
+  }
+  for (const r of rocks) {
+    blobs.push({ x: r.x, z: r.z, radius: Math.max(MIN_RADIUS, (r.size || 1) * ROCK_RADIUS_K) });
+  }
+  if (blobs.length === 0) return null;
+
+  // One shared horizontal unit quad; per-instance matrix scales it to the blob radius.
+  const geometry = new THREE.PlaneGeometry(1, 1);
+  geometry.rotateX(-Math.PI / 2);
+  const texture = createContactShadowTexture();
+  const material = new THREE.MeshBasicMaterial({
+    color: 0x000000,
+    map: texture,            // null in headless -> a plain soft disc isn't drawn anyway
+    transparent: true,
+    opacity: BLOB_OPACITY,
+    depthWrite: false,       // overlay: don't occlude / z-fight with itself or the snow
+    polygonOffset: true,
+    polygonOffsetFactor: -1,
+    polygonOffsetUnits: -1,
+  });
+
+  const mesh = new THREE.InstancedMesh(geometry, material, blobs.length);
+  mesh.name = 'contactShadows';
+  mesh.castShadow = false;     // it IS the (fake) shadow — never casts
+  mesh.receiveShadow = false;
+  mesh.frustumCulled = false;  // one batch spanning the whole slope; don't cull as a unit
+  mesh.renderOrder = 1;        // draw over the terrain surface
+
+  const dummy = new THREE.Object3D();
+  for (let i = 0; i < blobs.length; i++) {
+    const b = blobs[i]!;
+    dummy.position.set(b.x, getTerrainHeight(b.x, b.z) + SURFACE_LIFT, b.z);
+    dummy.scale.set(b.radius * 2, 1, b.radius * 2); // quad spans diameter
+    dummy.rotation.set(0, 0, 0);
+    dummy.updateMatrix();
+    mesh.setMatrixAt(i, dummy.matrix);
+  }
+  mesh.instanceMatrix.needsUpdate = true;
+  scene.add(mesh);
+  return mesh;
+}

--- a/src/mountains/rocks.ts
+++ b/src/mountains/rocks.ts
@@ -228,8 +228,14 @@ export function createRock(size: number, opts: RockOptions = {}): THREE.Mesh {
   return rock;
 }
 
-// Add rocks to create a more realistic mountain environment
-export function addRocks(scene: THREE.Scene): RockPosition[] {
+// Add rocks to create a more realistic mountain environment.
+//
+// `outAllRendered`, when supplied, is filled with EVERY rendered rock (scatter boulders
+// + cliff blocks), not just the collision-hazard subset that's returned. Contact shadows
+// (mountains/contact-shadows.ts) need the full rendered set so decorative rocks — and
+// large rocks filtered out of the hazard list by the ski-lane/spawn safety checks — still
+// get a grounding blob (Codex review #243). Optional, so existing callers are unchanged.
+export function addRocks(scene: THREE.Scene, outAllRendered?: RockPosition[]): RockPosition[] {
   // Remove any existing rocks from the scene to prevent duplicates
   for (let i = scene.children.length - 1; i >= 0; i--) {
     const child = scene.children[i]!;
@@ -288,6 +294,7 @@ export function addRocks(scene: THREE.Scene): RockPosition[] {
     rock.rotation.z = -Math.atan(gradient.x) * 0.8;
 
     scene.add(rock);
+    outAllRendered?.push({ x: pos.x, y: terrainHeight, z: pos.z, size: pos.size });
 
     if (rockIsCollisionHazard(pos.x, pos.z, pos.size)) {
       collisionRockPositions.push({ x: pos.x, y: terrainHeight, z: pos.z, size: pos.size });
@@ -332,6 +339,7 @@ export function addRocks(scene: THREE.Scene): RockPosition[] {
         rock.rotation.x = Math.atan(g.z) * 0.8;
         rock.rotation.z = -Math.atan(g.x) * 0.8;
         scene.add(rock);
+        outAllRendered?.push({ x: bx, y: bHeight, z: bz, size: bSize });
 
         if (rockIsCollisionHazard(bx, bz, bSize)) {
           collisionRockPositions.push({ x: bx, y: bHeight, z: bz, size: bSize });

--- a/src/mountains/terrain-mesh.ts
+++ b/src/mountains/terrain-mesh.ts
@@ -21,6 +21,8 @@ import {
   applySmoothShadingNormals,
 } from './snow-surface.js';
 import { addRocks } from './rocks.js';
+import { addContactShadows } from './contact-shadows.js';
+import { getTerrainHeight as sampleTerrainHeight } from './terrain.js';
 
 // Create Terrain (Natural Mountain)
 export function createTerrain(scene: THREE.Scene) {
@@ -136,6 +138,11 @@ export function createTerrain(scene: THREE.Scene) {
   } else {
     console.warn("Trees module not found, skipping tree creation");
   }
+
+  // Baked contact-AO blobs under each tree + large rock (issue #17) so obstacles read
+  // as grounded against the bright snow instead of floating. One InstancedMesh (one draw
+  // call) — reuses the positions trees/rocks already produced; render-only, no physics.
+  addContactShadows(scene, treePositions, rockPositions, sampleTerrainHeight);
 
   return { terrain, treePositions, rockPositions };
 }

--- a/src/mountains/terrain-mesh.ts
+++ b/src/mountains/terrain-mesh.ts
@@ -20,7 +20,7 @@ import {
   applySnowVertexColors,
   applySmoothShadingNormals,
 } from './snow-surface.js';
-import { addRocks } from './rocks.js';
+import { addRocks, type RockPosition } from './rocks.js';
 import { addContactShadows } from './contact-shadows.js';
 import { getTerrainHeight as sampleTerrainHeight } from './terrain.js';
 
@@ -128,8 +128,11 @@ export function createTerrain(scene: THREE.Scene) {
   console.log(`Height map contains ${Object.keys(heightMap).length} terrain points`);
 
   // Add rocks to make the mountain more realistic. The returned subset is the
-  // collision source of truth for rocks large enough to read as hazards.
-  const rockPositions = addRocks(scene);
+  // collision source of truth for rocks large enough to read as hazards; `allRocks`
+  // captures EVERY rendered rock so the contact shadows below ground decorative + safety-
+  // filtered rocks too (Codex review #243), not just the collision subset.
+  const allRocks: RockPosition[] = [];
+  const rockPositions = addRocks(scene, allRocks);
 
   // Add trees to make the slope more visible using the separate Trees module
   let treePositions: TreePosition[] = [];
@@ -142,7 +145,7 @@ export function createTerrain(scene: THREE.Scene) {
   // Baked contact-AO blobs under each tree + large rock (issue #17) so obstacles read
   // as grounded against the bright snow instead of floating. One InstancedMesh (one draw
   // call) — reuses the positions trees/rocks already produced; render-only, no physics.
-  addContactShadows(scene, treePositions, rockPositions, sampleTerrainHeight);
+  addContactShadows(scene, treePositions, allRocks, sampleTerrainHeight);
 
   return { terrain, treePositions, rockPositions };
 }

--- a/tests/contact-shadows-tests.js
+++ b/tests/contact-shadows-tests.js
@@ -1,0 +1,64 @@
+// @ts-check
+// Headless coverage for the obstacle contact-shadow decals (issue #17).
+//
+// addContactShadows places one soft AO blob under each tree + large rock as a single
+// InstancedMesh, so hazards read as grounded against the bright snow. These assertions
+// verify the instance count, placement (on the terrain, sized to the obstacle), the
+// no-shadow flags, the empty/headless fall-backs, and that it never throws without a DOM.
+// Pure + WebGL-free (THREE buffers only). CommonJS + dynamic import so the
+// register-ts-resolve loader resolves the `.ts` sources + 'three'.
+
+let pass = 0, fail = 0;
+function check(name, cond) { console.log(`  ${cond ? 'PASS ✅' : 'FAIL ❌'}: ${name}`); cond ? pass++ : fail++; }
+const approx = (a, b, eps = 1e-4) => Math.abs(a - b) <= eps;
+
+async function main() {
+  const THREE = await import('three');
+  const { addContactShadows } = await import('../src/mountains/contact-shadows.ts');
+
+  console.log('--- contact-shadows: placement ---');
+  const scene = new THREE.Scene();
+  const trees = [
+    { x: 5, y: 0, z: -20, scale: 1.0 },
+    { x: -8, y: 0, z: -40, scale: 0.1 },  // tiny -> radius floor
+  ];
+  const rocks = [
+    { x: 30, y: 0, z: -60, size: 2.0 },
+  ];
+  const getH = (x, z) => 100 + x * 0.01 + z * 0.02; // varying terrain height
+
+  const mesh = addContactShadows(scene, trees, rocks, getH);
+  check('returns an InstancedMesh', !!mesh && mesh.isInstancedMesh === true);
+  check('one instance per tree + rock', mesh.count === trees.length + rocks.length);
+  check('named for the cleanup sweep', mesh.name === 'contactShadows');
+  check('never casts or receives shadows (it IS the fake shadow)', mesh.castShadow === false && mesh.receiveShadow === false);
+  check('added to the scene', scene.children.includes(mesh));
+
+  // Decode instance 0 (tree, scale 1 -> radius 1.6 -> quad span 3.2) and check it sits on
+  // the terrain at the obstacle's x/z.
+  const m = new THREE.Matrix4();
+  const p = new THREE.Vector3(), q = new THREE.Quaternion(), s = new THREE.Vector3();
+  mesh.getMatrixAt(0, m); m.decompose(p, q, s);
+  check('blob 0 centred on the tree x/z', approx(p.x, 5) && approx(p.z, -20));
+  check('blob 0 sits just above the terrain height', approx(p.y, getH(5, -20) + 0.05));
+  check('blob 0 sized to the tree footprint (radius 1.6 -> span 3.2)', approx(s.x, 3.2) && approx(s.z, 3.2));
+
+  // Instance 1 is the tiny tree -> radius floored to 0.8 -> span 1.6.
+  mesh.getMatrixAt(1, m); m.decompose(p, q, s);
+  check('tiny obstacle radius is floored (span 1.6, not 0.32)', approx(s.x, 1.6));
+
+  // Instance 2 is the rock (size 2 -> radius 2.3 -> span 4.6).
+  mesh.getMatrixAt(2, m); m.decompose(p, q, s);
+  check('rock blob sized by rock.size (radius 2.3 -> span 4.6)', approx(s.x, 4.6) && approx(p.x, 30));
+
+  console.log('\n--- contact-shadows: edge cases ---');
+  check('no obstacles -> returns null (no empty draw)', addContactShadows(new THREE.Scene(), [], [], getH) === null);
+  check('headless build has no texture map (document-guarded), did not throw',
+    mesh.material.map === null);
+  check('material is a soft transparent black overlay', mesh.material.transparent === true && mesh.material.depthWrite === false);
+
+  console.log(`\ncontact-shadows: ${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch(err => { console.error('❌ CONTACT-SHADOWS TESTS FAILED:', err); process.exit(1); });

--- a/tests/contact-shadows-tests.js
+++ b/tests/contact-shadows-tests.js
@@ -53,9 +53,10 @@ async function main() {
 
   console.log('\n--- contact-shadows: edge cases ---');
   check('no obstacles -> returns null (no empty draw)', addContactShadows(new THREE.Scene(), [], [], getH) === null);
-  check('headless build has no texture map (document-guarded), did not throw',
-    mesh.material.map === null);
-  check('material is a soft transparent black overlay', mesh.material.transparent === true && mesh.material.depthWrite === false);
+  // mesh.material is typed Material | Material[]; this build uses a single MeshBasicMaterial.
+  const mat = /** @type {any} */ (mesh.material);
+  check('headless build has no texture map (document-guarded), did not throw', mat.map === null);
+  check('material is a soft transparent black overlay', mat.transparent === true && mat.depthWrite === false);
 
   console.log(`\ncontact-shadows: ${pass} passed, ${fail} failed`);
   if (fail > 0) process.exit(1);

--- a/tests/contact-shadows-tests.js
+++ b/tests/contact-shadows-tests.js
@@ -58,6 +58,16 @@ async function main() {
   check('headless build has no texture map (document-guarded), did not throw', mat.map === null);
   check('material is a soft transparent black overlay', mat.transparent === true && mat.depthWrite === false);
 
+  // The decal builder must be fed EVERY rendered rock, not just the collision subset
+  // (Codex review #243): addRocks fills the optional out-array with all rendered rocks.
+  console.log('\n--- contact-shadows: all rendered rocks feed the decals ---');
+  const { addRocks } = await import('../src/mountains/rocks.ts');
+  const rockScene = new THREE.Scene();
+  const allRendered = [];
+  const collision = addRocks(rockScene, allRendered);
+  check('addRocks fills the out-array with rendered rocks', allRendered.length > 0);
+  check('all-rendered is a superset of the collision-hazard subset', allRendered.length >= collision.length);
+
   console.log(`\ncontact-shadows: ${pass} passed, ${fail} failed`);
   if (fail > 0) process.exit(1);
 }


### PR DESCRIPTION
## Summary

Completes the **obstacle-silhouette** half of plan improvement **#2** (deferred from #242). Trees and rocks sat on the bright snow with no grounding cue, so on an all-white slope they could read as floating / pasted-on. The slope/cavity shading darkens the terrain itself, but nothing darkened the snow right where an obstacle meets it.

## Before / after

Each tree and large rock now gets a soft contact-AO blob, so it visually sits *in* the snow instead of floating on it.

| Before (obstacles float) | After (grounded by contact AO) |
|---|---|
| ![before](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/contact-shadows-17/contact-before.png) | ![after](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/contact-shadows-17/contact-after.png) |

## What's in this PR

- **New `src/mountains/contact-shadows.ts`.** `addContactShadows(scene, trees, rocks, getTerrainHeight)` places a soft baked AO blob under each tree and large rock as a **single `InstancedMesh`**: one shared horizontal quad + one shared radial-alpha texture. So the whole forest's grounding cue is **one extra draw call, one geometry, one texture** — the same perf discipline the instanced forest uses, staying well inside the `tests/e2e/perf-budget.spec.ts` ceilings. The blobs never cast or receive shadows (they *are* the fake shadow), so they add **no shadow-pass cost**.
- **Wired into `terrain-mesh.ts`** after trees/rocks are built, reusing the `treePositions` / `rockPositions` the placement code already produces — **no duplicated placement logic**.

## Why it's safe

Render-only scenery, like rocks/trees/snowtracks: it only **reads** the obstacle positions and the terrain height (to sit each blob on the surface) and never touches `pos`/`velocity`, the physics kernel, or the height field — the physics-invariant / terrain / regression suites are unaffected. Headless-safe (the radial texture is `document`-guarded → null in Node). Disposed by the generic scene sweep in `game/teardown.ts` (mesh + material + `material.map` texture are all collected there).

It **complements** the player-following directional shadow (#241): the contact blob is a tight AO darkening right at the base, independent of sun direction.

## Tests (all green)

- **New `tests/contact-shadows-tests.js`** (`npm run test:contact-shadows`, wired into `npm test`): 13 headless, WebGL-free assertions — one instance per tree+rock, blobs centred on each obstacle and sized to its footprint (with a radius floor), sitting just above the terrain, `castShadow`/`receiveShadow` false, empty input → `null` (no zero-count draw), and the `document`-guarded headless fall-back doesn't throw.
- `npm test` (exit 0), `test:verify` (physics invariant IDENTICAL), `lint` (0 errors), `typecheck`, `vite build`, terrain/trees/teardown/leak suites — all green.

## Docs

`docs/SNOW_RENDERING.md` (new "Obstacle contact shadows" section + ownership-table row), `docs/ARCHITECTURE.md` (new submodule), `docs/CHANGELOG.md`.

> Independent of PRs #241 (shadows) and #242 (cavity/AO) — branched off `main`; the only doc-file overlap is additive sections in `SNOW_RENDERING.md` / `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPKke9qBQGD75TnasMAJ63)_