### PR TITLE
Fix dead "V" camera-toggle key + add headless camera test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:course-line && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:wind && npm run test:contact-shadows && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:course-line && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:camera && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:wind && npm run test:contact-shadows && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:difficulty": "node --import ./tests/loaders/register-ts-resolve.mjs tests/difficulty-tests.js",
@@ -26,6 +26,7 @@
     "test:test-hooks": "node --import ./tests/loaders/register-ts-resolve.mjs tests/test-hooks-tests.js",
     "test:firebase": "npx -y firebase-tools@15.20.0 emulators:exec --project snowglider-rules-test --only firestore \"node tests/firestore-rules-tests.js\"",
     "test:controls": "node --import ./tests/loaders/register-ts-resolve.mjs tests/controls-node-tests.js",
+    "test:camera": "node --import ./tests/loaders/register-ts-resolve.mjs tests/camera-node-tests.js",
     "test:flex": "node --import ./tests/loaders/register-ts-resolve.mjs tests/snowman-flex-tests.js",
     "test:debris": "node tests/debris-tests.js",
     "test:leak": "node tests/leak-tests.js",

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -103,10 +103,13 @@ function setupKeyboardControls(signal?: AbortSignal) {
       case ' ':  // Spacebar
         gameControls.jump = true;
         break;
-      case 'v':  // Toggle camera view
+      case 'v':  // Toggle camera view (edge-triggered: once per physical press)
       case 'V':
-        // This will be handled in the main game code
-        if (typeof window.toggleCameraView === 'function') {
+        // Ignore OS/browser key auto-repeat while V is held. Unlike the movement keys
+        // (which just set an idempotent boolean), this flips a mode, so a long press
+        // must toggle exactly once — without the `event.repeat` guard the repeated
+        // keydowns would flicker the camera and leave it in an arbitrary mode.
+        if (!event.repeat && typeof window.toggleCameraView === 'function') {
           window.toggleCameraView();
         }
         break;

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -142,14 +142,16 @@ function setupKeyboardControls(signal?: AbortSignal) {
     }
   };
   
-  // Add keyboard listeners to both window and document for better coverage. The
-  // teardown signal (when supplied) lets disposeGame remove them on HMR/unmount.
+  // Register on `window` ONLY. A keydown dispatched at the focused element bubbles
+  // up to `window`, so a single window-level listener catches every key. Registering
+  // the SAME handler on both `window` and `document` (as this used to) fires it twice
+  // per keypress: harmless for the movement keys, which only set a boolean, but it
+  // broke the edge-triggered `V` toggle — `toggleCameraView()` ran twice and the
+  // camera flipped to the new mode and immediately back, so `V` looked dead.
+  // The teardown signal (when supplied) lets disposeGame remove them on HMR/unmount.
   const opts: AddEventListenerOptions | undefined = signal ? { signal } : undefined;
   window.addEventListener('keydown', handleKeyDown, opts);
-  document.addEventListener('keydown', handleKeyDown, opts);
-
   window.addEventListener('keyup', handleKeyUp, opts);
-  document.addEventListener('keyup', handleKeyUp, opts);
 }
 
 // Setup touch control handlers

--- a/tests/camera-node-tests.js
+++ b/tests/camera-node-tests.js
@@ -1,0 +1,181 @@
+// camera-node-tests.js
+// Headless, c8-instrumented coverage for src/camera.ts (the follow-camera).
+//
+// Until now src/camera.ts was exercised ONLY by the browser suite (?test=camera),
+// which needs the live WebGL game and so never counts toward Node coverage — camera
+// was one of the weakest-covered modules. camera.ts uses three.js math objects
+// (PerspectiveCamera/Vector3/Euler) and reads terrain through the imported
+// `Mountains.getTerrainHeight`; none of that needs a GPU, so the whole class runs
+// under jsdom. This harness drives both camera modes (third- and first-person),
+// the speed-based follow distance, and the terrain floor clamp.
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://snowglider.ai/' });
+global.window = dom.window;
+global.document = dom.window.document;
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS' : 'FAIL'}: ${name}`);
+  if (condition) {
+    pass++;
+  } else {
+    fail++;
+  }
+}
+// Position-based tests use the project's ±0.001 float tolerance (CLAUDE.md).
+function approx(a, b, tol = 0.001) {
+  return Math.abs(a - b) <= tol;
+}
+
+async function main() {
+  const THREE = await import('three');
+  const { Camera } = await import('../src/camera.ts');
+  const { Mountains } = await import('../src/mountains.js');
+
+  const newCamera = () => new Camera(new THREE.Scene());
+
+  console.log('--- construction defaults ---');
+  {
+    const cam = newCamera();
+    check('starts in thirdPerson mode', cam.mode === 'thirdPerson');
+    check('getCamera() returns the underlying PerspectiveCamera',
+      cam.getCamera() === cam.camera && cam.camera instanceof THREE.PerspectiveCamera);
+    check('isFirstFrame starts true, frameCount starts 0',
+      cam.isFirstFrame === true && cam.frameCount === 0);
+    check('follow-distance parameters are min 15 / max 25 / threshold 20',
+      cam.minDistance === 15 && cam.maxDistance === 25 && cam.speedThreshold === 20);
+  }
+
+  console.log('\n--- toggleCameraMode ---');
+  {
+    const cam = newCamera();
+    const first = cam.toggleCameraMode();
+    check('toggle from thirdPerson returns and sets firstPerson',
+      first === 'firstPerson' && cam.mode === 'firstPerson');
+    const second = cam.toggleCameraMode();
+    check('toggling again round-trips back to thirdPerson',
+      second === 'thirdPerson' && cam.mode === 'thirdPerson');
+  }
+
+  console.log('\n--- initialize: third-person ---');
+  {
+    const cam = newCamera();
+    const player = new THREE.Vector3(10, 50, -15);
+    cam.initialize(player, new THREE.Euler(0, 0, 0));
+    // rotation.y = 0 -> offset (sin0*15, 8, cos0*15) = (0, 8, 15)
+    const p = cam.camera.position;
+    check('places camera at player + (0,8,15) when facing forward',
+      approx(p.x, 10) && approx(p.y, 58) && approx(p.z, 0));
+    check('seeds smoothing targetPosition to the camera position',
+      cam.smoothingVectors.targetPosition.distanceTo(p) < 0.001);
+    check('seeds lookAtPosition to the player position',
+      approx(cam.smoothingVectors.lookAtPosition.x, 10) &&
+      approx(cam.smoothingVectors.lookAtPosition.z, -15));
+    check('resets isFirstFrame / frameCount after initialize',
+      cam.isFirstFrame === true && cam.frameCount === 0);
+  }
+
+  console.log('\n--- initialize: third-person with yaw ---');
+  {
+    const cam = newCamera();
+    // rotation.y = PI/2 -> offset (sin*15, 8, cos*15) = (15, 8, ~0)
+    cam.initialize(new THREE.Vector3(0, 0, 0), new THREE.Euler(0, Math.PI / 2, 0));
+    const p = cam.camera.position;
+    check('rotates the follow offset around the player by yaw',
+      approx(p.x, 15) && approx(p.y, 8) && approx(p.z, 0));
+  }
+
+  console.log('\n--- initialize: first-person ---');
+  {
+    const cam = newCamera();
+    cam.toggleCameraMode(); // -> firstPerson
+    cam.initialize(new THREE.Vector3(0, 20, 0), new THREE.Euler(0, 0, 0));
+    // offset (-sin0*2.5+0.2, 10, -cos0*2.5) = (0.2, 10, -2.5)
+    const p = cam.camera.position;
+    check('seats the camera just above/behind the head',
+      approx(p.x, 0.2) && approx(p.y, 30) && approx(p.z, -2.5));
+  }
+
+  console.log('\n--- update: first frame snaps (third-person) ---');
+  {
+    const cam = newCamera();
+    const player = new THREE.Vector3(0, 50, 0);
+    cam.initialize(player, new THREE.Euler(0, 0, 0));
+    cam.update(player, new THREE.Euler(0, 0, 0), { x: 0, z: 0 }, () => 0);
+    check('first update clears isFirstFrame', cam.isFirstFrame === false);
+    const p = cam.camera.position;
+    check('first update snaps directly to player + (0,8,15)',
+      approx(p.x, 0) && approx(p.y, 58) && approx(p.z, 15));
+  }
+
+  console.log('\n--- update: follow distance grows with speed (third-person) ---');
+  {
+    // Horizontal distance of the (un-smoothed) target from the player IS the dynamic
+    // follow distance. First update is the snap; the second computes the speed-based
+    // target, so drive two updates and read smoothingVectors.targetPosition.
+    const followDistanceAt = (velZ) => {
+      const cam = newCamera();
+      const player = new THREE.Vector3(0, 50, 0);
+      const rot = new THREE.Euler(0, 0, 0);
+      cam.initialize(player, rot);
+      cam.update(player, rot, { x: 0, z: velZ }, () => 0); // first-frame snap
+      cam.update(player, rot, { x: 0, z: velZ }, () => 0); // dynamic distance
+      const t = cam.smoothingVectors.targetPosition;
+      return Math.hypot(t.x - player.x, t.z - player.z);
+    };
+    const slow = followDistanceAt(0);   // speed 0   -> minDistance (15)
+    const fast = followDistanceAt(30);  // speed >=20 -> maxDistance (25)
+    check('at rest the camera sits at minDistance (~15)', approx(slow, 15, 0.5));
+    check('at high speed the camera pulls back to maxDistance (~25)', approx(fast, 25, 0.5));
+    check('faster travel pushes the camera farther back', fast > slow + 5);
+  }
+
+  console.log('\n--- update: terrain floor clamp (third-person) ---');
+  {
+    // Put the player far below the surface so the computed camera dips under terrain;
+    // the clamp must lift it to terrainHeight + 5.
+    const cam = newCamera();
+    const player = new THREE.Vector3(0, -100, 0);
+    const rot = new THREE.Euler(0, 0, 0);
+    cam.initialize(player, rot);
+    cam.update(player, rot, { x: 0, z: 0 }, () => 0); // first-frame snap (no clamp)
+    cam.update(player, rot, { x: 0, z: 0 }, () => 0); // clamp applies here
+    const terrain = Mountains.getTerrainHeight(cam.camera.position.x, cam.camera.position.z);
+    check('clamps the camera to terrainHeight + 5 when it would sink below ground',
+      approx(cam.camera.position.y, terrain + 5));
+    check('the clamp lifts the camera well above the buried player',
+      cam.camera.position.y > player.y + 50);
+  }
+
+  console.log('\n--- update: first-person follows the head ---');
+  {
+    const cam = newCamera();
+    cam.toggleCameraMode(); // -> firstPerson
+    const player = new THREE.Vector3(5, 20, 5);
+    const rot = new THREE.Euler(0, 0, 0);
+    cam.initialize(player, rot);
+    cam.update(player, rot, { x: 0, z: 0 }, () => 0);
+    const p = cam.camera.position;
+    // offset (-sin0*2.5+0.2, 10, -cos0*2.5) = (0.2, 10, -2.5)
+    check('first-person update keeps the camera at head height + offset',
+      approx(p.x, 5.2) && approx(p.y, 30) && approx(p.z, 2.5));
+  }
+
+  console.log('\n--- handleResize ---');
+  {
+    const cam = newCamera();
+    cam.handleResize();
+    check('handleResize syncs aspect to the window dimensions',
+      approx(cam.camera.aspect, window.innerWidth / window.innerHeight));
+  }
+
+  console.log(`\nCAMERA TEST TOTAL: ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -98,9 +98,12 @@ async function main() {
   let cameraToggles = 0;
   window.toggleCameraView = () => { cameraToggles++; };
   keydown('v');
-  // controls.ts registers the keydown handler on BOTH window and document ("for
-  // better coverage"), so a bubbling keydown legitimately fires it on each.
-  check('"v" key invokes window.toggleCameraView', cameraToggles >= 1);
+  // `V` is edge-triggered: each physical keypress must toggle the camera EXACTLY once.
+  // controls.ts registers the keydown handler on `window` only, so the bubbling keydown
+  // fires it a single time. (It used to be registered on BOTH window and document, which
+  // fired toggleCameraView twice per press — the camera flipped and immediately flipped
+  // back, so `V` looked dead. Regression guard: assert === 1, not >= 1.)
+  check('"v" key invokes window.toggleCameraView exactly once', cameraToggles === 1);
 
   console.log('\n--- touch controls (region mapping) ---');
   const W = window.innerWidth;

--- a/tests/controls-node-tests.js
+++ b/tests/controls-node-tests.js
@@ -51,6 +51,11 @@ const flush = () => new Promise(r => setTimeout(r, 0));
 function keydown(key) {
   document.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
 }
+// A held-key auto-repeat keydown (event.repeat === true), as the OS/browser emit while
+// a key is held down.
+function keydownRepeat(key) {
+  document.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true, repeat: true }));
+}
 function keyup(key) {
   document.dispatchEvent(new window.KeyboardEvent('keyup', { key, bubbles: true }));
 }
@@ -104,6 +109,13 @@ async function main() {
   // fired toggleCameraView twice per press — the camera flipped and immediately flipped
   // back, so `V` looked dead. Regression guard: assert === 1, not >= 1.)
   check('"v" key invokes window.toggleCameraView exactly once', cameraToggles === 1);
+  // Holding V emits OS/browser auto-repeat keydowns (event.repeat === true). The toggle
+  // is edge-triggered, so a long press must NOT keep flipping the camera — the V branch
+  // ignores repeats. Regression guard: a burst of repeat keydowns adds zero toggles.
+  keydownRepeat('v');
+  keydownRepeat('v');
+  keydownRepeat('V');
+  check('held "v" auto-repeat does not re-toggle the camera', cameraToggles === 1);
 
   console.log('\n--- touch controls (region mapping) ---');
   const W = window.innerWidth;


### PR DESCRIPTION
## Problem

Pressing **`V`** (toggle chase/normal camera view) did nothing — the key looked dead.

### Root cause
`setupKeyboardControls()` registered the **same** keydown handler on **both `window` and `document`**:

```js
window.addEventListener('keydown', handleKeyDown, opts);
document.addEventListener('keydown', handleKeyDown, opts);
```

A keydown dispatched at the focused element bubbles up through `document` **to** `window`, so the one handler ran **twice per keypress**. For the movement keys (`A/D/W/S/arrows/Space`) that's harmless — they only set a boolean, so setting it twice is idempotent. But `V` is **edge-triggered**: it calls `toggleCameraView()`. Two fires per press flipped the camera to the new mode and **immediately back**, so the view never appeared to change.

(The existing `controls-node-tests.js` even rationalized this with `cameraToggles >= 1` and a comment that the double-fire was "legitimate".)

## Fix
Register the keydown/keyup handlers on **`window` only**. Events bubble there regardless, so a single window-level listener catches every key and fires exactly once. The teardown `AbortSignal` still removes them on HMR/unmount.

## Tests
- **`controls-node-tests.js`**: tightened the `V` assertion from `>= 1` to **`=== 1`** so this regression can't come back.
- **New `tests/camera-node-tests.js`** (+ `test:camera` wired into `npm test`): the camera was the **weakest-covered module** — it was exercised only by the browser suite (`?test=camera`), which needs the live WebGL game and so never counts toward Node coverage. `camera.ts` uses only three.js math objects + the `Mountains` terrain sampler (no GPU), so the whole class runs under jsdom. The harness adds **21 assertions** covering:
  - construction defaults + `getCamera()`
  - `toggleCameraMode()` round-trip
  - `initialize()` third-person (yaw-rotated follow offset, smoothing seed) and first-person
  - `update()` first-frame snap, **speed-based follow distance** (min 15 → max 25), and the **terrain floor clamp**
  - first-person head-follow + `handleResize()`

## Verification
- `npm run test:controls` → 37/37
- `npm run test:camera` → 21/21
- `npm run lint` (changed files) + `npm run typecheck` clean

No gameplay-physics, terrain, or baseline changes — input wiring + new tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)