### PR TITLE
Wind Phase A: scarf streams in the apparent wind (#253)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,7 +106,7 @@ by name. The per-module `window.*` namespace bridges that used to link them were
 | `Trees` | `trees.ts` (facade → `src/mountains/trees.ts`) | object + fns | Tree meshes + placement; returns `treePositions` |
 | `Snow` | `snow.ts` | object + fns | Snowflakes + ski snow-splash particles (drift downwind, issue #253) |
 | `Sky` | `sky.ts` | object + fns | Preetham atmospheric sky + sun & horizon distance fog (gradient-dome fallback), issue #2 |
-| `Wind` | `wind.ts` | object + fns | Shared deterministic horizontal wind field (a pure clock-advanced sample read by snow drift and, in follow-ups, the scarf / tree sway / audio bed); cosmetic-only, no `THREE`/DOM import, issue #253 |
+| `Wind` | `wind.ts` | object + fns | Shared deterministic horizontal wind field (a pure clock-advanced sample read by snow drift and the scarf, and in follow-ups tree sway / audio bed); cosmetic-only, no `THREE`/DOM import, issue #253 |
 | `Camera` | `camera.ts` | `class Camera` | Chase/orbit camera positioning & look-ahead |
 | `Snowman` | `snowman.ts` | object + fns | Snowman model, `updateSnowman` physics, test hooks |
 | `Flex` | `snowman-flex.ts` | object + fns | Cosmetic snowman flex (squash/jiggle, head-cluster bob/lean, landing settle); runs after physics, never touches the kernel (#53) |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -107,6 +107,22 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   new `tests/course-line-tests.js` (`npm run test:course-line`) plus extended
   `difficulty-tests.js` line-block assertions. (Terrain corridor, gates, obstacles, the
   per-tier avalanche, and the ranked flip follow in later D3.2 sub-PRs.)
+
+### Wind — scarf streams in the apparent wind (#253, Phase A)
+- **The red scarf now reacts to the wind field.** The scarf tail trails the **apparent**
+  wind `(wind − player velocity)` — the wind a moving snowman actually feels — resolved
+  into the snowman's local frame: a crosswind streams the tail sideways, a head/tail wind
+  lifts it fore/aft, and the body braces lightly *into* a crosswind. The main loop computes
+  the local-frame apparent wind from `Wind.vector()`, the player velocity, and the snowman
+  heading, and passes it to the cosmetic flex layer as `windSway`/`windStream`.
+- **Invariant-safe & opt-in.** Both new `FlexMotion` fields **default to 0**, so every
+  existing caller and the flex tests are byte-identical (a dedicated test pins "absent ==
+  explicit 0"); the scarf is a child-mesh transform only, so the no-input physics path is
+  untouched. Smoothed between gusts, clamped so a gust never throws the pose, and calmed
+  under `prefers-reduced-motion` by the flex layer's existing gate. New flex tests cover
+  the sideways/fore-aft stream, the brace, the default-0 safety, and bounded gusting.
+  Docs: PHYSICS.md §11 consumers, ARCHITECTURE.md §3.
+
 ### Wind — shared wind field + snow drift (#253, Phase A)
 - **New `src/wind.ts`: one deterministic wind field for the whole scene.** Until now
   "wind" was faked per-subsystem (the `sfx.ts` bed is speed-scaled only; the #172 scarf

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -618,9 +618,13 @@ of each faking its own (issue #253).
   profile (e.g. a calmer vs. gustier difficulty tier).
 - **Consumers.** Snow drift (`snow.ts`: flakes blow downwind scaled by a per-flake
   `windFactor` — lighter flakes further — and the ski splash is advected by `SPLASH_WIND`).
-  *Follow-ups:* scarf streaming (`snowman-flex.ts`), tree sway (`mountains/trees.ts`),
-  audio bed (`sfx.ts`). Every consumer honours `prefers-reduced-motion` (calm) itself,
-  like `Flex`/`Sky`.
+  Scarf streaming (`snowman-flex.ts`: the scarf tail trails the **apparent** wind
+  `(wind − velocity)` resolved into the snowman's local frame — sideways in a crosswind,
+  lifted fore/aft in a head/tail wind — plus a light brace-into-the-wind body lean; the
+  main loop computes the local-frame apparent wind and passes it in as `windSway`/
+  `windStream`, both defaulting to 0 so the no-wind pose is byte-identical).
+  *Follow-ups:* tree sway (`mountains/trees.ts`), audio bed (`sfx.ts`). Every consumer
+  honours `prefers-reduced-motion` (calm) itself, like `Flex`/`Sky`.
 - **Why this is invariant-safe.** Because no consumer writes `pos`/`velocity`, the
   no-input coasting path stays byte-identical to the frozen baseline (§6) — adding wind
   needed **no** baseline regeneration. A wind *force* on the skier would be the opposite: a

--- a/src/game/main-loop.ts
+++ b/src/game/main-loop.ts
@@ -42,6 +42,13 @@ import { AVALANCHE_TRIGGER_DISTANCE, type SceneContext } from './scene-setup.js'
 export const FIXED_DT = 1 / 60;
 export const MAX_SUBSTEPS = 8;
 
+// Apparent-wind normalization for the scarf (#253): the local-frame apparent wind is
+// divided by this reference speed and clamped to [-1,1] before it reaches the cosmetic
+// flex layer. ~16 ≈ a brisk run, so a strong gust or fast straight-line saturates the
+// scarf stream without it ever exceeding its clamps.
+const WIND_LOCAL_REF = 16;
+const clamp = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, n));
+
 /** Events that can fire on ANY substep within a render frame, reduced across the
  *  frame so a jump/land that completes mid-frame still drives its one-shot cosmetics
  *  (whoosh / thump / toast / shake). Reading only the LAST substep's result would
@@ -188,6 +195,19 @@ export function createMainLoop(deps: MainLoopDeps) {
       CourseModule.flashAir(ev.landingQuality, ev.landingForce);
     }
 
+    // Apparent wind for the scarf (#253): the wind a moving snowman feels is
+    // wind - velocity. Resolve it into the snowman's LOCAL frame (heading = rotation.y,
+    // forward = (sin h, cos h), lateral = (cos h, -sin h)) and normalize, so the scarf
+    // streams sideways in a crosswind and lifts fore/aft in a head/tail wind. Reads
+    // Wind/velocity/rotation only — never writes pos/velocity.
+    const wv = Wind.vector();
+    const appX = wv.x - velocity.x;
+    const appZ = wv.z - velocity.z;
+    const h = snowman.rotation.y;
+    const sinH = Math.sin(h), cosH = Math.cos(h);
+    const windStream = clamp((appX * sinH + appZ * cosH) / WIND_LOCAL_REF, -1, 1); // forward
+    const windSway = clamp((appX * cosH - appZ * sinH) / WIND_LOCAL_REF, -1, 1);   // sideways
+
     // Cosmetic flexibility / jiggle (issue #53). Purely visual: reads the per-frame
     // result, only writes child-mesh transforms — never pos/velocity.
     const flexSpeed = result.currentSpeed;
@@ -197,7 +217,9 @@ export function createMainLoop(deps: MainLoopDeps) {
       turnRate: flexSpeed > 1e-3 ? velocity.x / flexSpeed : 0, // zero-speed guard (no 0/0 NaN)
       justLanded: ev.justLanded,
       landingForce: ev.landingForce,
-      isInAir: player.isInAir
+      isInAir: player.isInAir,
+      windSway,
+      windStream
     });
 
     // Sound effects (issue #158): a takeoff whoosh on the ground->air transition, a

--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -197,7 +197,11 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
   const tail = parts.scarfTail; const tb = base.scarfTail;
   if (tail && tb) {
     const windSwing = fs.windSwayS * SCARF_WIND_SWAY;
-    const windLift = clamp(fs.windStreamS * SCARF_WIND_STREAM, -0.4, 0.4);
+    // Negate the apparent-wind stream: the tail's rest pose is forward-draped (more-negative
+    // rotation.x sends it toward +z), so a head/tail wind must ADD positive rotation.x to
+    // trail it behind. A downhill self-motion headwind (windStreamS < 0) thus streams the
+    // scarf back; a tailwind (> 0) pushes it forward (Codex #259).
+    const windLift = clamp(-fs.windStreamS * SCARF_WIND_STREAM, -0.4, 0.4);
     const swing = clamp(-turn * 0.4 + windSwing + Math.sin(fs.t * 7.0) * 0.12 * (0.4 + speedN), -0.8, 0.8);
     tail.rotation.set(tb.rotation.x + (air ? -0.3 : 0.1) + windLift, tb.rotation.y, tb.rotation.z + swing);
   }

--- a/src/snowman-flex.ts
+++ b/src/snowman-flex.ts
@@ -25,6 +25,13 @@ export interface FlexMotion {
   justLanded: boolean;
   landingForce: number;
   isInAir: boolean;
+  /** Apparent wind (wind − player velocity) resolved into the snowman's LOCAL frame and
+   *  normalized to ~[-1,1] by the caller, so the scarf streams downwind (issue #253).
+   *  `windSway` = sideways component (swings the tail left/right); `windStream` = forward
+   *  component (lifts the tail back in a headwind / forward in a tailwind). BOTH DEFAULT
+   *  to 0 (absent), so every existing caller/test is byte-identical. */
+  windSway?: number;
+  windStream?: number;
 }
 
 interface XYZ { x: number; y: number; z: number; }
@@ -33,6 +40,9 @@ interface FlexState {
   t: number; settle: number; settleVel: number; leanZ: number; lagY: number;
   // Ski flex (issue #189): a smoothed base camber + a landing compression spring.
   skiCamber: number; skiSettle: number; skiSettleVel: number;
+  // Wind (issue #253): smoothed apparent-wind sway/stream so the scarf cloth and the
+  // brace lean ease between gusts instead of snapping.
+  windSwayS: number; windStreamS: number;
 }
 
 const finite = (n: number): number => (Number.isFinite(n) ? n : 0);
@@ -57,6 +67,15 @@ const LEAN_GLIDE = 0.5;         // fraction of the lean kept when not actively c
 
 const BALLS: ReadonlyArray<string> = ['bottom', 'middle', 'head'];
 const BALL_PHASE: ReadonlyArray<number> = [0, 1.1, 2.2]; // stagger so the stack ripples
+
+// --- wind tuning (issue #253) -----------------------------------------------
+// The caller passes apparent wind (wind - velocity) resolved into the snowman's local
+// frame, normalized to ~[-1,1]. The scarf streams with it; the body braces lightly into
+// a crosswind. All amplitudes are clamped so a gust never throws the pose.
+const SCARF_WIND_SWAY = 0.55;   // rad of tail side-swing at full crosswind
+const SCARF_WIND_STREAM = 0.35; // rad of tail fore/aft lift at full head/tail wind
+const BRACE_LEAN = 0.07;        // rad the head cluster leans INTO a full crosswind
+const WIND_SMOOTH = 4;          // per-s lerp easing the (already gust-smooth) wind inputs
 
 // --- ski flex tuning (issue #189) -------------------------------------------
 // The skis are split (in model.ts) into a tip arm (extends +z) and a tail arm (extends
@@ -86,7 +105,7 @@ function getState(ud: Record<string, unknown>): FlexState {
 }
 
 function freshState(): FlexState {
-  return { t: 0, settle: 0, settleVel: 0, leanZ: 0, lagY: 0, skiCamber: SKI_CAMBER_GLIDE, skiSettle: 0, skiSettleVel: 0 };
+  return { t: 0, settle: 0, settleVel: 0, leanZ: 0, lagY: 0, skiCamber: SKI_CAMBER_GLIDE, skiSettle: 0, skiSettleVel: 0, windSwayS: 0, windStreamS: 0 };
 }
 
 function prefersReducedMotion(): boolean {
@@ -112,6 +131,14 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
   const speedN = clamp(speed / SPEED_REF, 0, 1);
   const turn = clamp(finite(m.turnRate), -1, 1);
   const air = !!m.isInAir;
+
+  // Smooth the apparent-wind inputs (issue #253). Absent => 0, so a caller that doesn't
+  // pass wind leaves the scarf/brace byte-identical to before.
+  const swayIn = clamp(finite(m.windSway ?? 0), -1, 1);
+  const streamIn = clamp(finite(m.windStream ?? 0), -1, 1);
+  fs.windSwayS += (swayIn - fs.windSwayS) * clamp(dt * WIND_SMOOTH, 0, 1);
+  fs.windStreamS += (streamIn - fs.windStreamS) * clamp(dt * WIND_SMOOTH, 0, 1);
+  fs.windSwayS = finite(fs.windSwayS); fs.windStreamS = finite(fs.windStreamS);
 
   fs.t += dt;
 
@@ -153,18 +180,26 @@ function update(snowman: THREE.Object3D, dt: number, m: FlexMotion): void {
     fs.leanZ += (targetLean - fs.leanZ) * clamp(dt * 5, 0, 1);
     fs.lagY = finite(fs.lagY); fs.leanZ = finite(fs.leanZ);
 
+    // Brace lightly INTO a crosswind (opposite the direction the scarf streams). Tiny and
+    // clamped so it never reads as a turn; zero while airborne (#253).
+    const brace = air ? 0 : clamp(-fs.windSwayS * BRACE_LEAN, -0.09, 0.09);
+
     hg.rotation.set(
       hb.rotation.x + clamp(fs.settle * 0.25, -0.1, 0.1),
       hb.rotation.y + clamp(fs.lagY, -0.28, 0.28),
-      hb.rotation.z + clamp(fs.leanZ, -0.34, 0.34)
+      hb.rotation.z + clamp(fs.leanZ + brace, -0.36, 0.36)
     );
   }
 
   // Scarf tail trail — present-or-absent (added by the optional scarf follow-up, PR C).
+  // It swings with turns, flutters with speed, AND now streams in the apparent wind so a
+  // crosswind trails it sideways and a head/tail wind lifts it fore/aft (issue #253).
   const tail = parts.scarfTail; const tb = base.scarfTail;
   if (tail && tb) {
-    const swing = clamp(-turn * 0.4 + Math.sin(fs.t * 7.0) * 0.12 * (0.4 + speedN), -0.6, 0.6);
-    tail.rotation.set(tb.rotation.x + (air ? -0.3 : 0.1), tb.rotation.y, tb.rotation.z + swing);
+    const windSwing = fs.windSwayS * SCARF_WIND_SWAY;
+    const windLift = clamp(fs.windStreamS * SCARF_WIND_STREAM, -0.4, 0.4);
+    const swing = clamp(-turn * 0.4 + windSwing + Math.sin(fs.t * 7.0) * 0.12 * (0.4 + speedN), -0.8, 0.8);
+    tail.rotation.set(tb.rotation.x + (air ? -0.3 : 0.1) + windLift, tb.rotation.y, tb.rotation.z + swing);
   }
 
   // --- Ski flex (issue #189) -------------------------------------------------

--- a/tests/snowman-flex-tests.js
+++ b/tests/snowman-flex-tests.js
@@ -181,11 +181,18 @@ async function main() {
     const tz = sm.userData.parts.scarfTail.rotation.z - base.scarfTail.rotation.z;
     check('crosswind streams the scarf sideways (rotation.z)', Math.abs(tz) > 0.2 && Number.isFinite(tz));
 
-    // A head/tail wind lifts the tail fore/aft (rotation.x).
+    // A head/tail wind lifts the tail fore/aft (rotation.x). A self-motion headwind
+    // (windStream < 0 — the common downhill case) trails the tail BEHIND the snowman:
+    // rotation.x goes positive, away from the forward-draped rest pose (Codex #259).
     const sm2 = makeSnowman();
-    for (let i = 0; i < 60; i++) Flex.update(sm2, 1 / 60, { speed: 6, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false, windSway: 0, windStream: 1 });
+    for (let i = 0; i < 60; i++) Flex.update(sm2, 1 / 60, { speed: 6, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false, windSway: 0, windStream: -1 });
     const tx = sm2.userData.parts.scarfTail.rotation.x - base.scarfTail.rotation.x;
-    check('head/tail wind lifts the scarf fore/aft (rotation.x)', tx > 0.1 && Number.isFinite(tx));
+    check('headwind trails the scarf behind (rotation.x > 0)', tx > 0.1 && Number.isFinite(tx));
+    // ...and a tailwind (windStream > 0) pushes it forward (rotation.x < 0).
+    const sm2b = makeSnowman();
+    for (let i = 0; i < 60; i++) Flex.update(sm2b, 1 / 60, { speed: 6, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false, windSway: 0, windStream: 1 });
+    const txb = sm2b.userData.parts.scarfTail.rotation.x - base.scarfTail.rotation.x;
+    check('tailwind pushes the scarf forward (rotation.x < 0)', txb < -0.1 && Number.isFinite(txb));
 
     // The body braces INTO the crosswind: the head leans opposite the scarf stream.
     check('body braces into the crosswind (head leans opposite the scarf)', Math.sign(sm.userData.parts.headGroup.rotation.z) === -Math.sign(tz));

--- a/tests/snowman-flex-tests.js
+++ b/tests/snowman-flex-tests.js
@@ -46,7 +46,9 @@ function makeSnowman() {
     rightArmGroup: makePart(-1.35, 4.9, 0),
     // Ski flex arms (issue #189): pivot at the waist (root-local z = -0.1).
     leftSkiTip: makePart(0, 0, -0.1), leftSkiTail: makePart(0, 0, -0.1),
-    rightSkiTip: makePart(0, 0, -0.1), rightSkiTail: makePart(0, 0, -0.1)
+    rightSkiTip: makePart(0, 0, -0.1), rightSkiTail: makePart(0, 0, -0.1),
+    // Scarf tail (issue #53 / wind streaming #253).
+    scarfTail: makePart(0.3, 6.25, 0.75)
   };
   return { userData: { parts, partBaseTransforms: recordBase(parts) } };
 }
@@ -166,6 +168,48 @@ async function main() {
     Flex.reset(sm);
     const restored = skiKeys.every((k) => sm.userData.parts[k].rotation.x === base[k].rotation.x);
     check('reset() restores ski arms to neutral', restored);
+  }
+
+  // --- Scarf wind streaming (issue #253) -------------------------------------
+  {
+    const base = makeSnowman().userData.partBaseTransforms;
+
+    // A steady crosswind streams the tail sideways (rotation.z), opposite to the sign of
+    // windSway in this neutral pose, and well beyond the idle sine flutter (~0.07).
+    const sm = makeSnowman();
+    for (let i = 0; i < 60; i++) Flex.update(sm, 1 / 60, { speed: 6, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false, windSway: 1, windStream: 0 });
+    const tz = sm.userData.parts.scarfTail.rotation.z - base.scarfTail.rotation.z;
+    check('crosswind streams the scarf sideways (rotation.z)', Math.abs(tz) > 0.2 && Number.isFinite(tz));
+
+    // A head/tail wind lifts the tail fore/aft (rotation.x).
+    const sm2 = makeSnowman();
+    for (let i = 0; i < 60; i++) Flex.update(sm2, 1 / 60, { speed: 6, technique: 'glide', turnRate: 0, justLanded: false, landingForce: 0, isInAir: false, windSway: 0, windStream: 1 });
+    const tx = sm2.userData.parts.scarfTail.rotation.x - base.scarfTail.rotation.x;
+    check('head/tail wind lifts the scarf fore/aft (rotation.x)', tx > 0.1 && Number.isFinite(tx));
+
+    // The body braces INTO the crosswind: the head leans opposite the scarf stream.
+    check('body braces into the crosswind (head leans opposite the scarf)', Math.sign(sm.userData.parts.headGroup.rotation.z) === -Math.sign(tz));
+
+    // DEFAULT-0 SAFETY: omitting the wind fields == passing 0 (so existing callers/tests
+    // stay byte-identical). Drive two snowmen in lockstep, identical except for the absent
+    // vs explicit-0 wind, and require every scarf transform to match exactly.
+    const a = makeSnowman(), b = makeSnowman();
+    for (let i = 0; i < 90; i++) {
+      const m = { speed: 14, technique: 'carve', turnRate: Math.sin(i / 9), justLanded: false, landingForce: 0, isInAir: false };
+      Flex.update(a, 1 / 60, m);
+      Flex.update(b, 1 / 60, { ...m, windSway: 0, windStream: 0 });
+    }
+    const at = a.userData.parts.scarfTail.rotation, bt = b.userData.parts.scarfTail.rotation;
+    check('absent wind == windSway/windStream 0 (byte-identical scarf)', at.x === bt.x && at.y === bt.y && at.z === bt.z);
+
+    // Bounded + finite under a hard gusting sweep.
+    const sm3 = makeSnowman(); let okay = true;
+    for (let i = 0; i < 400; i++) {
+      Flex.update(sm3, 1 / 60, { speed: 22, technique: 'carve', turnRate: Math.sin(i / 7), justLanded: false, landingForce: 0, isInAir: i % 50 < 8, windSway: Math.sin(i / 5), windStream: Math.cos(i / 11) });
+      const r = sm3.userData.parts.scarfTail.rotation;
+      if (![r.x, r.y, r.z].every(Number.isFinite) || Math.abs(r.z) > 1.2 || Math.abs(r.x) > 1.2) okay = false;
+    }
+    check('scarf stays bounded + finite over 400 gusting frames', okay);
   }
 
   console.log(`\nSNOWMAN-FLEX TOTAL: ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
## Wind Phase A — PR3: scarf streams in the apparent wind

Third PR of the wind plan (#253), stacked on **#256** (`feat/wind-system` → review that first; this diff is only the scarf changes on top). Makes the existing red scarf (#172) react to the shared wind field.

### What's here

The scarf tail now trails the **apparent wind** `(wind − player velocity)` — the wind a moving snowman actually feels — resolved into the snowman's **local frame**:

- a **crosswind** streams the tail sideways (`rotation.z`),
- a **head/tail wind** lifts it fore/aft (`rotation.x`),
- the body **braces lightly into** a crosswind (a small, clamped head lean opposite the stream).

The main loop computes the local-frame apparent wind from `Wind.vector()`, the player velocity, and the snowman heading (`forward = (sin h, cos h)`, `lateral = (cos h, −sin h)`), normalizes it, and passes it to the cosmetic flex layer as `windSway` / `windStream`.

### Why it's safe

- Both new `FlexMotion` fields **default to 0**, so every existing caller and flex test is **byte-identical** — a dedicated test pins *"absent == explicit 0"*.
- The scarf is a **child-mesh transform only** (the flex layer never touches `pos`/`velocity`), so the no-input coasting path stays byte-identical to the frozen baseline:

```
--- Invariant: coasting (no input) baseline vs current [GATING] ---
  steps: 220 220 | max abs diff: 0.000e+0
  PASS: IDENTICAL ✅
```

- Smoothed between gusts, clamped so a gust never throws the pose, and calmed under `prefers-reduced-motion` by the flex layer's existing reduced-motion gate.

### Tests / checks

- `npm run test:flex` — **16/16** (5 new): sideways stream, fore/aft lift, brace direction, the default-0 byte-identity, and bounded+finite over 400 gusting frames. Added `scarfTail` to the test stub.
- `npm run test:verify` byte-identical (above) + 53/53 DOM smoke; `tsc --noEmit`, `eslint .` (0 errors), `npm run build` all green.

### Docs

PHYSICS.md §11 (scarf moved from follow-up to a live consumer, with the apparent-wind math), ARCHITECTURE.md §3, CHANGELOG.md.



### Visual

Player frozen, HUD hidden, steady crosswind (swing exaggerated for the still — the shipped amplitude is gentler):

![scarf calm vs windy](https://raw.githubusercontent.com/den-run-ai/snowglider/assets/wind-shots/scarf_compare.png)

### Remaining in #253

Tree sway (`mountains/trees.ts`), audio bed (`sfx.ts`), optional HUD indicator; the tier-gated gameplay wind force stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
