### PR TITLE
feat(feedback): in-game feature-request / bug-report form (#258)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: 🐞 Bug report
+about: Report something broken in SnowGlider
+title: "[Bug] "
+labels: ["bug", "game-feedback"]
+---
+
+## What happened?
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behaviour
+<!-- What you expected instead. -->
+
+## Context
+<!-- Browser/device, and the diagnostics block if you submitted from the in-game
+     feedback form with "Include diagnostics" checked. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 In-game feedback
+    url: https://den-run-ai.github.io/snowglider/
+    about: You can also send a feature request or bug report straight from the game's start screen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: ✨ Feature request
+about: Suggest an idea or improvement for SnowGlider
+title: "[Feature] "
+labels: ["enhancement", "game-feedback"]
+---
+
+## What would you like to see?
+<!-- A clear description of the feature or improvement. -->
+
+## Why is it useful?
+<!-- What problem does it solve, or how does it make the game better? -->
+
+## Additional context
+<!-- Mockups, references, or anything else. The in-game feedback form fills this
+     in automatically when you submit from the game. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ SnowGlider is a Three.js animation/game featuring a snowman skiing on natural ba
 - `src/audio.ts` - Background music and audio controls
 - `src/sfx.ts` - Procedural Web Audio sound effects (wind/carve/jump/land/avalanche/crash/finish)
 - `src/diagnostics.ts` - Read-only runtime physics/frame-rate telemetry (`Diag`): catches the frame-rate-dependence bug class (#209) live — runaway low-FPS speed, per-frame steps past a collision radius (tunnel risk), NaN. Dev overlay (`?debug`), `window.__snowgliderDiag.dump()` JSON export; off under automation. See `docs/DIAGNOSTICS.md`.
+- `src/ui/feedback.ts` - In-game feature-request / bug-report form (issue #258): opens a GitHub prefilled new-issue URL (keyless — the player submits under their own account) and fires a `feedback_submitted` Firebase Analytics event via the shared `window.firebaseModules.logEvent` seam. Pure helpers are headless-tested (`npm run test:feedback`); issue templates live in `.github/ISSUE_TEMPLATE/`.
 - `src/auth.ts` - Firebase authentication implementation
 - `src/scores.ts` - User scoring and leaderboard functionality
 - `src/boot/` - Classic-script local-auth fallback + Firebase bootstrap (the only remaining `.js`), and `script-loader.ts` (startup driver)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ SnowGlider is a Three.js-based skiing game featuring a snowman gliding down a pr
 - Tracking camera that follows the snowman's movements
 - Background music (simplified native HTML5 audio; see the audio history in [`CHANGELOG.md`](docs/CHANGELOG.md))
 - Timer with best time tracking
+- In-game feedback form — send a feature request or bug report straight from the start screen; it opens a prefilled GitHub issue (you submit under your own account) and logs an anonymous Firebase Analytics event
 - Comprehensive test suite for verifying game mechanics
 
 ## Roadmap

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,25 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
 
 ## Unreleased
 
+### Feature: in-game feedback / feature-request form (#258)
+- **Gap.** A player who hit a bug or had an idea had no in-game path to report it — they
+  had to leave the game and find the repo. Two backends we already run (GitHub for
+  tracking, Firebase Analytics for engagement) were unused for feedback.
+- **`src/ui/feedback.ts` (new).** A "💬 Feedback" button on the start screen opens a small
+  modal (category: feature / bug / general, a message, and an opt-in "include diagnostics"
+  checkbox). **Submit opens a GitHub _prefilled_ new-issue URL** (`/issues/new?title=…&body=…&labels=…`)
+  in a new tab — keyless by design: a static GitHub-Pages client must never hold a write
+  token, so the player previews and submits the issue under their **own** GitHub account.
+  No server, no Cloud Function.
+- **Analytics.** Fires a `feedback_submitted` event (category dimension only — no message
+  text/PII) through the existing `window.firebaseModules.logEvent` seam (`auth.ts`), the
+  same path `share_result` / `complete_run` use; no-ops when Analytics is absent.
+- Opt-in diagnostics pull build id, URL, viewport, user-agent, and `window.__snowgliderDiag.dump()`
+  into the issue body. Every `window`/`navigator`/`__snowgliderDiag` read is guarded so the
+  module is inert under SSR/Node/tests. Pure helpers are headless-tested
+  (`tests/feedback-tests.js`, `npm run test:feedback`). Structured issue templates added
+  under `.github/ISSUE_TEMPLATE/`.
+
 ### Feature: obstacle contact shadows (#17)
 - **Readability gap.** Trees and rocks sat on the bright snow with no grounding cue, so a
   tree could read as floating / pasted-on. The slope/cavity shading darkens the terrain

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,10 +19,12 @@ diagnostic history. For the current design see [`ARCHITECTURE.md`](ARCHITECTURE.
   tracking, Firebase Analytics for engagement) were unused for feedback.
 - **`src/ui/feedback.ts` (new).** A "💬 Feedback" button on the start screen opens a small
   modal (category: feature / bug / general, a message, and an opt-in "include diagnostics"
-  checkbox). **Submit opens a GitHub _prefilled_ new-issue URL** (`/issues/new?title=…&body=…&labels=…`)
+  checkbox). **Submit opens a GitHub _prefilled_ new-issue URL** (`/issues/new?title=…&body=…`)
   in a new tab — keyless by design: a static GitHub-Pages client must never hold a write
   token, so the player previews and submits the issue under their **own** GitHub account.
-  No server, no Cloud Function.
+  No server, no Cloud Function. (No `labels=` param — GitHub 404s that form for users
+  without label permission, i.e. ordinary players; labels come from the title prefix and
+  the `.github/ISSUE_TEMPLATE/*` templates instead.)
 - **Analytics.** Fires a `feedback_submitted` event (category dimension only — no message
   text/PII) through the existing `window.firebaseModules.logEvent` seam (`auth.ts`), the
   same path `share_result` / `complete_run` use; no-ops when Analytics is absent.

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
     <div id="startMenu">
       <button id="startGameButton" class="menu-button start">Start Game</button>
       <button id="aboutGameButton" class="menu-button about">About Game</button>
+      <button id="feedbackButton" class="menu-button feedback">💬 Feedback</button>
     </div>
 
     <!-- Global Top Times preview; populated by start-menu.ts once scores load,
@@ -295,5 +296,6 @@
   -->
   <script type="module" src="src/boot/script-loader.ts"></script>
   <script type="module" src="src/ui/start-menu.ts"></script>
+  <script type="module" src="src/ui/feedback.ts"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/snowglider.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:course-line && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:camera && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:wind && npm run test:contact-shadows && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
+    "test": "npm run test:terrain && npm run test:physics && npm run test:difficulty && npm run test:course-line && npm run test:regression && npm run test:tree-collision && npm run test:trees && npm run test:avalanche && npm run test:snowtrails && npm run test:auth && npm run test:local-auth && npm run test:scores && npm run test:limits-sync && npm run test:start-menu && npm run test:collapsible && npm run test:result-overlay && npm run test:lifecycle && npm run test:test-hooks && npm run test:controls && npm run test:camera && npm run test:flex && npm run test:debris && npm run test:leak && npm run test:teardown && npm run test:intro && npm run test:sfx && npm run test:diagnostics && npm run test:contract && npm run test:share && npm run test:feedback && npm run test:share-card && npm run test:share-menu && npm run test:audio-asset && npm run test:sky && npm run test:wind && npm run test:contact-shadows && npm run test:snow-surface && npm run test:sun-shadow && npm run test:coverage-merge && npm run test:verify && npm run test:turn-styles && npm run test:stress && npm run test:winnable && npm run test:floor",
     "test:terrain": "node --import ./tests/loaders/register-ts-resolve.mjs tests/terrain-tests.js",
     "test:physics": "node tests/physics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/player-state-tests.js",
     "test:difficulty": "node --import ./tests/loaders/register-ts-resolve.mjs tests/difficulty-tests.js",
@@ -36,6 +36,7 @@
     "test:diagnostics": "node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-tests.js && node --import ./tests/loaders/register-ts-resolve.mjs tests/diagnostics-dom-tests.js",
     "test:contract": "node --import ./tests/loaders/register-ts-resolve.mjs tests/contract-surface-tests.js",
     "test:share": "node tests/share-tests.js",
+    "test:feedback": "node tests/feedback-tests.js",
     "test:share-card": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-card-tests.js",
     "test:share-menu": "node --import ./tests/loaders/register-ts-resolve.mjs tests/share-menu-tests.js",
     "test:audio-asset": "node tests/audio-asset-tests.js",

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -103,11 +103,14 @@ export function collectContext(includeDiagnostics: boolean): FeedbackContext {
   if (typeof navigator !== 'undefined' && navigator.userAgent) {
     ctx.userAgent = navigator.userAgent;
   }
+  // Use snapshot(), NOT dump(): both return the same trace, but dump() also
+  // downloads a snowglider-diag-*.json file as a side effect — we only want the
+  // data to embed in the issue body, not a surprise download on every submit.
   if (includeDiagnostics && typeof window !== 'undefined' && window.__snowgliderDiag &&
-      typeof window.__snowgliderDiag.dump === 'function') {
+      typeof window.__snowgliderDiag.snapshot === 'function') {
     try {
-      const dump = window.__snowgliderDiag.dump();
-      ctx.diagnostics = truncate(JSON.stringify(dump), 3000);
+      const snap = window.__snowgliderDiag.snapshot();
+      ctx.diagnostics = truncate(JSON.stringify(snap), 3000);
     } catch { /* diagnostics are opt-in and best-effort */ }
   }
   return ctx;
@@ -353,6 +356,16 @@ export function initFeedback(): void {
   if (btn && btn.dataset.feedbackWired !== '1') {
     btn.dataset.feedbackWired = '1';
     btn.addEventListener('click', openFeedback);
+    // Keep Enter/Space on this button from bubbling to start-menu.ts's document
+    // keydown handler, which starts the run for any target outside #difficultyPicker
+    // while #startGameContainer is visible (the button sits inside it). Without this,
+    // keyboard-activating the button would launch the game instead of just opening
+    // the modal. We don't preventDefault, so the button's native click still fires.
+    btn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.stopPropagation();
+      }
+    });
   }
 }
 

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -80,13 +80,21 @@ export interface FeedbackContext {
 }
 
 /**
- * Gather best-effort runtime context for the issue body. `includeDiagnostics`
- * additionally serialises `window.__snowgliderDiag.dump()` (the same trace the
- * diagnostics bug-report API exposes). Every access is guarded so this is inert
- * under SSR / Node / tests.
+ * Gather best-effort runtime context for the issue body, ONLY when
+ * `includeDiagnostics` is true (the modal's opt-in checkbox). It then collects
+ * build id, URL, viewport, user-agent, and — if available — the
+ * `window.__snowgliderDiag.snapshot()` physics trace. With the box unchecked it
+ * returns an empty object so an ordinary submission carries only the player's
+ * message. Every access is guarded so this is inert under SSR / Node / tests.
  */
 export function collectContext(includeDiagnostics: boolean): FeedbackContext {
   const ctx: FeedbackContext = {};
+  // ALL of the following is device/page context gated behind the opt-in checkbox
+  // ("Include diagnostics (build, device, physics trace)"). With the box unchecked
+  // we attach nothing, so an ordinary submission never leaks the URL (which can
+  // carry query-string state), the viewport, or the user-agent — only the player's
+  // own message goes into the issue.
+  if (!includeDiagnostics) return ctx;
   if (typeof document !== 'undefined' && document.querySelector) {
     const meta = document.querySelector('meta[name="build-id"]');
     const content = meta && 'content' in meta ? (meta as HTMLMetaElement).content : '';
@@ -106,7 +114,7 @@ export function collectContext(includeDiagnostics: boolean): FeedbackContext {
   // Use snapshot(), NOT dump(): both return the same trace, but dump() also
   // downloads a snowglider-diag-*.json file as a side effect — we only want the
   // data to embed in the issue body, not a surprise download on every submit.
-  if (includeDiagnostics && typeof window !== 'undefined' && window.__snowgliderDiag &&
+  if (typeof window !== 'undefined' && window.__snowgliderDiag &&
       typeof window.__snowgliderDiag.snapshot === 'function') {
     try {
       const snap = window.__snowgliderDiag.snapshot();

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -1,0 +1,351 @@
+// ui/feedback.ts - In-game feature-request / bug-report entry point (issue #258).
+//
+// Lets a player file feedback without leaving the game. Two integrations, both
+// keyless and safe to ship inside a static GitHub-Pages client:
+//
+//   1. GitHub - we never hold a write token in the browser (embedding one would
+//      leak it to every visitor). Instead "Submit" opens GitHub's *prefilled*
+//      new-issue form (title / body / labels filled from the player's input plus
+//      optional runtime context). The player previews it and submits on
+//      github.com under their OWN account. No server, no Cloud Function, no
+//      secret in the bundle.
+//   2. Firebase Analytics - we fire a `feedback_submitted` event through the
+//      existing `window.firebaseModules.logEvent` seam (wired in auth.ts, the
+//      same path `share_result` / `complete_run` use) so we get aggregate
+//      feedback-engagement metrics. It carries only the category string - never
+//      the message text or any PII - and no-ops when Analytics is unavailable
+//      (local / offline / tests).
+//
+// The pure helpers (buildFeedbackIssueUrl / buildIssueBody / collectContext /
+// truncate / isFeedbackCategory / logFeedbackEvent) hold no DOM or Firebase
+// state, so tests/feedback-tests.js imports the real `.ts` and exercises them
+// headlessly. The DOM builder is modelled on ui/share-menu.ts.
+
+const REPO_SLUG = 'den-run-ai/snowglider';
+
+/** Shared label so all in-game feedback is findable on the Issues tab. */
+export const FEEDBACK_LABEL = 'game-feedback';
+
+export type FeedbackCategory = 'feature' | 'bug' | 'general';
+
+interface CategoryMeta {
+  /** Human label shown in the modal's category picker. */
+  label: string;
+  /** Prefix prepended to the issue title. */
+  titlePrefix: string;
+  /** Labels applied to the prefilled GitHub issue. */
+  issueLabels: string[];
+}
+
+// Order here drives the radio order in the modal; `feature` is the default.
+export const FEEDBACK_CATEGORIES: Record<FeedbackCategory, CategoryMeta> = {
+  feature: { label: '✨ Feature request', titlePrefix: '[Feature] ', issueLabels: ['enhancement', FEEDBACK_LABEL] },
+  bug:     { label: '🐞 Bug report',      titlePrefix: '[Bug] ',     issueLabels: ['bug', FEEDBACK_LABEL] },
+  general: { label: '💬 General feedback', titlePrefix: '[Feedback] ', issueLabels: [FEEDBACK_LABEL] },
+};
+
+const DEFAULT_CATEGORY: FeedbackCategory = 'feature';
+
+// Keep the prefilled URL comfortably under real-world browser/address-bar caps
+// (~8 k for the whole URL). The diagnostics dump is the only thing that can grow
+// large, so the body is bounded too.
+const MAX_MESSAGE = 4000;
+const MAX_BODY = 6000;
+
+/** Narrowing guard for an untrusted category string (e.g. a radio value). */
+export function isFeedbackCategory(value: unknown): value is FeedbackCategory {
+  return value === 'feature' || value === 'bug' || value === 'general';
+}
+
+/** Hard length cap with an ellipsis marker, so a long message can't blow the URL. */
+export function truncate(text: string, max = MAX_MESSAGE): string {
+  if (typeof text !== 'string') return '';
+  if (text.length <= max) return text;
+  return text.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+/** First non-empty line of the message, used for the issue title. */
+function firstLine(message: string): string {
+  const line = message.split('\n').map((l) => l.trim()).find((l) => l.length > 0) || '';
+  return truncate(line, 80);
+}
+
+/** Optional runtime context appended to the issue body. Every field is best-effort. */
+export interface FeedbackContext {
+  build?: string;
+  url?: string;
+  userAgent?: string;
+  viewport?: string;
+  diagnostics?: string;
+}
+
+/**
+ * Gather best-effort runtime context for the issue body. `includeDiagnostics`
+ * additionally serialises `window.__snowgliderDiag.dump()` (the same trace the
+ * diagnostics bug-report API exposes). Every access is guarded so this is inert
+ * under SSR / Node / tests.
+ */
+export function collectContext(includeDiagnostics: boolean): FeedbackContext {
+  const ctx: FeedbackContext = {};
+  if (typeof document !== 'undefined' && document.querySelector) {
+    const meta = document.querySelector('meta[name="build-id"]');
+    const content = meta && 'content' in meta ? (meta as HTMLMetaElement).content : '';
+    if (content) ctx.build = content;
+  }
+  if (typeof window !== 'undefined') {
+    try {
+      if (window.location && window.location.href) ctx.url = window.location.href;
+      if (typeof window.innerWidth === 'number' && typeof window.innerHeight === 'number') {
+        ctx.viewport = `${window.innerWidth}x${window.innerHeight}`;
+      }
+    } catch { /* defensive: jsdom/odd hosts */ }
+  }
+  if (typeof navigator !== 'undefined' && navigator.userAgent) {
+    ctx.userAgent = navigator.userAgent;
+  }
+  if (includeDiagnostics && typeof window !== 'undefined' && window.__snowgliderDiag &&
+      typeof window.__snowgliderDiag.dump === 'function') {
+    try {
+      const dump = window.__snowgliderDiag.dump();
+      ctx.diagnostics = truncate(JSON.stringify(dump), 3000);
+    } catch { /* diagnostics are opt-in and best-effort */ }
+  }
+  return ctx;
+}
+
+/** Render the context map as a fenced details block (omitted entirely if empty). */
+function renderContext(ctx: FeedbackContext): string {
+  const rows: string[] = [];
+  if (ctx.build) rows.push(`- Build: \`${ctx.build}\``);
+  if (ctx.url) rows.push(`- URL: ${ctx.url}`);
+  if (ctx.viewport) rows.push(`- Viewport: ${ctx.viewport}`);
+  if (ctx.userAgent) rows.push(`- User agent: \`${ctx.userAgent}\``);
+  let block = rows.length ? rows.join('\n') : '';
+  if (ctx.diagnostics) {
+    block += `\n\n<details><summary>Diagnostics trace</summary>\n\n\`\`\`json\n${ctx.diagnostics}\n\`\`\`\n\n</details>`;
+  }
+  return block;
+}
+
+export interface BuildIssueOptions {
+  category: FeedbackCategory;
+  message: string;
+  context?: FeedbackContext;
+}
+
+/** Compose the Markdown issue body from the player's message + optional context. */
+export function buildIssueBody(opts: BuildIssueOptions): string {
+  const message = truncate((opts.message || '').trim());
+  const ctx = opts.context ? renderContext(opts.context) : '';
+  const parts = [
+    message || '_(no description provided)_',
+  ];
+  if (ctx) {
+    parts.push('\n---\n\n### Context\n' + ctx);
+  }
+  parts.push('\n\n> Submitted from the in-game feedback form.');
+  return truncate(parts.join('\n'), MAX_BODY);
+}
+
+/**
+ * Build the GitHub prefilled new-issue URL. The player opens this, reviews the
+ * filled form on github.com, and submits under their own account - no token
+ * ever touches the client.
+ */
+export function buildFeedbackIssueUrl(opts: BuildIssueOptions): string {
+  const cat = isFeedbackCategory(opts.category) ? opts.category : DEFAULT_CATEGORY;
+  const meta = FEEDBACK_CATEGORIES[cat];
+  const title = meta.titlePrefix + (firstLine(opts.message || '') || 'feedback');
+  const params = new URLSearchParams({
+    title,
+    body: buildIssueBody({ ...opts, category: cat }),
+    labels: meta.issueLabels.join(','),
+  });
+  return `https://github.com/${REPO_SLUG}/issues/new?${params.toString()}`;
+}
+
+/**
+ * Fire the Firebase Analytics `feedback_submitted` event through the shared
+ * window seam. Carries only the category (no message text / PII) and never
+ * throws into the caller.
+ */
+export function logFeedbackEvent(category: FeedbackCategory): void {
+  try {
+    const fm = typeof window !== 'undefined' ? window.firebaseModules : undefined;
+    if (fm && typeof fm.logEvent === 'function') {
+      fm.logEvent('feedback_submitted', { category });
+    }
+  } catch { /* analytics is best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// DOM: the start-screen feedback button + modal. Built lazily, self-contained
+// inline styles like ui/share-menu.ts (no shared CSS class dependency beyond the
+// reused .menu-button for the start-screen trigger).
+// ---------------------------------------------------------------------------
+
+let modalEl: HTMLDivElement | null = null;
+
+function styleOverlay(el: HTMLElement): void {
+  Object.assign(el.style, {
+    position: 'fixed', inset: '0', display: 'none', alignItems: 'center',
+    justifyContent: 'center', background: 'rgba(0,0,0,0.55)', zIndex: '10000',
+    fontFamily: 'Arial, sans-serif',
+  });
+}
+
+function buildModal(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'feedbackOverlay';
+  styleOverlay(overlay);
+
+  const panel = document.createElement('div');
+  panel.id = 'feedbackPanel';
+  Object.assign(panel.style, {
+    background: '#1c2230', color: '#fff', width: 'min(440px, 92vw)',
+    maxHeight: '90vh', overflowY: 'auto', borderRadius: '14px', padding: '20px',
+    boxShadow: '0 12px 40px rgba(0,0,0,0.5)',
+  });
+
+  const heading = document.createElement('h3');
+  heading.textContent = '💬 Send Feedback';
+  Object.assign(heading.style, { margin: '0 0 6px', fontSize: '20px' });
+
+  const blurb = document.createElement('p');
+  blurb.textContent = 'Tell us what to build or fix. Submit opens a prefilled GitHub issue you confirm under your own account.';
+  Object.assign(blurb.style, { margin: '0 0 14px', fontSize: '13px', color: 'rgba(255,255,255,0.7)', lineHeight: '1.4' });
+
+  // Category radios.
+  const catWrap = document.createElement('div');
+  Object.assign(catWrap.style, { display: 'flex', flexDirection: 'column', gap: '6px', marginBottom: '14px' });
+  (Object.keys(FEEDBACK_CATEGORIES) as FeedbackCategory[]).forEach((key, i) => {
+    const row = document.createElement('label');
+    Object.assign(row.style, { display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', cursor: 'pointer' });
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'feedbackCategory';
+    radio.value = key;
+    radio.checked = i === 0;
+    row.appendChild(radio);
+    row.appendChild(document.createTextNode(FEEDBACK_CATEGORIES[key].label));
+    catWrap.appendChild(row);
+  });
+
+  const textarea = document.createElement('textarea');
+  textarea.id = 'feedbackMessage';
+  textarea.placeholder = 'Describe your idea or the bug you hit…';
+  textarea.maxLength = MAX_MESSAGE;
+  Object.assign(textarea.style, {
+    width: '100%', minHeight: '110px', resize: 'vertical', boxSizing: 'border-box',
+    padding: '10px', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
+    background: '#11151f', color: '#fff', fontSize: '14px', fontFamily: 'inherit',
+  });
+
+  const diagRow = document.createElement('label');
+  Object.assign(diagRow.style, { display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', margin: '12px 0', cursor: 'pointer', color: 'rgba(255,255,255,0.8)' });
+  const diagCheck = document.createElement('input');
+  diagCheck.type = 'checkbox';
+  diagCheck.id = 'feedbackIncludeDiagnostics';
+  diagRow.appendChild(diagCheck);
+  diagRow.appendChild(document.createTextNode('Include diagnostics (build, device, physics trace)'));
+
+  const error = document.createElement('p');
+  error.id = 'feedbackError';
+  Object.assign(error.style, { display: 'none', margin: '0 0 8px', fontSize: '13px', color: '#ff7675' });
+
+  // Buttons.
+  const btnRow = document.createElement('div');
+  Object.assign(btnRow.style, { display: 'flex', gap: '10px', marginTop: '6px' });
+
+  const submit = document.createElement('button');
+  submit.id = 'feedbackSubmit';
+  submit.type = 'button';
+  submit.textContent = 'Submit on GitHub →';
+  Object.assign(submit.style, {
+    flex: '1', padding: '10px', borderRadius: '10px', border: 'none', cursor: 'pointer',
+    fontWeight: '700', fontSize: '14px', color: '#fff',
+    background: 'linear-gradient(90deg,#0984e3,#74b9ff)',
+  });
+
+  const cancel = document.createElement('button');
+  cancel.id = 'feedbackCancel';
+  cancel.type = 'button';
+  cancel.textContent = 'Cancel';
+  Object.assign(cancel.style, {
+    padding: '10px 16px', borderRadius: '10px', border: 'none', cursor: 'pointer',
+    fontWeight: '700', fontSize: '14px', color: '#fff', background: 'rgba(255,255,255,0.14)',
+  });
+
+  btnRow.appendChild(submit);
+  btnRow.appendChild(cancel);
+
+  panel.appendChild(heading);
+  panel.appendChild(blurb);
+  panel.appendChild(catWrap);
+  panel.appendChild(textarea);
+  panel.appendChild(diagRow);
+  panel.appendChild(error);
+  panel.appendChild(btnRow);
+  overlay.appendChild(panel);
+
+  // --- Behaviour ---
+  const close = (): void => { overlay.style.display = 'none'; error.style.display = 'none'; };
+  cancel.addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay.style.display !== 'none') close();
+  });
+
+  submit.addEventListener('click', () => {
+    const message = textarea.value.trim();
+    if (!message) {
+      error.textContent = 'Please describe your feedback first.';
+      error.style.display = 'block';
+      textarea.focus();
+      return;
+    }
+    const selected = panel.querySelector('input[name="feedbackCategory"]:checked');
+    const rawCat = selected instanceof HTMLInputElement ? selected.value : DEFAULT_CATEGORY;
+    const category: FeedbackCategory = isFeedbackCategory(rawCat) ? rawCat : DEFAULT_CATEGORY;
+    const context = collectContext(diagCheck.checked);
+    const url = buildFeedbackIssueUrl({ category, message, context });
+    logFeedbackEvent(category);
+    if (typeof window !== 'undefined' && typeof window.open === 'function') {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+    close();
+    textarea.value = '';
+  });
+
+  return overlay;
+}
+
+/** Open the feedback modal, building it on first use. */
+export function openFeedback(): void {
+  if (typeof document === 'undefined') return;
+  if (!modalEl) {
+    modalEl = buildModal();
+    document.body.appendChild(modalEl);
+  }
+  modalEl.style.display = 'flex';
+  const ta = modalEl.querySelector('#feedbackMessage');
+  if (ta instanceof HTMLTextAreaElement) ta.focus();
+}
+
+/** Wire the start-screen feedback button. Safe to call repeatedly. */
+export function initFeedback(): void {
+  if (typeof document === 'undefined') return;
+  const btn = document.getElementById('feedbackButton');
+  if (btn && btn.dataset.feedbackWired !== '1') {
+    btn.dataset.feedbackWired = '1';
+    btn.addEventListener('click', openFeedback);
+  }
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initFeedback);
+  } else {
+    initFeedback();
+  }
+}

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -297,8 +297,17 @@ function buildModal(): HTMLDivElement {
   const close = (): void => { overlay.style.display = 'none'; error.style.display = 'none'; };
   cancel.addEventListener('click', close);
   overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && overlay.style.display !== 'none') close();
+  // Keep modal keystrokes from reaching start-menu.ts's document-level keydown
+  // handler. That handler starts the run on Enter/Space whenever #startGameContainer
+  // is visible (it is — this modal only overlays it), so without this a Space or
+  // Enter typed in the textarea would launch the game and hide the start screen
+  // mid-report. The modal's focusable controls are all descendants of `overlay`, so
+  // stopping propagation here intercepts every in-modal keystroke before it bubbles
+  // to `document`; we don't preventDefault, so typing (space/newline) still works.
+  // Escape closes the modal.
+  overlay.addEventListener('keydown', (e) => {
+    e.stopPropagation();
+    if (e.key === 'Escape') close();
   });
 
   submit.addEventListener('click', () => {

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -159,10 +159,16 @@ export function buildFeedbackIssueUrl(opts: BuildIssueOptions): string {
   const cat = isFeedbackCategory(opts.category) ? opts.category : DEFAULT_CATEGORY;
   const meta = FEEDBACK_CATEGORIES[cat];
   const title = meta.titlePrefix + (firstLine(opts.message || '') || 'feedback');
+  // NB: deliberately NO `labels=` param. GitHub's /issues/new `labels` query
+  // parameter requires permission to add labels and returns a 404 (instead of the
+  // prefilled form) for users who lack it. This form is for ordinary players
+  // submitting under their own accounts, so labels are applied repo-side instead:
+  // the `[Feature]`/`[Bug]`/`[Feedback]` title prefix is the categorisation signal,
+  // and the .github/ISSUE_TEMPLATE/* templates carry the labels for the Issues-tab
+  // path. (meta.issueLabels documents that intended labelling.)
   const params = new URLSearchParams({
     title,
     body: buildIssueBody({ ...opts, category: cat }),
-    labels: meta.issueLabels.join(','),
   });
   return `https://github.com/${REPO_SLUG}/issues/new?${params.toString()}`;
 }

--- a/src/ui/feedback.ts
+++ b/src/ui/feedback.ts
@@ -171,7 +171,12 @@ export function buildFeedbackIssueUrl(opts: BuildIssueOptions): string {
  */
 export function logFeedbackEvent(category: FeedbackCategory): void {
   try {
-    const fm = typeof window !== 'undefined' ? window.firebaseModules : undefined;
+    // window.firebaseModules is typed `any` (the shared seam), so narrow it to the
+    // one method we call before touching it — keeps this access type-safe instead
+    // of leaking `any` through the no-unsafe-* lint rules.
+    const fm = typeof window !== 'undefined'
+      ? (window.firebaseModules as { logEvent?: (name: string, params?: Record<string, unknown>) => void } | undefined)
+      : undefined;
     if (fm && typeof fm.logEvent === 'function') {
       fm.logEvent('feedback_submitted', { category });
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -850,6 +850,10 @@ canvas { display: block; }
   background-color: #ff7979;
 }
 
+.menu-button.feedback {
+  background-color: #0984e3;
+}
+
 .menu-button:hover {
   background-color: #45a049;
   transform: scale(1.05);
@@ -861,6 +865,10 @@ canvas { display: block; }
 
 .menu-button.about:hover {
   background-color: #ff6b6b;
+}
+
+.menu-button.feedback:hover {
+  background-color: #0a74c4;
 }
 
 .menu-button:active {

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -125,24 +125,34 @@ async function main() {
   const diagBody = buildIssueBody({ category: 'bug', message: 'm', context: { diagnostics: '{"fps":60}' } });
   check('diagnostics render in a details block', diagBody.includes('<details>') && diagBody.includes('{"fps":60}'));
 
-  // ---- collectContext: real jsdom reads ----
+  // ---- collectContext: opt-in gating ----
   console.log('--- collectContext ---');
-  const ctx = collectContext(false);
-  check('collectContext reads the build-id meta', ctx.build === '2026-06-30 05:00');
-  check('collectContext reads the location', ctx.url === 'https://snowglider.ai/play');
-  check('collectContext reads the viewport', typeof ctx.viewport === 'string' && ctx.viewport.includes('x'));
-  check('collectContext reads the user agent', typeof ctx.userAgent === 'string' && ctx.userAgent.length > 0);
-  check('collectContext skips diagnostics when none present', ctx.diagnostics === undefined);
+  // Opt-OUT: nothing is attached — no build, URL, viewport, or user-agent. This is
+  // the privacy contract behind the "Include diagnostics" checkbox.
+  const optedOut = collectContext(false);
+  check('opt-out attaches NO build', optedOut.build === undefined);
+  check('opt-out attaches NO url (no query-string leak)', optedOut.url === undefined);
+  check('opt-out attaches NO viewport', optedOut.viewport === undefined);
+  check('opt-out attaches NO user agent', optedOut.userAgent === undefined);
+  check('opt-out attaches NO diagnostics', optedOut.diagnostics === undefined);
 
-  // Opt-in diagnostics via __snowgliderDiag.snapshot() (NOT dump(), which would
-  // trigger a file download). dump is present here to assert we don't call it.
+  // Opt-IN (no diag API present yet): device/page context is collected.
+  const ctx = collectContext(true);
+  check('opt-in reads the build-id meta', ctx.build === '2026-06-30 05:00');
+  check('opt-in reads the location', ctx.url === 'https://snowglider.ai/play');
+  check('opt-in reads the viewport', typeof ctx.viewport === 'string' && ctx.viewport.includes('x'));
+  check('opt-in reads the user agent', typeof ctx.userAgent === 'string' && ctx.userAgent.length > 0);
+  check('opt-in omits diagnostics trace when no diag API present', ctx.diagnostics === undefined);
+
+  // Opt-IN with a diagnostics API: serialise via __snowgliderDiag.snapshot() (NOT
+  // dump(), which would trigger a file download). dump is present here to assert
+  // we never call it.
   let dumpCalls = 0;
   g.window.__snowgliderDiag = { snapshot: () => ({ fps: 60, ok: true }), dump: () => { dumpCalls++; return {}; } };
   const withDiag = collectContext(true);
-  check('collectContext serialises diagnostics when opted in', (withDiag.diagnostics || '').includes('"fps":60'));
+  check('opt-in serialises diagnostics when available', (withDiag.diagnostics || '').includes('"fps":60'));
   check('collectContext uses snapshot(), never the downloading dump()', dumpCalls === 0);
-  const optedOut = collectContext(false);
-  check('collectContext omits diagnostics when not opted in', optedOut.diagnostics === undefined);
+  check('opt-out still attaches nothing even when a diag API exists', collectContext(false).diagnostics === undefined);
   delete g.window.__snowgliderDiag;
 
   // ---- logFeedbackEvent: analytics seam ----

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -121,8 +121,9 @@ async function main() {
 
   // ---- logFeedbackEvent: analytics seam ----
   console.log('--- logFeedbackEvent ---');
+  /** @type {{ name: string, params: { category?: string } } | null} */
   let logged = null;
-  setGlobal('window', { firebaseModules: { logEvent: (name, params) => { logged = { name, params }; } } });
+  setGlobal('window', { firebaseModules: { logEvent: (/** @type {string} */ name, /** @type {{ category?: string }} */ params) => { logged = { name, params }; } } });
   logFeedbackEvent('feature');
   check('fires feedback_submitted', logged && logged.name === 'feedback_submitted');
   check('carries only the category dimension', logged && logged.params && logged.params.category === 'feature');

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -132,10 +132,13 @@ async function main() {
   check('collectContext reads the user agent', typeof ctx.userAgent === 'string' && ctx.userAgent.length > 0);
   check('collectContext skips diagnostics when none present', ctx.diagnostics === undefined);
 
-  // Opt-in diagnostics via __snowgliderDiag.dump().
-  g.window.__snowgliderDiag = { dump: () => ({ fps: 60, ok: true }) };
+  // Opt-in diagnostics via __snowgliderDiag.snapshot() (NOT dump(), which would
+  // trigger a file download). dump is present here to assert we don't call it.
+  let dumpCalls = 0;
+  g.window.__snowgliderDiag = { snapshot: () => ({ fps: 60, ok: true }), dump: () => { dumpCalls++; return {}; } };
   const withDiag = collectContext(true);
   check('collectContext serialises diagnostics when opted in', (withDiag.diagnostics || '').includes('"fps":60'));
+  check('collectContext uses snapshot(), never the downloading dump()', dumpCalls === 0);
   const optedOut = collectContext(false);
   check('collectContext omits diagnostics when not opted in', optedOut.diagnostics === undefined);
   delete g.window.__snowgliderDiag;
@@ -191,9 +194,24 @@ async function main() {
   console.log('--- keystroke isolation ---');
   // Mimic start-menu.ts's document-level keydown handler that starts the run on
   // Enter/Space. With the modal open, in-modal keystrokes must NOT reach it.
+  /** @type {boolean} */
   let docSawKey = false;
   const docHandler = () => { docSawKey = true; };
   document.addEventListener('keydown', docHandler);
+
+  // Codex P2: Enter/Space on the (focusable) start-screen button must not bubble
+  // to the start-menu handler either, or keyboard-activating it would start the run.
+  if (btn) {
+    btn.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    check('Space on the feedback button does not reach the start-menu handler', docSawKey === false);
+    btn.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    check('Enter on the feedback button does not reach the start-menu handler', docSawKey === false);
+    // A non-activation key (e.g. Tab) is left alone to bubble normally.
+    btn.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    check('Tab on the feedback button still bubbles (not swallowed)', docSawKey);
+    docSawKey = false;
+  }
+
   if (btn) btn.click(); // reopen
   overlay = document.getElementById('feedbackOverlay');
   const ta2 = /** @type {HTMLTextAreaElement} */ (document.getElementById('feedbackMessage'));

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -1,0 +1,145 @@
+// @ts-check
+// feedback-tests.js
+// Focused, headless coverage for src/ui/feedback.ts - the in-game feature-request /
+// bug-report helper behind the start screen's "💬 Feedback" button (issue #258).
+//
+// feedback.ts imports nothing (no three.js / Firebase / DOM module), so we import
+// the REAL `.ts` directly - Node 23 type-strips it and c8 instruments it with
+// correct source-mapped lines. The module's DOM code is all inside functions the
+// pure-helper tests never call, and its self-init block is guarded by
+// `typeof document !== 'undefined'`, so importing it under Node is side-effect free.
+// The Analytics seam is reached via `window.firebaseModules`, so that case installs
+// a stub and restores it. Run via `test:feedback` (`node tests/feedback-tests.js`).
+
+let pass = 0;
+let fail = 0;
+function check(name, condition) {
+  console.log(`  ${condition ? 'PASS ✅' : 'FAIL ❌'}: ${name}`);
+  if (condition) pass++; else fail++;
+}
+
+function setGlobal(name, value) {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+function clearGlobal(name) {
+  if (Object.prototype.hasOwnProperty.call(globalThis, name)) delete globalThis[name];
+}
+
+async function main() {
+  const {
+    buildFeedbackIssueUrl, buildIssueBody, collectContext, truncate,
+    isFeedbackCategory, logFeedbackEvent, FEEDBACK_CATEGORIES, FEEDBACK_LABEL,
+  } = await import('../src/ui/feedback.ts');
+
+  // ---- isFeedbackCategory ----
+  console.log('--- isFeedbackCategory ---');
+  check('accepts feature', isFeedbackCategory('feature') === true);
+  check('accepts bug', isFeedbackCategory('bug') === true);
+  check('accepts general', isFeedbackCategory('general') === true);
+  check('rejects unknown string', isFeedbackCategory('nope') === false);
+  check('rejects non-string', isFeedbackCategory(undefined) === false);
+
+  // ---- truncate ----
+  console.log('--- truncate ---');
+  check('passes through short text', truncate('hello', 10) === 'hello');
+  check('truncates with ellipsis', truncate('abcdef', 4) === 'abc…');
+  check('ellipsis keeps length at max', truncate('abcdef', 4).length === 4);
+  check('non-string -> empty', truncate(/** @type {any} */ (null)) === '');
+
+  // ---- buildFeedbackIssueUrl: structure ----
+  console.log('--- buildFeedbackIssueUrl ---');
+  const url = buildFeedbackIssueUrl({ category: 'feature', message: 'Add a replay mode' });
+  check('targets the snowglider new-issue endpoint',
+    url.startsWith('https://github.com/den-run-ai/snowglider/issues/new?'));
+  const parsed = new URL(url);
+  check('title carries the [Feature] prefix + first line',
+    parsed.searchParams.get('title') === '[Feature] Add a replay mode');
+  check('body contains the message', (parsed.searchParams.get('body') || '').includes('Add a replay mode'));
+  check('labels include enhancement + game-feedback',
+    parsed.searchParams.get('labels') === 'enhancement,game-feedback');
+
+  // bug category mapping
+  const bugUrl = new URL(buildFeedbackIssueUrl({ category: 'bug', message: 'Avalanche clips through trees' }));
+  check('bug title prefix', bugUrl.searchParams.get('title') === '[Bug] Avalanche clips through trees');
+  check('bug labels include bug + game-feedback', bugUrl.searchParams.get('labels') === 'bug,game-feedback');
+
+  // general category mapping
+  const genUrl = new URL(buildFeedbackIssueUrl({ category: 'general', message: 'Love the game' }));
+  check('general title prefix', genUrl.searchParams.get('title') === '[Feedback] Love the game');
+  check('general labels = game-feedback only', genUrl.searchParams.get('labels') === FEEDBACK_LABEL);
+
+  // invalid category falls back to feature (default)
+  const fbUrl = new URL(buildFeedbackIssueUrl({ category: /** @type {any} */ ('bogus'), message: 'x' }));
+  check('invalid category defaults to [Feature]', (fbUrl.searchParams.get('title') || '').startsWith('[Feature]'));
+
+  // title uses first non-empty line and is bounded
+  const multiline = new URL(buildFeedbackIssueUrl({ category: 'feature', message: '\n\n  First real line\nsecond' }));
+  check('title picks first non-empty line', multiline.searchParams.get('title') === '[Feature] First real line');
+
+  const longTitle = new URL(buildFeedbackIssueUrl({ category: 'feature', message: 'x'.repeat(200) }));
+  check('long title is bounded (<= prefix + 80)',
+    (longTitle.searchParams.get('title') || '').length <= '[Feature] '.length + 80);
+
+  // empty message -> graceful title + placeholder body
+  const emptyUrl = new URL(buildFeedbackIssueUrl({ category: 'feature', message: '' }));
+  check('empty message title falls back', emptyUrl.searchParams.get('title') === '[Feature] feedback');
+  check('empty message body placeholder', (emptyUrl.searchParams.get('body') || '').includes('no description provided'));
+
+  // ---- buildIssueBody: context rendering ----
+  console.log('--- buildIssueBody ---');
+  const body = buildIssueBody({
+    category: 'bug',
+    message: 'It broke',
+    context: { build: 'abc123', url: 'https://x/', viewport: '800x600', userAgent: 'TestUA' },
+  });
+  check('body has the message', body.includes('It broke'));
+  check('body renders build context', body.includes('abc123'));
+  check('body renders viewport', body.includes('800x600'));
+  check('body renders user agent', body.includes('TestUA'));
+  check('body has the submitted-from footer', body.includes('in-game feedback form'));
+
+  const bodyNoCtx = buildIssueBody({ category: 'feature', message: 'Just text' });
+  check('body without context omits the Context heading', !bodyNoCtx.includes('### Context'));
+
+  const diagBody = buildIssueBody({ category: 'bug', message: 'm', context: { diagnostics: '{"fps":60}' } });
+  check('diagnostics render in a details block', diagBody.includes('<details>') && diagBody.includes('{"fps":60}'));
+
+  // ---- collectContext: guarded reads ----
+  console.log('--- collectContext ---');
+  // No DOM/window globals in Node -> returns an (almost) empty object, never throws.
+  const bare = collectContext(false);
+  check('collectContext returns an object with no globals', bare && typeof bare === 'object');
+  check('collectContext skips diagnostics when none present', bare.diagnostics === undefined);
+
+  // With a __snowgliderDiag dump available and opt-in.
+  setGlobal('window', { __snowgliderDiag: { dump: () => ({ fps: 60, ok: true }) } });
+  const withDiag = collectContext(true);
+  check('collectContext serialises diagnostics when opted in', (withDiag.diagnostics || '').includes('"fps":60'));
+  const optedOut = collectContext(false);
+  check('collectContext omits diagnostics when not opted in', optedOut.diagnostics === undefined);
+  clearGlobal('window');
+
+  // ---- logFeedbackEvent: analytics seam ----
+  console.log('--- logFeedbackEvent ---');
+  let logged = null;
+  setGlobal('window', { firebaseModules: { logEvent: (name, params) => { logged = { name, params }; } } });
+  logFeedbackEvent('feature');
+  check('fires feedback_submitted', logged && logged.name === 'feedback_submitted');
+  check('carries only the category dimension', logged && logged.params && logged.params.category === 'feature');
+  clearGlobal('window');
+
+  // No window / no seam -> no throw.
+  let threw = false;
+  try { logFeedbackEvent('bug'); } catch { threw = true; }
+  check('logFeedbackEvent no-ops without a window', threw === false);
+
+  // ---- category table sanity ----
+  console.log('--- FEEDBACK_CATEGORIES ---');
+  check('every category carries the shared game-feedback label',
+    ['feature', 'bug', 'general'].every((k) => FEEDBACK_CATEGORIES[k].issueLabels.includes(FEEDBACK_LABEL)));
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -1,15 +1,45 @@
 // @ts-check
 // feedback-tests.js
-// Focused, headless coverage for src/ui/feedback.ts - the in-game feature-request /
-// bug-report helper behind the start screen's "💬 Feedback" button (issue #258).
+// Headless, c8-instrumented coverage for src/ui/feedback.ts - the in-game
+// feature-request / bug-report helper behind the start screen's "💬 Feedback"
+// button (issue #258).
 //
 // feedback.ts imports nothing (no three.js / Firebase / DOM module), so we import
 // the REAL `.ts` directly - Node 23 type-strips it and c8 instruments it with
-// correct source-mapped lines. The module's DOM code is all inside functions the
-// pure-helper tests never call, and its self-init block is guarded by
-// `typeof document !== 'undefined'`, so importing it under Node is side-effect free.
-// The Analytics seam is reached via `window.firebaseModules`, so that case installs
-// a stub and restores it. Run via `test:feedback` (`node tests/feedback-tests.js`).
+// correct source-mapped lines. We set up jsdom first so importing the module (its
+// self-init wires the start-screen button) and the modal builder are exercised for
+// real. The Analytics / window.open seams are reached via the jsdom `window`.
+// Run via the `test:feedback` npm script (`node tests/feedback-tests.js`).
+
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(`<!doctype html><html><head>
+  <meta name="build-id" content="2026-06-30 05:00">
+</head><body>
+  <div id="startGameContainer">
+    <div id="difficultyPicker"></div>
+    <div id="startMenu">
+      <button id="startGameButton">Start Game</button>
+      <button id="aboutGameButton">About</button>
+      <button id="feedbackButton">💬 Feedback</button>
+    </div>
+  </div>
+</body></html>`, { url: 'https://snowglider.ai/play' });
+
+const { window } = dom;
+const g = /** @type {any} */ (globalThis);
+g.window = window;
+g.document = window.document;
+// feedback.ts uses bare `instanceof HTMLInputElement` / `HTMLTextAreaElement`,
+// which resolve to globalThis; expose jsdom's constructors there.
+g.HTMLInputElement = window.HTMLInputElement;
+g.HTMLTextAreaElement = window.HTMLTextAreaElement;
+g.navigator = window.navigator;
+
+// Capture window.open (jsdom's is a not-implemented stub).
+/** @type {string | null} */
+let openedUrl = null;
+window.open = (/** @type {string} */ url) => { openedUrl = url; return null; };
 
 let pass = 0;
 let fail = 0;
@@ -18,17 +48,11 @@ function check(name, condition) {
   if (condition) pass++; else fail++;
 }
 
-function setGlobal(name, value) {
-  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
-}
-function clearGlobal(name) {
-  if (Object.prototype.hasOwnProperty.call(globalThis, name)) delete globalThis[name];
-}
-
 async function main() {
   const {
     buildFeedbackIssueUrl, buildIssueBody, collectContext, truncate,
-    isFeedbackCategory, logFeedbackEvent, FEEDBACK_CATEGORIES, FEEDBACK_LABEL,
+    isFeedbackCategory, logFeedbackEvent, openFeedback, initFeedback,
+    FEEDBACK_CATEGORIES, FEEDBACK_LABEL,
   } = await import('../src/ui/feedback.ts');
 
   // ---- isFeedbackCategory ----
@@ -58,21 +82,17 @@ async function main() {
   check('labels include enhancement + game-feedback',
     parsed.searchParams.get('labels') === 'enhancement,game-feedback');
 
-  // bug category mapping
   const bugUrl = new URL(buildFeedbackIssueUrl({ category: 'bug', message: 'Avalanche clips through trees' }));
   check('bug title prefix', bugUrl.searchParams.get('title') === '[Bug] Avalanche clips through trees');
   check('bug labels include bug + game-feedback', bugUrl.searchParams.get('labels') === 'bug,game-feedback');
 
-  // general category mapping
   const genUrl = new URL(buildFeedbackIssueUrl({ category: 'general', message: 'Love the game' }));
   check('general title prefix', genUrl.searchParams.get('title') === '[Feedback] Love the game');
   check('general labels = game-feedback only', genUrl.searchParams.get('labels') === FEEDBACK_LABEL);
 
-  // invalid category falls back to feature (default)
   const fbUrl = new URL(buildFeedbackIssueUrl({ category: /** @type {any} */ ('bogus'), message: 'x' }));
   check('invalid category defaults to [Feature]', (fbUrl.searchParams.get('title') || '').startsWith('[Feature]'));
 
-  // title uses first non-empty line and is bounded
   const multiline = new URL(buildFeedbackIssueUrl({ category: 'feature', message: '\n\n  First real line\nsecond' }));
   check('title picks first non-empty line', multiline.searchParams.get('title') === '[Feature] First real line');
 
@@ -80,7 +100,6 @@ async function main() {
   check('long title is bounded (<= prefix + 80)',
     (longTitle.searchParams.get('title') || '').length <= '[Feature] '.length + 80);
 
-  // empty message -> graceful title + placeholder body
   const emptyUrl = new URL(buildFeedbackIssueUrl({ category: 'feature', message: '' }));
   check('empty message title falls back', emptyUrl.searchParams.get('title') === '[Feature] feedback');
   check('empty message body placeholder', (emptyUrl.searchParams.get('body') || '').includes('no description provided'));
@@ -104,35 +123,105 @@ async function main() {
   const diagBody = buildIssueBody({ category: 'bug', message: 'm', context: { diagnostics: '{"fps":60}' } });
   check('diagnostics render in a details block', diagBody.includes('<details>') && diagBody.includes('{"fps":60}'));
 
-  // ---- collectContext: guarded reads ----
+  // ---- collectContext: real jsdom reads ----
   console.log('--- collectContext ---');
-  // No DOM/window globals in Node -> returns an (almost) empty object, never throws.
-  const bare = collectContext(false);
-  check('collectContext returns an object with no globals', bare && typeof bare === 'object');
-  check('collectContext skips diagnostics when none present', bare.diagnostics === undefined);
+  const ctx = collectContext(false);
+  check('collectContext reads the build-id meta', ctx.build === '2026-06-30 05:00');
+  check('collectContext reads the location', ctx.url === 'https://snowglider.ai/play');
+  check('collectContext reads the viewport', typeof ctx.viewport === 'string' && ctx.viewport.includes('x'));
+  check('collectContext reads the user agent', typeof ctx.userAgent === 'string' && ctx.userAgent.length > 0);
+  check('collectContext skips diagnostics when none present', ctx.diagnostics === undefined);
 
-  // With a __snowgliderDiag dump available and opt-in.
-  setGlobal('window', { __snowgliderDiag: { dump: () => ({ fps: 60, ok: true }) } });
+  // Opt-in diagnostics via __snowgliderDiag.dump().
+  g.window.__snowgliderDiag = { dump: () => ({ fps: 60, ok: true }) };
   const withDiag = collectContext(true);
   check('collectContext serialises diagnostics when opted in', (withDiag.diagnostics || '').includes('"fps":60'));
   const optedOut = collectContext(false);
   check('collectContext omits diagnostics when not opted in', optedOut.diagnostics === undefined);
-  clearGlobal('window');
+  delete g.window.__snowgliderDiag;
 
   // ---- logFeedbackEvent: analytics seam ----
   console.log('--- logFeedbackEvent ---');
   /** @type {{ name: string, params: { category?: string } } | null} */
   let logged = null;
-  setGlobal('window', { firebaseModules: { logEvent: (/** @type {string} */ name, /** @type {{ category?: string }} */ params) => { logged = { name, params }; } } });
+  g.window.firebaseModules = { logEvent: (/** @type {string} */ name, /** @type {{category?: string}} */ params) => { logged = { name, params }; } };
   logFeedbackEvent('feature');
   check('fires feedback_submitted', logged && logged.name === 'feedback_submitted');
   check('carries only the category dimension', logged && logged.params && logged.params.category === 'feature');
-  clearGlobal('window');
 
-  // No window / no seam -> no throw.
-  let threw = false;
-  try { logFeedbackEvent('bug'); } catch { threw = true; }
-  check('logFeedbackEvent no-ops without a window', threw === false);
+  // ---- DOM: button wiring + modal flow ----
+  console.log('--- modal flow ---');
+  // The self-init at import time already wired #feedbackButton; calling initFeedback
+  // again must be idempotent (data-flag guard).
+  initFeedback();
+  const btn = document.getElementById('feedbackButton');
+  if (btn) btn.click();
+  let overlay = document.getElementById('feedbackOverlay');
+  check('clicking the start-screen button opens the modal',
+    !!overlay && overlay.style.display === 'flex');
+
+  // Submitting with an empty message shows an error and does NOT open GitHub.
+  openedUrl = null;
+  logged = null;
+  const submitBtn = document.getElementById('feedbackSubmit');
+  if (submitBtn) submitBtn.click();
+  const errEl = document.getElementById('feedbackError');
+  check('empty submit shows an error', !!errEl && errEl.style.display === 'block');
+  check('empty submit does not open GitHub', openedUrl === null);
+
+  // Fill it in, pick the bug category, opt into diagnostics, submit.
+  const ta = /** @type {HTMLTextAreaElement} */ (document.getElementById('feedbackMessage'));
+  ta.value = 'Tree collision feels off';
+  const bugRadio = /** @type {HTMLInputElement} */ (document.querySelector('input[name="feedbackCategory"][value="bug"]'));
+  bugRadio.checked = true;
+  const diagCheck = /** @type {HTMLInputElement} */ (document.getElementById('feedbackIncludeDiagnostics'));
+  diagCheck.checked = true;
+  if (submitBtn) submitBtn.click();
+  check('submit opens a prefilled GitHub issue URL',
+    typeof openedUrl === 'string' && openedUrl.includes('/issues/new?'));
+  check('submit URL carries the [Bug] title',
+    typeof openedUrl === 'string' &&
+    new URL(openedUrl).searchParams.get('title') === '[Bug] Tree collision feels off');
+  check('submit fires the analytics event with the bug category',
+    logged && logged.name === 'feedback_submitted' && logged.params.category === 'bug');
+  check('submit closes the modal', overlay !== null && overlay.style.display === 'none');
+  check('submit clears the textarea', ta.value === '');
+
+  // ---- DOM: keystroke isolation (Codex P1) ----
+  console.log('--- keystroke isolation ---');
+  // Mimic start-menu.ts's document-level keydown handler that starts the run on
+  // Enter/Space. With the modal open, in-modal keystrokes must NOT reach it.
+  let docSawKey = false;
+  const docHandler = () => { docSawKey = true; };
+  document.addEventListener('keydown', docHandler);
+  if (btn) btn.click(); // reopen
+  overlay = document.getElementById('feedbackOverlay');
+  const ta2 = /** @type {HTMLTextAreaElement} */ (document.getElementById('feedbackMessage'));
+  ta2.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+  check('space typed in the modal does not bubble to the start-menu handler', docSawKey === false);
+  // Escape on the overlay closes the modal.
+  ta2.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  check('Escape inside the modal closes it', overlay !== null && overlay.style.display === 'none');
+  check('Escape did not reach the start-menu handler either', docSawKey === false);
+  document.removeEventListener('keydown', docHandler);
+
+  // ---- DOM: cancel + backdrop close ----
+  console.log('--- close paths ---');
+  if (btn) btn.click();
+  overlay = document.getElementById('feedbackOverlay');
+  const cancelBtn = document.getElementById('feedbackCancel');
+  if (cancelBtn) cancelBtn.click();
+  check('cancel closes the modal', overlay !== null && overlay.style.display === 'none');
+
+  if (btn) btn.click();
+  overlay = document.getElementById('feedbackOverlay');
+  // Backdrop click (target === overlay) closes; a click on the panel does not.
+  const panel = document.getElementById('feedbackPanel');
+  if (panel) panel.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  check('clicking inside the panel keeps the modal open',
+    overlay !== null && overlay.style.display === 'flex');
+  if (overlay) overlay.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  check('clicking the backdrop closes the modal', overlay !== null && overlay.style.display === 'none');
 
   // ---- category table sanity ----
   console.log('--- FEEDBACK_CATEGORIES ---');

--- a/tests/feedback-tests.js
+++ b/tests/feedback-tests.js
@@ -79,16 +79,18 @@ async function main() {
   check('title carries the [Feature] prefix + first line',
     parsed.searchParams.get('title') === '[Feature] Add a replay mode');
   check('body contains the message', (parsed.searchParams.get('body') || '').includes('Add a replay mode'));
-  check('labels include enhancement + game-feedback',
-    parsed.searchParams.get('labels') === 'enhancement,game-feedback');
+  // The URL must NOT carry a `labels` param: GitHub 404s the /issues/new form for
+  // users without label permission (i.e. ordinary players). Labels are applied
+  // repo-side (templates / title prefix), not via the query string.
+  check('URL omits the labels param (avoids 404 for non-collaborators)',
+    parsed.searchParams.get('labels') === null && !url.includes('labels='));
 
   const bugUrl = new URL(buildFeedbackIssueUrl({ category: 'bug', message: 'Avalanche clips through trees' }));
   check('bug title prefix', bugUrl.searchParams.get('title') === '[Bug] Avalanche clips through trees');
-  check('bug labels include bug + game-feedback', bugUrl.searchParams.get('labels') === 'bug,game-feedback');
+  check('bug URL also omits labels', bugUrl.searchParams.get('labels') === null);
 
   const genUrl = new URL(buildFeedbackIssueUrl({ category: 'general', message: 'Love the game' }));
   check('general title prefix', genUrl.searchParams.get('title') === '[Feedback] Love the game');
-  check('general labels = game-feedback only', genUrl.searchParams.get('labels') === FEEDBACK_LABEL);
 
   const fbUrl = new URL(buildFeedbackIssueUrl({ category: /** @type {any} */ ('bogus'), message: 'x' }));
   check('invalid category defaults to [Feature]', (fbUrl.searchParams.get('title') || '').startsWith('[Feature]'));


### PR DESCRIPTION
Closes #258.

## What
Adds an **in-game feedback / feature-request form**, integrated with the two backends the project already runs:
- **GitHub** — submitting opens a **prefilled new-issue URL** (`/issues/new?title=…&body=…&labels=…`) in a new tab. The player previews the form and submits the issue under their **own** GitHub account.
- **Firebase Analytics** — a `feedback_submitted` event (category dimension only) fires through the existing `window.firebaseModules.logEvent` seam (`auth.ts`), the same path `share_result` / `complete_run` already use.

A "💬 Feedback" button on the start screen (next to **About Game**) opens a small modal: category (✨ Feature / 🐞 Bug / 💬 General), a message, and an opt-in "include diagnostics" checkbox.

## Why a prefilled URL, not a direct API write
A static GitHub-Pages client must never embed a write-scoped GitHub token — it would leak to every visitor. The prefilled-URL pattern is keyless and serverless: the player owns the submission, sees exactly what's posted, and no Cloud Function is needed.

## Changes
- **`src/ui/feedback.ts`** (new) — pure, headless-testable helpers (`buildFeedbackIssueUrl`, `buildIssueBody`, `collectContext`, `truncate`, `isFeedbackCategory`, `logFeedbackEvent`) + a self-contained modal modelled on `ui/share-menu.ts`. Every `window`/`navigator`/`__snowgliderDiag` access is guarded so the module is inert under SSR/Node/tests.
- **`index.html` / `styles/main.css`** — feedback button + module `<script>` tag (mirrors `start-menu.ts`).
- **`.github/ISSUE_TEMPLATE/`** — `feature_request.md`, `bug_report.md`, `config.yml`, all labelled `game-feedback`.
- **`tests/feedback-tests.js`** (37 checks) + `test:feedback` wired into `npm test`.
- Docs: `CLAUDE.md`, `README.md`, `docs/CHANGELOG.md`.

## Privacy / security
- No token in the client; the player owns the GitHub submission.
- Diagnostics are **opt-in** and previewed on github.com before the player submits.
- Analytics event carries only the category string — no message text or PII.

## Testing
- `npm run test:feedback` → 37/37 pass.
- `npm run test:start-menu`, `test:share`, `test:verify` (DOM smoke) → pass (start-menu DOM change is safe).
- `npx tsc --noEmit` clean; `npm run build` bundles the module (`feedback_submitted` / `issues/new` present in the entry chunk); `npm run lint` → 0 errors (the only warnings are the same `firebaseModules`-is-`any` warnings `share.ts` already has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01THMUJutwSQzTo715usHEyt)_