### PR TITLE
Fix: make the finish/share result overlay scrollable so RESTART stays reachable

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -232,15 +232,18 @@ function setupTouchControls(signal?: AbortSignal) {
   window.addEventListener('resize', updateTouchRegions, opts);
   
   // Touches that begin inside a scrollable UI panel (the Controls / Ski Techniques
-  // guides) must be handed to the browser so the panel can scroll natively. The
-  // document-level handlers below otherwise call preventDefault() on every move —
-  // killing the scroll — and would also mis-read the drag as ski steering. A
-  // TouchEvent's target stays the element the gesture started on, so excluding these
-  // targets lets the overflow areas scroll without leaking into gameplay input.
+  // guides, or the finish/game-over result overlay) must be handed to the browser so
+  // the panel can scroll natively. The document-level handlers below otherwise call
+  // preventDefault() on every move — killing the scroll — and would also mis-read the
+  // drag as ski steering. A TouchEvent's target stays the element the gesture started
+  // on, so excluding these targets lets the overflow areas scroll without leaking into
+  // gameplay input. `#gameOverOverlay` is included because on a tall finish screen
+  // (result panel + expanded share menu) it scrolls to keep RESTART reachable, and the
+  // run is already over there, so a drag is never gameplay steering.
   const isScrollableUiTouch = (event: TouchEvent): boolean => {
     const target = event.target as Element | null;
     return !!(target && typeof target.closest === 'function' &&
-      target.closest('#controlsGuide, #controlsContent'));
+      target.closest('#controlsGuide, #controlsContent, #gameOverOverlay'));
   };
 
   // Touches that land on an interactive control (any button/link/form field, or an

--- a/src/game/scene-setup.ts
+++ b/src/game/scene-setup.ts
@@ -118,7 +118,19 @@ export function setupScene(signal?: AbortSignal) {
   gameOverOverlay.style.display = 'flex';
   gameOverOverlay.style.flexDirection = 'column';
   gameOverOverlay.style.alignItems = 'center';
-  gameOverOverlay.style.justifyContent = 'center';
+  // `safe center` keeps the contents centered when they fit, but falls back to
+  // top-alignment when they're taller than the viewport instead of clipping the
+  // overflow off both ends (the flex-centering overflow trap). Combined with the
+  // vertical scroll below, this keeps the whole stack — crucially the RESTART
+  // button at the bottom — reachable on short screens or when the finish result
+  // panel + expanded share menu make the overlay taller than the viewport.
+  gameOverOverlay.style.justifyContent = 'safe center';
+  // Allow the overlay itself to scroll when its contents overflow, so nothing
+  // (GAME OVER header, result panel, RESTART) becomes unreachable.
+  gameOverOverlay.style.overflowY = 'auto';
+  gameOverOverlay.style.boxSizing = 'border-box';
+  gameOverOverlay.style.padding = '24px 16px';
+  gameOverOverlay.style.setProperty('-webkit-overflow-scrolling', 'touch');
   gameOverOverlay.style.zIndex = '1000';
   gameOverOverlay.style.display = 'none'; // Initially hidden
 
@@ -144,9 +156,12 @@ export function setupScene(signal?: AbortSignal) {
 
   // Restart button
   const restartButton = document.createElement('button');
+  restartButton.id = 'restartButton';
   restartButton.textContent = 'RESTART';
   restartButton.style.padding = '15px 30px';
   restartButton.style.fontSize = '22px';
+  // Never let the flex column squeeze the primary "get out of here" control.
+  restartButton.style.flexShrink = '0';
   restartButton.style.backgroundColor = '#ff4136';
   restartButton.style.color = 'white';
   restartButton.style.border = 'none';

--- a/tests/e2e/gameplay.spec.ts
+++ b/tests/e2e/gameplay.spec.ts
@@ -50,6 +50,53 @@ test.describe('gameplay flow', () => {
     expect((await getControls(page))?.left).toBe(false);
   });
 
+  test('finish result overlay stays exitable when it overflows the viewport', async ({ page }) => {
+    // Regression for the "impossible to leave the share-results window" bug: on a
+    // finished run the medal/splits result panel plus the (desktop) expanded share
+    // menu makes #gameOverOverlay taller than the window. It used to center its
+    // contents with justify-content:center and no scroll, so the overflow was
+    // clipped off both ends — the RESTART button fell below the viewport with no
+    // way to reach it, trapping the player on the share screen.
+    await gotoGame(page);
+    await startGame(page);
+
+    // A deliberately short window guarantees the result panel + share menu overflow.
+    await page.setViewportSize({ width: 820, height: 460 });
+
+    // Drive the real game-over path with a valid finish time so the full result
+    // panel (medal + splits + share controls) is built exactly as a finished run.
+    await page.evaluate(() => {
+      const w = window as unknown as { startTime: number; showGameOver: (r: string) => void };
+      // ~20s elapsed clears the leaderboard plausibility floor (MIN_VALID_SCORE_TIME
+      // = 18s) so showGameOver builds the full result panel, as a real finish would.
+      w.startTime = performance.now() - 20000;
+      w.showGameOver('You reached the end of the slope!');
+    });
+
+    await expect(page.locator('#gameOverOverlay')).toBeVisible();
+    await expect(page.locator('#courseResult')).toBeVisible();
+
+    // Expand the desktop per-platform share menu (X/Facebook/…) — the worst case
+    // from the bug report, which makes the overlay clearly taller than the window.
+    await page.click('#shareResultBtn');
+    await expect(page.locator('#shareMenu')).toBeVisible();
+
+    // The scenario is only meaningful if the overlay actually overflows.
+    const overflows = await page.evaluate(() => {
+      const ov = document.getElementById('gameOverOverlay')!;
+      return ov.scrollHeight > ov.clientHeight + 1;
+    });
+    expect(overflows, 'overlay should overflow the short viewport in this scenario').toBe(true);
+
+    // The fix: the overlay scrolls, so RESTART can be reached and clicked. On the
+    // old clipping overlay Playwright cannot bring the button into view and this
+    // click times out — exactly the user-facing "can't exit" bug.
+    await page.click('#restartButton');
+
+    // Clicking RESTART dismisses the overlay and resumes a live run.
+    await expect(page.locator('#gameOverOverlay')).toBeHidden();
+  });
+
   test('reset returns the snowman to the start', async ({ page }) => {
     await gotoGame(page);
     await startGame(page);


### PR DESCRIPTION
## Problem
On a finished run, the **share result window cannot be exited** — there is no reachable way to leave it (reported on snowglider.ai). [screenshot in the issue/report]

The game-over overlay (`#gameOverOverlay`) is a full-viewport flex column centered with `justify-content: center` and **no scrolling**. A finish stacks: `GAME OVER` header → medal/splits result panel → (desktop) the **expanded** per-platform share menu (X / Facebook / LinkedIn / WhatsApp / Reddit / Telegram + Save image + Copy link) → the `RESTART` button. Once that content is taller than the window, `justify-content: center` clips the overflow off **both** ends with nothing to scroll, so the `RESTART` button drops below the viewport and the player is stuck.

This is the same flex‑centering overflow trap previously fixed for the start‑screen build badge (#196) and leaderboard (#200).

## Fix (in the overlay's own styles, `src/game/scene-setup.ts`)
- `justify-content: safe center` — still centers when content fits, but falls back to top‑alignment instead of clipping when it's taller than the viewport.
- `overflow-y: auto` (+ `box-sizing: border-box`, padding, `-webkit-overflow-scrolling: touch`) so the overlay scrolls and **every** child — crucially `RESTART` — is reachable.
- Give the `RESTART` button an `id` and `flex-shrink: 0` so it's a stable, never‑squeezed, testable click target.

No gameplay/physics/terrain changes → no snowman invariant baseline regen needed.

## Verification
Empirically reproduced in headless Chrome (short viewport, tall content):
- **Broken** (`center` + no scroll): `RESTART` bottom `646` > viewport `600`, `restartReachable: false` (cannot scroll to it).
- **Fixed** (`safe center` + `overflow-y: auto`): overlay scrolls to the button, `restartReachable: true`.

Added an E2E regression test (`tests/e2e/gameplay.spec.ts`) that drives the **real** finish overlay on a short viewport with the share menu expanded, asserts the overlay overflows, then clicks `RESTART` and asserts the overlay is dismissed. Confirmed it **fails on the pre‑fix CSS** (`page.click('#restartButton')` times out — "element is outside of the viewport") and **passes with the fix**, on both chromium and webkit.

- `npm run lint` — 0 errors
- `npm run build` — OK
- `npm test` — all node suites pass (DOM smoke 53/0; physics/collision/avalanche/winnability harnesses green)
- `npm run test:e2e` (gameplay spec) — passes on chromium + webkit (the unrelated parallel‑load flake in the existing "reset returns the snowman to the start" spec passes in isolation and CI has retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)